### PR TITLE
fix std::chrono not found at compilation time

### DIFF
--- a/examples/Advanced/Utilities/LightnessSampler.hpp
+++ b/examples/Advanced/Utilities/LightnessSampler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/functional/hash.hpp>
+#include <chrono>
 #include <halp/controls.hpp>
 #include <halp/layout.hpp>
 #include <halp/meta.hpp>


### PR DESCRIPTION
ref #40
