### PR TITLE
max: pd: fix that both message and audio processor factories were ins…

### DIFF
--- a/include/avnd/binding/max/prototype.cpp.in
+++ b/include/avnd/binding/max/prototype.cpp.in
@@ -1,25 +1,30 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
+// clang-format off
 #include <@AVND_MAIN_FILE@>
 #include <avnd/binding/max/audio_processor.hpp>
 #include <avnd/binding/max/message_processor.hpp>
 #include <avnd/binding/max/configure.hpp>
 #include "commonsyms.h"
+using type = decltype(avnd::configure<max::config, @AVND_MAIN_CLASS@>())::type;
+// clang-format on
 
 extern "C" AVND_EXPORTED_SYMBOL void ext_main(void* r)
 {
   common_symbols_init();
 
-  using type = decltype(avnd::configure<max::config, @AVND_MAIN_CLASS@>())::type;
-  if constexpr(avnd::monophonic_audio_processor<type> || avnd::polyphonic_audio_processor<type>)
-  {
-    // If we're an audio effect, make a type with the whole DSP stuff
-    static const max::audio_processor_metaclass< type > instance{};
-  }
-  else
-  {
-    // Simpler case which just processes messages
-    static const max::message_processor_metaclass< type > instance{};
-  }
+  []<typename T = type> {
+    if constexpr(
+        avnd::monophonic_audio_processor<T> || avnd::polyphonic_audio_processor<T>)
+    {
+      // If we're an audio effect, make a type with the whole DSP stuff
+      static const max::audio_processor_metaclass<T> instance{};
+    }
+    else
+    {
+      // Simpler case which just processes messages
+      static const max::message_processor_metaclass<T> instance{};
+    }
+  }();
 }
 

--- a/include/avnd/binding/pd/prototype.cpp.in
+++ b/include/avnd/binding/pd/prototype.cpp.in
@@ -1,22 +1,26 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
+// clang-format off
 #include <@AVND_MAIN_FILE@>
 #include <avnd/binding/pd/audio_processor.hpp>
 #include <avnd/binding/pd/message_processor.hpp>
 #include <avnd/binding/pd/configure.hpp>
+using type = decltype(avnd::configure<pd::config, @AVND_MAIN_CLASS@>())::type;
+// clang-format on
 
 extern "C" AVND_EXPORTED_SYMBOL void @AVND_C_NAME@_setup()
 {
-  using type = decltype(avnd::configure<pd::config, @AVND_MAIN_CLASS@>())::type;
-  if constexpr(avnd::monophonic_audio_processor<type> || avnd::polyphonic_audio_processor<type>)
-  {
-    // If we're an audio effect, make a type with the whole DSP stuff
-    static const pd::audio_processor_metaclass< type > instance{};
-  }
-  else
-  {
-    // Simpler case which just processes messages
-    static const pd::message_processor_metaclass< type > instance{};
-  }
+  []<typename T = type> {
+    if constexpr(
+        avnd::monophonic_audio_processor<T> || avnd::polyphonic_audio_processor<T>)
+    {
+      // If we're an audio effect, make a type with the whole DSP stuff
+      static const pd::audio_processor_metaclass<T> instance{};
+    }
+    else
+    {
+      // Simpler case which just processes messages
+      static const pd::message_processor_metaclass<T> instance{};
+    }
+  }();
 }
-


### PR DESCRIPTION
…tantiated when only one is needed

This caused build errors due to some objects being rightfully incompatible with either backend.
To solve this, we defer instantation of the type inside a templated lambda, so that the `if constexpr` branch actually behaves with the expected template semantics, with the unused branch not being seen by template instantiation, unlike the previous case in a non-template function causing all branches to be instantiated even if optimized-out afterwards.