### PR TITLE
feature/add multicursor and pathgenerator widgets

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -67,13 +67,13 @@ jobs:
             }
           - {
               name: "macOS",
-              os: macos-13,
+              os: macos-latest,
               common_flags: "",
               debug_flags: "-DCMAKE_BUILD_TYPE=Debug",
               release_flags: "-DCMAKE_BUILD_TYPE=Release",
               build_flags: "",
               sdk: "/opt/ossia-sdk-x86_64",
-              pre_build: "sudo xcode-select -s /Applications/Xcode_15.0.app"
+              pre_build: "sudo xcode-select -s /Applications/Xcode_16.2.app"
             }
 
     steps:

--- a/include/avnd/common/aggregates.hpp
+++ b/include/avnd/common/aggregates.hpp
@@ -16,11 +16,21 @@ struct typelist
 };
 }
 
+// clang-format off
+#if defined(__clang_major__) && (__clang_major__ < 21)
+#define AVND_USE_BOOST_PFR 1
+#endif
+
+#if defined(_MSC_VER)
+#define AVND_USE_BOOST_PFR 1
+#endif
+
 #if !defined(AVND_USE_BOOST_PFR)
-#if __cpp_­structured_­bindings < 202400L && __cplusplus < 202400L
+#if (__cpp_structured_bindings < 202403L) || (__cpp_pack_indexing < 202311L) || (__cplusplus < 202400L)
 #define AVND_USE_BOOST_PFR 1
 #endif
 #endif
+// clang-format on
 
 #if AVND_USE_BOOST_PFR
 #include <boost/mp11/algorithm.hpp>

--- a/include/avnd/common/aggregates.hpp
+++ b/include/avnd/common/aggregates.hpp
@@ -3,9 +3,10 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include <avnd/common/index_sequence.hpp>
+#include <avnd/common/inline.hpp>
+#include <avnd/common/tuple.hpp>
 
 #include <string_view>
-#include <tuple>
 
 namespace avnd
 {
@@ -16,7 +17,9 @@ struct typelist
 }
 
 #if !defined(AVND_USE_BOOST_PFR)
+#if __cpp_­structured_­bindings < 202400L && __cplusplus < 202400L
 #define AVND_USE_BOOST_PFR 1
+#endif
 #endif
 
 #if AVND_USE_BOOST_PFR

--- a/include/avnd/common/aggregates.p1061.hpp
+++ b/include/avnd/common/aggregates.p1061.hpp
@@ -1,18 +1,15 @@
-#if __has_include(<tuplet/tuple.hpp>)
-#include <tuplet/tuple.hpp>
-namespace tpl = tuplet;
-#else
-namespace tpl = std;
-#endif
+
 namespace avnd
 {
 namespace pfr
 {
+AVND_INLINE
 constexpr auto structure_to_typelist(const auto& s) noexcept
 {
   const auto& [... elts] = s;
   return typelist<std::decay_t<decltype(elts)>...>{};
 }
+AVND_INLINE
 constexpr auto structure_to_tuple(const auto& s) noexcept
 {
   const auto& [... elts] = s;
@@ -23,106 +20,39 @@ namespace detail
 {
 namespace sequence_tuple = ::tpl;
 template <typename S>
-constexpr auto tie_as_tuple(S&& s) noexcept
+AVND_INLINE constexpr auto tie_as_tuple(S&& s) noexcept
 {
   auto&& [... elts] = static_cast<S&&>(s);
-  return tpl::tie(elts...);
+  return tpl::tie(std::forward_like<S>(elts)...);
 }
 }
 
 template <class T>
-constexpr auto fields_count_impl(const T& t) noexcept
+AVND_INLINE constexpr auto fields_count_impl(const T& t) noexcept
 {
   const auto& [... elts] = t;
   return avnd::num<sizeof...(elts)>{};
 }
 
 template <typename T>
-static constexpr const std::size_t tuple_size_v = fields_count<T>();
+static constexpr const std::size_t tuple_size_v
+    = decltype(fields_count_impl<T>(std::declval<const T&>()))::value;
 
 template <std::size_t I, typename S>
-constexpr auto& get(S&& s) noexcept
+AVND_INLINE constexpr auto&& get(S&& s) noexcept
 {
-  if constexpr(I == 0)
-  {
-    auto&& [a, ... elts] = static_cast<S&&>(s);
-    return a;
-  }
-  else if constexpr(I == 1)
-  {
-    auto&& [a, b, ... elts] = static_cast<S&&>(s);
-    return b;
-  }
-  else if constexpr(I == 2)
-  {
-    auto&& [a, b, c, ... elts] = static_cast<S&&>(s);
-    return c;
-  }
-  else if constexpr(I == 3)
-  {
-    auto&& [a, b, c, d, ... elts] = static_cast<S&&>(s);
-    return d;
-  }
-  else if constexpr(I == 4)
-  {
-    auto&& [a, b, c, d, e, ... elts] = static_cast<S&&>(s);
-    return e;
-  }
-  else if constexpr(I == 5)
-  {
-    auto&& [a, b, c, d, e, f, ... elts] = static_cast<S&&>(s);
-    return f;
-  }
-  else if constexpr(I == 6)
-  {
-    auto&& [a, b, c, d, e, f, g, ... elts] = static_cast<S&&>(s);
-    return g;
-  }
-  else if constexpr(I == 7)
-  {
-    auto&& [a, b, c, d, e, f, g, h, ... elts] = static_cast<S&&>(s);
-    return h;
-  }
-  else if constexpr(I == 8)
-  {
-    auto&& [a, b, c, d, e, f, g, h, i, ... elts] = static_cast<S&&>(s);
-    return i;
-  }
-  else if constexpr(I == 9)
-  {
-    auto&& [a, b, c, d, e, f, g, h, i, j, ... elts] = static_cast<S&&>(s);
-    return j;
-  }
-  else if constexpr(I == 10)
-  {
-    auto&& [a, b, c, d, e, f, g, h, i, j, k, ... elts] = static_cast<S&&>(s);
-    return k;
-  }
-  else if constexpr(I == 11)
-  {
-    auto&& [a, b, c, d, e, f, g, h, i, j, k, l, ... elts] = static_cast<S&&>(s);
-    return l;
-  }
-  else if constexpr(I == 12)
-  {
-    auto&& [a, b, c, d, e, f, g, h, i, j, k, l, m, ... elts] = static_cast<S&&>(s);
-    return m;
-  }
-  else if constexpr(I > 12)
-  {
-    auto&& [... elts] = static_cast<S&&>(s);
-    return tpl::get<I>(tpl::tie(elts...));
-  }
+  auto&& [... elts] = static_cast<S&&>(s);
+  return std::forward_like<S>(elts...[I]);
 }
 
 template <std::size_t Index, typename T>
 using tuple_element_t = std::decay_t<decltype(get<Index>(std::declval<const T&>()))>;
 
-template <typename S>
-constexpr auto for_each_field(S&& s, auto&& f) noexcept
+template <typename S, typename F>
+AVND_INLINE constexpr auto for_each_field(S&& s, F&& f) noexcept
 {
-  auto&& [... elts] = std::forward<S>(s);
-  (f(elts), ...);
+  auto&& [... elts] = static_cast<S&&>(s);
+  ((static_cast<F&&>(f)(std::forward_like<S>(elts))), ...);
 }
 }
 

--- a/include/avnd/common/for_nth.hpp
+++ b/include/avnd/common/for_nth.hpp
@@ -23,7 +23,7 @@ constexpr void for_each_field_ref(T&& value, F&& func)
 #if AVND_USE_BOOST_PFR
   using namespace pfr;
   using namespace pfr::detail;
-  static constexpr std::size_t fields_count_val
+  AVND_STATIC_CONSTEXPR std::size_t fields_count_val
       = boost::pfr::tuple_size_v<std::remove_reference_t<T>>;
 
   auto t = boost::pfr::detail::tie_as_tuple(
@@ -74,7 +74,7 @@ constexpr void for_each_field_ref(T&& value, F&& func)
 #if AVND_USE_BOOST_PFR
   using namespace pfr;
   using namespace pfr::detail;
-  static constexpr std::size_t fields_count_val
+  AVND_STATIC_CONSTEXPR std::size_t fields_count_val
       = avnd::pfr::tuple_size_v<std::remove_reference_t<T>>;
 
   auto t = avnd::pfr::detail::tie_as_tuple(value);
@@ -97,7 +97,7 @@ constexpr void for_each_field_ref_n(T&& value, F&& func)
 #if AVND_USE_BOOST_PFR
   using namespace pfr;
   using namespace pfr::detail;
-  static constexpr std::size_t fields_count_val
+  AVND_STATIC_CONSTEXPR std::size_t fields_count_val
       = avnd::pfr::tuple_size_v<std::remove_reference_t<T>>;
   auto t = avnd::pfr::detail::tie_as_tuple(value);
 
@@ -148,7 +148,7 @@ constexpr void for_each_field_function_table(T&& value, R func)
 #endif
   using namespace avnd::pfr;
   using namespace avnd::pfr::detail;
-  static constexpr std::size_t fields_count_val
+  AVND_STATIC_CONSTEXPR std::size_t fields_count_val
       = avnd::pfr::tuple_size_v<std::remove_reference_t<T>>;
 
   auto t = avnd::pfr::detail::tie_as_tuple(value);

--- a/include/avnd/common/for_nth.hpp
+++ b/include/avnd/common/for_nth.hpp
@@ -23,7 +23,7 @@ constexpr void for_each_field_ref(T&& value, F&& func)
 #if AVND_USE_BOOST_PFR
   using namespace pfr;
   using namespace pfr::detail;
-  constexpr std::size_t fields_count_val
+  static constexpr std::size_t fields_count_val
       = boost::pfr::tuple_size_v<std::remove_reference_t<T>>;
 
   auto t = boost::pfr::detail::tie_as_tuple(
@@ -74,7 +74,7 @@ constexpr void for_each_field_ref(T&& value, F&& func)
 #if AVND_USE_BOOST_PFR
   using namespace pfr;
   using namespace pfr::detail;
-  constexpr std::size_t fields_count_val
+  static constexpr std::size_t fields_count_val
       = avnd::pfr::tuple_size_v<std::remove_reference_t<T>>;
 
   auto t = avnd::pfr::detail::tie_as_tuple(value);
@@ -97,9 +97,8 @@ constexpr void for_each_field_ref_n(T&& value, F&& func)
 #if AVND_USE_BOOST_PFR
   using namespace pfr;
   using namespace pfr::detail;
-  constexpr std::size_t fields_count_val
+  static constexpr std::size_t fields_count_val
       = avnd::pfr::tuple_size_v<std::remove_reference_t<T>>;
-
   auto t = avnd::pfr::detail::tie_as_tuple(value);
 
   [&]<std::size_t... I>(std::index_sequence<I...>)
@@ -109,7 +108,9 @@ constexpr void for_each_field_ref_n(T&& value, F&& func)
   (std::make_index_sequence<fields_count_val>{});
 #else
   auto&& [... elts] = value;
-  (func(elts), ...);
+  const auto [... Is] = field_indices(std::make_index_sequence<sizeof...(elts)>{});
+
+  (func(elts, Is), ...);
 #endif
 }
 
@@ -147,7 +148,7 @@ constexpr void for_each_field_function_table(T&& value, R func)
 #endif
   using namespace avnd::pfr;
   using namespace avnd::pfr::detail;
-  constexpr std::size_t fields_count_val
+  static constexpr std::size_t fields_count_val
       = avnd::pfr::tuple_size_v<std::remove_reference_t<T>>;
 
   auto t = avnd::pfr::detail::tie_as_tuple(value);

--- a/include/avnd/common/index.hpp
+++ b/include/avnd/common/index.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <avnd/common/tuple.hpp>
+
 #include <array>
 #include <utility>
 
@@ -22,6 +24,12 @@ struct field_reflection
   using type = Field;
   static const constexpr auto index = Idx;
 };
+
+template <std::size_t... I>
+static constexpr auto field_indices(std::index_sequence<I...>)
+{
+  return tpl::tuple<avnd::field_index<I>...>{};
+}
 
 template <int N, typename T, std::size_t M>
 constexpr int index_of_element(const std::array<T, M>& arr) noexcept

--- a/include/avnd/common/inline.hpp
+++ b/include/avnd/common/inline.hpp
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <version>
+#if __cpp_constexpr >= 202211L
+#define AVND_STATIC_CONSTEXPR static constexpr
+#else
+#define AVND_STATIC_CONSTEXPR constexpr
+#endif
+
 #if defined(__clang__)
 #define AVND_INLINE inline __attribute__((always_inline))
 #elif defined(__GNUC__)

--- a/include/avnd/common/inline.hpp
+++ b/include/avnd/common/inline.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#if defined(__GNUC__)
+#if defined(__clang__)
 #define AVND_INLINE inline __attribute__((always_inline))
-#elif defined(__clang__)
+#elif defined(__GNUC__)
 #define AVND_INLINE inline __attribute__((always_inline))
 #elif defined(_MSC_VER)
 #define AVND_INLINE inline __forceinline
@@ -10,8 +10,12 @@
 #define AVND_INLINE inline
 #endif
 
-#if defined(__clang__)
+#if defined __has_attribute
+#if __has_attribute(flatten)
 #define AVND_INLINE_FLATTEN AVND_INLINE __attribute__((flatten))
-#else
+#endif
+#endif
+
+#if !defined(AVND_INLINE_FLATTEN)
 #define AVND_INLINE_FLATTEN AVND_INLINE
 #endif

--- a/include/avnd/wrappers/widgets.hpp
+++ b/include/avnd/wrappers/widgets.hpp
@@ -39,6 +39,8 @@ enum class widget_type
   range_slider,
   range_spinbox,
   multi_slider,
+  multi_slider_xy,
+  path_generator_xy,
   log_slider,
   log_knob,
   control,
@@ -98,6 +100,10 @@ struct widget_reflection
         return "range_spinbox";
       case widget_type::multi_slider:
         return "multi_slider";
+      case widget_type::multi_slider_xy:
+        return "multi_slider_xy";
+      case widget_type::path_generator_xy:
+        return "path_generator_xy";
       case widget_type::log_slider:
         return "log_slider";
       case widget_type::log_knob:
@@ -202,6 +208,14 @@ consteval auto get_widget()
   else if constexpr(requires { T::widget::multi_slider; })
   {
     return widget_reflection<std::vector<float>>{widget_type::multi_slider};
+  }
+  else if constexpr(requires { T::widget::multi_slider_xy; })
+  {
+    return widget_reflection<std::vector<float>>{widget_type::multi_slider_xy};
+  }
+  else if constexpr(requires { T::widget::path_generator_xy; })
+  {
+    return widget_reflection<std::vector<float>>{widget_type::path_generator_xy};
   }
   else if constexpr(requires { T::widget::log_slider; })
   {

--- a/include/halp/layout.hpp
+++ b/include/halp/layout.hpp
@@ -135,6 +135,19 @@ struct custom_control : T
   decltype(F) model = F;
 };
 
+
+template <typename T, auto F>
+struct multi_control : T
+{
+  halp_meta(layout, halp::layouts::multi_control)
+
+  double x = 0.0;
+  double y = 0.0;
+  double scale = 1.0;
+
+  decltype(F) model = F;
+};
+
 template <typename M, typename L, typename T>
 struct prop
 {


### PR DESCRIPTION
- core: provide an implementation that does not requires boost.pfr on C++26. yay !!!
- ci: try with xcode 16
- ci: fix build on msvc
- add multicursor and path generaor widgets
