### PR TITLE
change geometry node to inherit from ArrayMesh

### DIFF
--- a/include/avnd/binding/godot/geometry_node.hpp
+++ b/include/avnd/binding/godot/geometry_node.hpp
@@ -284,12 +284,11 @@ godot::Array build_mesh_arrays(const Geom& geom)
  * Each frame, runs the processor and rebuilds the mesh from geometry outputs.
  */
 template <typename T>
-struct godot_geometry_node : public godot::Node3D
+struct godot_geometry_node : public godot::MeshInstance3D
 {
   mutable avnd::effect_container<T> effect;
 
   godot::Ref<godot::ArrayMesh> mesh;
-  godot::MeshInstance3D* mesh_instance{nullptr};
 
   godot_geometry_node()
   {
@@ -317,9 +316,7 @@ struct godot_geometry_node : public godot::Node3D
   void do_ready()
   {
     // Create the MeshInstance3D child
-    mesh_instance = memnew(godot::MeshInstance3D);
-    mesh_instance->set_mesh(mesh);
-    add_child(mesh_instance);
+    set_mesh(mesh);
 
     if constexpr(avnd::has_inputs<T>)
     {

--- a/include/avnd/binding/godot/geometry_node.prototype.cpp.in
+++ b/include/avnd/binding/godot/geometry_node.prototype.cpp.in
@@ -15,7 +15,7 @@ using type = decltype(avnd::configure<godot_binding::config, @AVND_MAIN_CLASS@>(
 struct avnd_@AVND_C_NAME@@_AVND_GODOT_SUFFIX@ final
     : godot_binding::godot_geometry_node<type>
 {
-  GDCLASS(avnd_@AVND_C_NAME@@_AVND_GODOT_SUFFIX@, godot::Node3D);
+  GDCLASS(avnd_@AVND_C_NAME@@_AVND_GODOT_SUFFIX@, godot::MeshInstance3D);
   AVND_GODOT_GEOMETRY_NODE_OVERRIDES
 
 protected:


### PR DESCRIPTION
This way the geometry computed by the nodes can be clicked in the 3D viewport to select the node.