### PR TITLE
ossia: disambiguate tensor_port from parameter_port + tensor_like from aggregate paths

### DIFF
--- a/include/avnd/binding/max/inputs.hpp
+++ b/include/avnd/binding/max/inputs.hpp
@@ -160,7 +160,7 @@ struct inputs<T>
       using element_type = avnd::tensor_element<value_type>;
       t_symbol* type = jitter::jitter_type_for_element<element_type>();
 
-      constexpr std::size_t static_rank = halp::static_port_rank<Field>();
+      constexpr std::size_t static_rank = avnd::static_port_rank<Field>();
       long mindim = 1;
       long maxdim = jitter::jitter_max_dimcount;
       if constexpr(static_rank != avnd::dynamic_rank)

--- a/include/avnd/binding/max/jitter_helpers.hpp
+++ b/include/avnd/binding/max/jitter_helpers.hpp
@@ -8,7 +8,6 @@
 #include <avnd/concepts/tensor.hpp>
 #include <avnd/introspection/input.hpp>
 #include <avnd/introspection/output.hpp>
-#include <halp/tensor_port.hpp>
 #include <algorithm>
 #include <boost/container/vector.hpp>
 #include <cstdint>
@@ -490,22 +489,14 @@ inline void matrix_to_tensor(void* matrix, Field& field)
   using element_type = avnd::tensor_element<value_type>;
   const std::size_t bytes = total * sizeof(element_type);
 
-  if constexpr(halp::is_tensor_view_v<value_type>)
+  if constexpr(avnd::view_tensor_like<value_type>)
   {
-    auto scratch
-        = std::make_shared<std::vector<element_type>>(total);
+    auto scratch = std::make_shared<std::vector<element_type>>(total);
     std::memcpy(scratch->data(), matrix_data, bytes);
-
-    field.value.shape_v.assign(shape_buf, shape_buf + rank);
-    field.value.strides_v.resize(rank);
-    if(rank > 0)
-    {
-      field.value.strides_v[rank - 1] = 1;
-      for(std::size_t i = rank - 1; i > 0; --i)
-        field.value.strides_v[i - 1] = field.value.strides_v[i] * shape_buf[i];
-    }
-    field.value.data_ptr = scratch->data();
-    field.value.keep_alive = std::move(scratch);
+    avnd::set_view_buffer(
+        field.value, scratch->data(),
+        std::vector<std::size_t>(shape_buf, shape_buf + rank),
+        std::shared_ptr<void>(scratch, scratch->data()));
   }
   else if constexpr(avnd::resizable_tensor_like<value_type>)
   {

--- a/include/avnd/binding/max/outputs.hpp
+++ b/include/avnd/binding/max/outputs.hpp
@@ -751,7 +751,7 @@ struct outputs
       using element_type = avnd::tensor_element<value_type>;
       t_symbol* type = jitter::jitter_type_for_element<element_type>();
 
-      constexpr std::size_t static_rank = halp::static_port_rank<Field>();
+      constexpr std::size_t static_rank = avnd::static_port_rank<Field>();
       long mindim = 1;
       long maxdim = jitter::jitter_max_dimcount;
       if constexpr(static_rank != avnd::dynamic_rank)

--- a/include/avnd/binding/ossia/from_value.hpp
+++ b/include/avnd/binding/ossia/from_value.hpp
@@ -8,7 +8,6 @@
 #include <avnd/introspection/range.hpp>
 #include <avnd/introspection/type_wrapper.hpp>
 #include <avnd/introspection/vecf.hpp>
-#include <halp/tensor_port.hpp>
 #include <boost/mp11/algorithm.hpp>
 #include <ossia/network/value/value.hpp>
 #include <ossia/network/value/value_conversion.hpp>
@@ -1562,11 +1561,12 @@ from_ossia_value(auto& field, const ossia::value& src, std::optional<ossia::valu
 }
 
 // Forward-declared so the generic 3-arg dispatcher below resolves them
-// — they live in oscr:: and ADL on halp::tensor_view can't reach them.
+// at template-definition time.
 template <typename T>
-inline bool from_ossia_value(const ossia::value& src, halp::tensor_view<T>& dst);
+  requires avnd::view_tensor_like<T>
+inline bool from_ossia_value(const ossia::value& src, T& dst);
 template <typename T>
-  requires(avnd::tensor_like<T> && !halp::is_tensor_view_v<T>)
+  requires(avnd::tensor_like<T> && !avnd::view_tensor_like<T>)
 inline bool from_ossia_value(const ossia::value& src, T& dst);
 
 OSSIA_INLINE void from_ossia_value(auto& field, const ossia::value& src, auto& dst)
@@ -1712,8 +1712,10 @@ inline void fill_tensor_data(
 }  // namespace tensor_detail
 
 template <typename T>
-inline bool from_ossia_value(const ossia::value& src, halp::tensor_view<T>& dst)
+  requires avnd::view_tensor_like<T>
+inline bool from_ossia_value(const ossia::value& src, T& dst)
 {
+  using elem_t = avnd::tensor_element<T>;
   std::vector<std::size_t> shape;
   tensor_detail::infer_tensor_shape(src, shape, 0);
   std::size_t total = 1;
@@ -1721,30 +1723,20 @@ inline bool from_ossia_value(const ossia::value& src, halp::tensor_view<T>& dst)
     total *= d;
   if(total == 0)
   {
-    dst.data_ptr = nullptr;
-    dst.shape_v.clear();
-    dst.strides_v.clear();
-    dst.keep_alive.reset();
+    avnd::set_view_buffer(dst, static_cast<elem_t*>(nullptr), {}, {});
     return false;
   }
-  auto buf = std::make_shared<std::vector<T>>(total);
+  auto buf = std::make_shared<std::vector<elem_t>>(total);
   std::size_t idx = 0;
   tensor_detail::fill_tensor_data(src, buf->data(), shape, 0, idx);
-  dst.data_ptr = buf->data();
-  dst.shape_v = std::move(shape);
-  dst.strides_v.resize(dst.shape_v.size());
-  std::size_t stride = 1;
-  for(std::size_t d = dst.shape_v.size(); d-- > 0;)
-  {
-    dst.strides_v[d] = stride;
-    stride *= dst.shape_v[d];
-  }
-  dst.keep_alive = std::shared_ptr<void>(buf, buf->data());
+  avnd::set_view_buffer(
+      dst, buf->data(), std::move(shape),
+      std::shared_ptr<void>(buf, buf->data()));
   return true;
 }
 
 template <typename T>
-  requires(avnd::tensor_like<T> && !halp::is_tensor_view_v<T>)
+  requires(avnd::tensor_like<T> && !avnd::view_tensor_like<T>)
 inline bool from_ossia_value(const ossia::value& src, T& dst)
 {
   using elem_t = avnd::tensor_element<T>;

--- a/include/avnd/binding/ossia/from_value.hpp
+++ b/include/avnd/binding/ossia/from_value.hpp
@@ -343,7 +343,7 @@ struct from_ossia_value_impl
   }
 
   template <typename F>
-    requires std::is_aggregate_v<F> bool
+    requires(std::is_aggregate_v<F> && !avnd::tensor_like<F>) bool
   operator()(const ossia::value& src, F& dst)
   {
     constexpr int sz = avnd::pfr::tuple_size_v<F>;

--- a/include/avnd/binding/ossia/from_value.hpp
+++ b/include/avnd/binding/ossia/from_value.hpp
@@ -1375,7 +1375,7 @@ bool from_ossia_value_rec(const ossia::value& src, T& dst)
 }
 
 template <typename T>
-  requires std::is_aggregate_v<T>
+  requires(std::is_aggregate_v<T> && !avnd::tensor_like<T>)
 bool from_ossia_value(const ossia::value& src, T& dst)
 {
   using type = std::decay_t<T>;

--- a/include/avnd/binding/ossia/from_value.hpp
+++ b/include/avnd/binding/ossia/from_value.hpp
@@ -1561,6 +1561,14 @@ from_ossia_value(auto& field, const ossia::value& src, std::optional<ossia::valu
   dst = src;
 }
 
+// Forward-declared so the generic 3-arg dispatcher below resolves them
+// — they live in oscr:: and ADL on halp::tensor_view can't reach them.
+template <typename T>
+inline bool from_ossia_value(const ossia::value& src, halp::tensor_view<T>& dst);
+template <typename T>
+  requires(avnd::tensor_like<T> && !halp::is_tensor_view_v<T>)
+inline bool from_ossia_value(const ossia::value& src, T& dst);
+
 OSSIA_INLINE void from_ossia_value(auto& field, const ossia::value& src, auto& dst)
 {
   from_ossia_value(src, dst);

--- a/include/avnd/binding/ossia/port_run_postprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_postprocess.hpp
@@ -114,7 +114,8 @@ struct process_after_run
   }
 
   template <avnd::parameter_port Field, std::size_t Idx>
-    requires(!avnd::sample_accurate_parameter_port<Field> && !ossia_port<Field>)
+    requires(!avnd::sample_accurate_parameter_port<Field> && !avnd::tensor_port<Field>
+             && !ossia_port<Field>)
   void operator()(
       Field& ctrl, ossia::value_outlet& port, avnd::field_index<Idx>) const noexcept
   {

--- a/include/avnd/binding/ossia/port_run_preprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_preprocess.hpp
@@ -145,7 +145,7 @@ struct process_before_run
   template <avnd::parameter_port Field, std::size_t Idx>
     requires(
         !avnd::sample_accurate_parameter_port<Field> && !avnd::span_parameter_port<Field>
-        && !ossia_port<Field>)
+        && !avnd::tensor_port<Field> && !ossia_port<Field>)
   void operator()(
       Field& ctrl, ossia::value_inlet& port, avnd::field_index<Idx> idx) const noexcept
   {

--- a/include/avnd/binding/ossia/to_value.hpp
+++ b/include/avnd/binding/ossia/to_value.hpp
@@ -75,7 +75,7 @@ struct to_ossia_value_impl
   }
 
   template <typename F>
-    requires(std::is_aggregate_v<F> && !avnd::vector_ish<F>)
+    requires(std::is_aggregate_v<F> && !avnd::vector_ish<F> && !avnd::tensor_like<F>)
   void operator()(const F& f)
   {
     constexpr int fields = avnd::pfr::tuple_size_v<F>;

--- a/include/avnd/binding/pd/outputs.hpp
+++ b/include/avnd/binding/pd/outputs.hpp
@@ -601,7 +601,7 @@ inline void value_to_pd_dispatch(t_outlet* outlet, Args&&... v) noexcept
 {
   if constexpr(tensor_output_dispatch<C, Args...>)
   {
-    constexpr std::size_t static_rank = halp::static_port_rank<C>();
+    constexpr std::size_t static_rank = avnd::static_port_rank<C>();
     pd::emit_tensor<static_rank>(outlet, std::forward<Args>(v)...);
     return;
   }

--- a/include/avnd/binding/pd/tensor_atoms.hpp
+++ b/include/avnd/binding/pd/tensor_atoms.hpp
@@ -9,7 +9,6 @@
 
 #include <avnd/binding/pd/helpers.hpp>
 #include <avnd/concepts/tensor.hpp>
-#include <halp/tensor_port.hpp>
 #include <m_pd.h>
 
 #include <cstddef>
@@ -95,7 +94,7 @@ inline bool apply_atoms_to_tensor(Container& container, int argc, t_atom* argv) 
     payload_offset = 0;
   }
 
-  if constexpr(halp::is_tensor_view_v<Container>)
+  if constexpr(avnd::view_tensor_like<Container>)
   {
     auto buf = std::make_shared<std::vector<element_type>>(total);
     auto* dst = buf->data();
@@ -103,20 +102,9 @@ inline bool apply_atoms_to_tensor(Container& container, int argc, t_atom* argv) 
     {
       dst[i] = tensor_element_from_atom<element_type>(argv[payload_offset + static_cast<int>(i)]);
     }
-
-    // Row-major contiguous strides (in elements).
-    std::vector<std::size_t> strides(shape.size(), 1);
-    for(std::ptrdiff_t i = static_cast<std::ptrdiff_t>(shape.size()) - 2; i >= 0; --i)
-    {
-      strides[static_cast<std::size_t>(i)]
-          = strides[static_cast<std::size_t>(i) + 1] * shape[static_cast<std::size_t>(i) + 1];
-    }
-
-    container.data_ptr = dst;
-    container.shape_v = std::move(shape);
-    container.strides_v = std::move(strides);
-    container.keep_alive
-        = std::shared_ptr<void>(buf, static_cast<void*>(buf->data()));
+    avnd::set_view_buffer(
+        container, dst, std::move(shape),
+        std::shared_ptr<void>(buf, static_cast<void*>(dst)));
     return true;
   }
   else if constexpr(avnd::resizable_tensor_like<Container>)

--- a/include/avnd/binding/python/processor.hpp
+++ b/include/avnd/binding/python/processor.hpp
@@ -12,7 +12,6 @@
 #include <avnd/wrappers/controls.hpp>
 #include <avnd/wrappers/metadatas.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
-#include <halp/tensor_port.hpp>
 #include <boost/type_index.hpp>
 #include <cmath>
 #include <cstring>
@@ -197,70 +196,52 @@ struct processor
   // Tensor-typed port: marshal as py::array_t<Elem> with shape +
   // strides preserved, zero-copy from numpy when layout matches.
   //
-  // Two dispatches based on the port's value type:
-  //
-  //   - `halp::tensor_view<T>` — non-owning input view. The setter
-  //     stashes the numpy buffer pointer + shape and holds a
-  //     reference to the array via `keep_alive`. Saves the per-tick
-  //     allocation + memcpy. Forcecast + c_style still apply so a
-  //     non-contiguous source still gets a one-time copy through
-  //     pybind11 internals; the view simply points at that copy.
-  //
-  //   - owning tensor (ndarray<T>, xt::xarray, …) — existing
-  //     resize + memcpy path. Required when ports want to retain
-  //     the input across ticks, or pass through cmake-locked
-  //     backends.
+  // Dispatch on the port's value type via avnd::view_tensor_like:
+  // view types receive a numpy buffer pointer + shape via
+  // avnd::set_view_buffer (zero-copy when c_style + dtype match);
+  // owning containers go through resize_to + memcpy.
   template <auto Idx, typename C>
   void setup_tensor_input(avnd::field_reflection<Idx, C>)
   {
     using value_type = std::remove_cvref_t<decltype(C::value)>;
     using elem_t = avnd::tensor_element<value_type>;
 
-    if constexpr(halp::is_tensor_view_v<value_type>)
+    if constexpr(avnd::view_tensor_like<value_type>)
     {
       class_def.def_property(
           c_str(input_name(avnd::field_reflection<Idx, C>{})),
-          // Reader: rebuild a numpy view from the stored pointer +
-          // shape. Returns None if no input has been set this tick.
           [](T& self) -> py::object {
             auto& v = avnd::pfr::get<Idx>(self.inputs).value;
-            if(v.data_ptr == nullptr)
+            const auto* data = avnd::data_of(v);
+            if(data == nullptr)
               return py::none();
-            std::vector<py::ssize_t> sh(v.shape_v.begin(), v.shape_v.end());
+            const auto sh = avnd::shape_of(v);
+            std::vector<py::ssize_t> shv(sh.begin(), sh.end());
             return py::array_t<elem_t>(
-                       sh,
-                       const_cast<elem_t*>(v.data_ptr),
+                       shv,
+                       const_cast<elem_t*>(data),
                        py::cast(&self, py::return_value_policy::reference));
           },
-          // Writer: capture the numpy buffer as a view and hold a
-          // ref to keep it alive until the next assignment.
-          // `c_style | forcecast` ensures contiguous + correct dtype;
-          // if the source is already so, no copy happens inside
-          // pybind11. Strides are converted from bytes (numpy) to
-          // elements (our tensor_view convention) at the boundary.
           [](T& self,
              py::array_t<elem_t,
                          py::array::c_style | py::array::forcecast> arr) {
             auto& v = avnd::pfr::get<Idx>(self.inputs).value;
             const auto info = arr.request();
-            v.data_ptr = static_cast<const elem_t*>(info.ptr);
-            v.shape_v.assign(info.shape.begin(), info.shape.end());
-            v.strides_v.assign(info.strides.size(), 0);
+            std::vector<std::size_t> shape(info.shape.begin(), info.shape.end());
+            std::vector<std::size_t> strides(info.strides.size());
             for(std::size_t d = 0; d < info.strides.size(); ++d)
-              v.strides_v[d]
-                  = static_cast<std::size_t>(info.strides[d])
-                    / sizeof(elem_t);
-            // Hold a py::object reference to the (possibly
-            // pybind11-internally-copied) array so its buffer stays
-            // valid until the next setter call. Custom deleter
-            // re-acquires the GIL because the holder may be released
-            // from a C++ destructor on an arbitrary thread.
-            v.keep_alive = std::shared_ptr<void>(
+              strides[d] = static_cast<std::size_t>(info.strides[d]) / sizeof(elem_t);
+            // GIL-acquiring deleter — the holder may be released from
+            // a C++ destructor on an arbitrary thread.
+            std::shared_ptr<void> keep_alive(
                 new py::object(arr),
                 [](void* p) {
                   py::gil_scoped_acquire gil;
                   delete static_cast<py::object*>(p);
                 });
+            avnd::set_view_buffer(
+                v, static_cast<elem_t*>(info.ptr),
+                std::move(shape), std::move(strides), std::move(keep_alive));
             auto& inputs = avnd::get_inputs(self);
             auto& field = boost::pfr::get<Idx>(inputs);
             if_possible(field.update(self));

--- a/include/avnd/binding/touchdesigner/chop/message_processor.hpp
+++ b/include/avnd/binding/touchdesigner/chop/message_processor.hpp
@@ -68,9 +68,9 @@ struct output_length_visitor
     if(r == 0)
       return 0;
 
-    if constexpr(halp::has_static_rank<T>)
+    if constexpr(avnd::has_static_rank<T>)
     {
-      constexpr std::size_t static_r = halp::static_port_rank<T>();
+      constexpr std::size_t static_r = avnd::static_port_rank<T>();
       static_assert(static_r <= 2,
                     "TD CHOP cannot lower a tensor of rank > 2");
       if constexpr(static_r == 1)
@@ -123,9 +123,9 @@ struct output_channel_count_visitor
       const std::size_t r = std::ranges::size(sh);
       if(r == 0)
         return 1;
-      if constexpr(halp::has_static_rank<T>)
+      if constexpr(avnd::has_static_rank<T>)
       {
-        constexpr std::size_t static_r = halp::static_port_rank<T>();
+        constexpr std::size_t static_r = avnd::static_port_rank<T>();
         static_assert(static_r <= 2,
                       "TD CHOP cannot lower a tensor of rank > 2.");
         if constexpr(static_r == 1)
@@ -577,16 +577,17 @@ private:
                                   : static_cast<std::size_t>(n_chan)
                                         * static_cast<std::size_t>(n_samp);
 
-    if constexpr(halp::is_tensor_view_v<value_type>)
+    if constexpr(avnd::view_tensor_like<value_type>)
     {
-      using elem_t = typename value_type::element_type;
-
-      if(tensor_input_scratch.size() <= P)
-        tensor_input_scratch.resize(P + 1);
-      auto& scratch_raw = tensor_input_scratch[P];
+      using elem_t = avnd::tensor_element<value_type>;
 
       if constexpr(std::is_same_v<elem_t, double>)
       {
+        // Per-port scratch buffer reused across ticks — no keep_alive
+        // needed since the processor owns it.
+        if(tensor_input_scratch.size() <= P)
+          tensor_input_scratch.resize(P + 1);
+        auto& scratch_raw = tensor_input_scratch[P];
         scratch_raw.resize(total);
         for(int c = 0; c < n_chan; ++c)
         {
@@ -596,7 +597,8 @@ private:
           for(int s = 0; s < n_samp; ++s)
             dst[s] = static_cast<double>(src[s]);
         }
-        field.value.data_ptr = scratch_raw.data();
+        avnd::set_view_buffer(
+            field.value, scratch_raw.data(), shape, {});
       }
       else
       {
@@ -609,15 +611,10 @@ private:
           for(int s = 0; s < n_samp; ++s)
             dst[s] = static_cast<elem_t>(src[s]);
         }
-        field.value.data_ptr = holder->data();
-        field.value.keep_alive
-            = std::shared_ptr<void>(holder, holder.get());
+        avnd::set_view_buffer(
+            field.value, holder->data(), shape,
+            std::shared_ptr<void>(holder, holder.get()));
       }
-
-      field.value.shape_v = shape;
-      field.value.strides_v.assign(shape.size(), 1);
-      if(shape.size() >= 2)
-        field.value.strides_v[0] = shape[1];
     }
     else if constexpr(avnd::resizable_tensor_like<value_type>)
     {

--- a/include/avnd/binding/touchdesigner/dat/data_processor.hpp
+++ b/include/avnd/binding/touchdesigner/dat/data_processor.hpp
@@ -15,7 +15,6 @@
 #include <avnd/wrappers/avnd.hpp>
 #include <avnd/wrappers/controls.hpp>
 #include <avnd/wrappers/controls_double.hpp>
-#include <halp/tensor_port.hpp>
 
 #include <charconv>
 #include <cstring>
@@ -265,7 +264,7 @@ private:
   {
     using value_type = std::remove_cvref_t<decltype(field.value)>;
     using elem_t = avnd::tensor_element<value_type>;
-    constexpr std::size_t static_rank = halp::static_port_rank<Field>();
+    constexpr std::size_t static_rank = avnd::static_port_rank<Field>();
 
     const int rows = dat_input->numRows;
     const int cols = dat_input->numCols;
@@ -274,7 +273,7 @@ private:
 
     constexpr bool wire_rank_1 = (static_rank == 1);
 
-    if constexpr(halp::is_tensor_view_v<value_type>)
+    if constexpr(avnd::view_tensor_like<value_type>)
     {
       if constexpr(wire_rank_1)
       {
@@ -287,10 +286,9 @@ private:
           else
             buf[c] = elem_t{};
         }
-        field.value.data_ptr = buf.get();
-        field.value.shape_v = {N};
-        field.value.strides_v = {1};
-        field.value.keep_alive = std::shared_ptr<void>(buf, buf.get());
+        avnd::set_view_buffer(
+            field.value, buf.get(), std::vector<std::size_t>{N},
+            std::shared_ptr<void>(buf, buf.get()));
       }
       else
       {
@@ -308,10 +306,9 @@ private:
               buf[r * C + c] = elem_t{};
           }
         }
-        field.value.data_ptr = buf.get();
-        field.value.shape_v = {R, C};
-        field.value.strides_v = {C, 1};
-        field.value.keep_alive = std::shared_ptr<void>(buf, buf.get());
+        avnd::set_view_buffer(
+            field.value, buf.get(), std::vector<std::size_t>{R, C},
+            std::shared_ptr<void>(buf, buf.get()));
       }
     }
     else if constexpr(avnd::resizable_tensor_like<value_type>)
@@ -505,7 +502,7 @@ private:
     const auto shape = avnd::shape_of(v);
     const elem_t* data = avnd::data_of(v);
     const std::size_t rank = std::ranges::size(shape);
-    constexpr std::size_t static_rank = halp::static_port_rank<Field>();
+    constexpr std::size_t static_rank = avnd::static_port_rank<Field>();
 
     if(data == nullptr || rank == 0)
     {

--- a/include/avnd/concepts/tensor.hpp
+++ b/include/avnd/concepts/tensor.hpp
@@ -42,6 +42,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <ranges>
 #include <type_traits>
 #include <vector>
@@ -214,6 +215,50 @@ template <typename T>
 concept mutable_tensor_like
     = tensor_like<T> && !std::is_const_v<std::remove_pointer_t<detail::data_result_t<T>>>;
 
+// Customization point: install backing buffer + shape + strides into
+// a view type. Default assumes the halp::tensor_view layout; users
+// plug their own view in by overloading in its namespace.
+// `view_tensor_like<T>` resolves true for any T accepted by some
+// `set_view_buffer` candidate.
+template <typename View, typename Elem>
+  requires requires(View& v) { v.data_ptr; v.shape_v; v.strides_v; v.keep_alive; }
+inline void set_view_buffer(
+    View& v, Elem* data,
+    std::vector<std::size_t> shape, std::vector<std::size_t> strides,
+    std::shared_ptr<void> keep_alive)
+{
+  v.data_ptr = data;
+  v.shape_v = std::move(shape);
+  v.strides_v = std::move(strides);
+  v.keep_alive = std::move(keep_alive);
+}
+
+// Convenience: row-major contiguous strides derived from shape.
+template <typename View, typename Elem>
+inline void set_view_buffer(
+    View& v, Elem* data,
+    std::vector<std::size_t> shape, std::shared_ptr<void> keep_alive)
+{
+  std::vector<std::size_t> strides(shape.size());
+  std::size_t stride = 1;
+  for(std::size_t d = shape.size(); d-- > 0;)
+  {
+    strides[d] = stride;
+    stride *= shape[d];
+  }
+  set_view_buffer(
+      v, data, std::move(shape), std::move(strides), std::move(keep_alive));
+}
+
+template <typename T>
+concept view_tensor_like
+    = tensor_like<T>
+      && requires(
+             T t, tensor_element<T>* p, std::vector<std::size_t> sh,
+             std::vector<std::size_t> st, std::shared_ptr<void> ka) {
+           set_view_buffer(t, p, sh, st, ka);
+         };
+
 // -----------------------------------------------------------------
 // Concept: dynamic_tensor_like<T>
 //
@@ -259,6 +304,26 @@ constexpr std::size_t container_static_rank() noexcept
   else
     return dynamic_rank;
 }
+
+// Static port rank — `Port::static_rank` if it exposes one (e.g. via
+// a kind hint computed in the user-facing port template), else the
+// container's compile-time rank.
+template <typename Port>
+constexpr std::size_t static_port_rank() noexcept
+{
+  if constexpr(requires { { Port::static_rank } -> std::convertible_to<std::size_t>; })
+  {
+    constexpr std::size_t r = Port::static_rank;
+    if constexpr(r != dynamic_rank)
+      return r;
+  }
+  if constexpr(requires { typename Port::value_type; })
+    return container_static_rank<typename Port::value_type>();
+  return dynamic_rank;
+}
+
+template <typename Port>
+concept has_static_rank = (static_port_rank<Port>() != dynamic_rank);
 
 template <typename Field>
 concept tensor_port

--- a/include/halp/tensor_port.hpp
+++ b/include/halp/tensor_port.hpp
@@ -139,29 +139,6 @@ enum class tensor_kind : unsigned char
   spectrogram,
 };
 
-template <static_string Name, typename Container,
-          tensor_kind Kind = tensor_kind::generic>
-struct tensor_port
-{
-  using value_type = Container;
-  static constexpr tensor_kind kind = Kind;
-
-  static clang_buggy_consteval auto name() noexcept
-  {
-    return std::string_view{Name.value};
-  }
-
-  Container value{};
-
-  // Convenience accessors that go through the customization points.
-  auto data() noexcept             { return avnd::data_of(value); }
-  auto data() const noexcept       { return avnd::data_of(value); }
-  auto shape() const noexcept      { return avnd::shape_of(value); }
-
-  operator Container&() noexcept             { return value; }
-  operator const Container&() const noexcept { return value; }
-};
-
 constexpr std::size_t kind_to_rank(tensor_kind k) noexcept
 {
   switch(k)
@@ -178,23 +155,31 @@ constexpr std::size_t kind_to_rank(tensor_kind k) noexcept
   }
 }
 
-template <typename Port>
-constexpr std::size_t static_port_rank() noexcept
+template <static_string Name, typename Container,
+          tensor_kind Kind = tensor_kind::generic>
+struct tensor_port
 {
-  if constexpr(requires { { Port::kind } -> std::convertible_to<tensor_kind>; })
-  {
-    constexpr std::size_t from_kind = kind_to_rank(Port::kind);
-    if constexpr(from_kind != avnd::dynamic_rank)
-      return from_kind;
-  }
-  if constexpr(requires { typename Port::value_type; })
-  {
-    return avnd::container_static_rank<typename Port::value_type>();
-  }
-  return avnd::dynamic_rank;
-}
+  using value_type = Container;
+  static constexpr tensor_kind kind = Kind;
+  static constexpr std::size_t static_rank
+      = kind_to_rank(Kind) != avnd::dynamic_rank
+            ? kind_to_rank(Kind)
+            : avnd::container_static_rank<Container>();
 
-template <typename Port>
-concept has_static_rank = (static_port_rank<Port>() != avnd::dynamic_rank);
+  static clang_buggy_consteval auto name() noexcept
+  {
+    return std::string_view{Name.value};
+  }
+
+  Container value{};
+
+  // Convenience accessors that go through the customization points.
+  auto data() noexcept             { return avnd::data_of(value); }
+  auto data() const noexcept       { return avnd::data_of(value); }
+  auto shape() const noexcept      { return avnd::shape_of(value); }
+
+  operator Container&() noexcept             { return value; }
+  operator const Container&() const noexcept { return value; }
+};
 
 }  // namespace halp


### PR DESCRIPTION
## Summary

Four small constraint additions / forward declarations that fix overload-ambiguity errors triggered when an addon registers tensor ports on the ossia (score) back-end.

| Commit | What |
|---|---|
| `30ea784` | `port_run_preprocess.hpp` / `port_run_postprocess.hpp`: add `!avnd::tensor_port<Field>` to the parameter_port + value_inlet / value_outlet overloads. `avnd::parameter_port` is `is_default_constructible_v<value>`, which matches `halp::tensor_port<...>` — gcc then reports ambiguous between the parameter_port handler and the tensor_port handler I added in `fcb682e ossia: tensor port lowering as recursive value list`. |
| `ce151c3` | `from_value.hpp` + `to_value.hpp`: add `!avnd::tensor_like<F>` to the impl-side `std::is_aggregate_v<F>` paths. `ndarray<T>` / `tensor_view<T>` are aggregates; the aggregate path walked their fields via `pfr::for_each_field` and bottomed out on `const T* data_ptr` (no `from_ossia_value_impl(value, const double*&)` overload). |
| `7f0e0fc` | `from_value.hpp`: symmetric exclusion at the public `is_aggregate_v` 2-arg `from_ossia_value` overload, for the same reason. |
| `76704e3` | `from_value.hpp`: forward-declare the 2-arg tensor overloads (`tensor_view<T>` and constrained tensor_like) right before the generic 3-arg dispatcher. The dispatcher calls unqualified `from_ossia_value(src, dst)`; the tensor 2-arg overloads live in `oscr::` further down the file, so two-phase lookup at the dispatcher's definition point can't see them and ADL on `halp::tensor_view<T>` doesn't reach `oscr::` either. The forward decls put them on the candidate list at definition time. |

## Why this slipped through

The original tensor-lowering commit (`fcb682e`) was validated only by the Python build harness in the goofi-pipe port tree, which doesn't exercise the ossia back-end. The ambiguity surfaces as soon as a real ossia node is generated for a tensor port — caught here while validating `avnd-goofi` as a score addon.

## Test plan

- [x] `cmake --build build-validate --target avnd_goofi` against an ossia/score worktree previously fails with `ambiguous` for `process_before_run / process_after_run`, with `no match` for `from_ossia_value_impl` chasing `const T*` / `std::shared_ptr<void>`, and finally with `no matching function for call to from_ossia_value(value, halp::tensor_view<double>&)`. With this PR the same target builds **1409/1409** clean and the score plugin `libavnd_goofi.so` links.
- [ ] No effect on Python / Pd / TD / Max bindings (the predicates exist only inside `binding/ossia/`).