### PR TITLE
Semantic tagging follow-ups: instance semantics, backend texture gaps

### DIFF
--- a/examples/Gpu/FilterGeometry.hpp
+++ b/examples/Gpu/FilterGeometry.hpp
@@ -2,104 +2,15 @@
 
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <avnd/concepts/gfx.hpp>
+#include <halp/geometry.hpp>
 
-#include <cstdlib>
-#include <cstring>
-#include <random>
+#include <algorithm>
+#include <cassert>
 #include <span>
 
 namespace examples
 {
-struct dynamic_geometry
-{
-  struct buffer
-  {
-    void* data{};
-    int size{};
-    bool dirty{};
-  };
-
-  struct binding
-  {
-    int stride{};
-    enum
-    {
-      per_vertex,
-      per_instance
-    } classification{};
-    int step_rate{};
-  };
-
-  struct attribute
-  {
-    int binding = 0;
-    enum : uint32_t
-    {
-      position,
-      tex_coord,
-      color,
-      normal,
-      tangent
-    } location{};
-    enum
-    {
-      float4,
-      float3,
-      float2,
-      float1,
-      uint4,
-      uint2,
-      uint1
-    } format{};
-    int32_t offset{};
-  };
-
-  struct input
-  {
-    int buffer{}; // Index of the buffer to use
-    int offset{};
-  };
-
-  std::vector<buffer> buffers;
-  std::vector<binding> bindings;
-  std::vector<attribute> attributes;
-  std::vector<input> input;
-  int vertices = 0;
-  enum
-  {
-    triangles,
-    triangle_strip,
-    triangle_fan,
-    lines,
-    line_strip,
-    points
-  } topology;
-  enum
-  {
-    none,
-    front,
-    back
-  } cull_mode;
-  enum
-  {
-    counter_clockwise,
-    clockwise
-  } front_face;
-
-  struct
-  {
-    int buffer{-1};
-    int offset{};
-    enum
-    {
-      uint16,
-      uint32
-    } format{};
-  } index;
-
-  bool dirty{};
-};
-static_assert(avnd::geometry_port<dynamic_geometry>);
+static_assert(avnd::geometry_port<halp::dynamic_geometry>);
 
 struct FilterGeometry
 {
@@ -109,53 +20,49 @@ struct FilterGeometry
 
   struct
   {
-    dynamic_geometry geometry;
+    halp::dynamic_geometry geometry;
   } inputs;
 
   struct
   {
-    dynamic_geometry geometry;
+    halp::dynamic_geometry geometry;
   } outputs;
-
-  FilterGeometry() { }
-
-  ~FilterGeometry()
-  {
-    //delete outputs.geometry.buffers.main_buffer.data;
-  }
 
   void operator()()
   {
     outputs.geometry = inputs.geometry;
-    outputs.geometry.dirty = true;
     if(outputs.geometry.buffers.empty())
       return;
 
-    // Find the position attribute:
+    // Find the position attribute through its semantic
     auto& attr = outputs.geometry.attributes;
-    auto it = std::find_if(
-        attr.begin(), attr.end(), [](auto& a) { return a.location == 0; });
+    auto it = std::find_if(attr.begin(), attr.end(), [](auto& a) {
+      return a.semantic == halp::attribute_semantic::position;
+    });
     if(it == attr.end())
       return;
 
     const int binding = it->binding;
     auto& ins = outputs.geometry.input;
     assert(binding >= 0);
-    assert(binding < ins.size());
+    assert(binding < std::ssize(ins));
 
     const int buffer = ins[binding].buffer;
 
     auto& bufs = outputs.geometry.buffers;
     assert(buffer >= 0);
-    assert(buffer < bufs.size());
+    assert(buffer < std::ssize(bufs));
 
     auto& buf = bufs[buffer];
+    if(!buf.raw_data)
+      return;
 
-    // Cheat a bit for now... and assume that position comes first,
-    // and that things aren't interleaved,
-    // and that we have float[3]s, ...
+    // Cheat a bit for now... and assume that positions aren't interleaved
+    // and that we have float[3]s
     using type = float[3];
-    std::span<type> vertices((type*)buf.data, outputs.geometry.vertices);
+    std::span<type> vertices(
+        (type*)((char*)buf.raw_data + ins[binding].byte_offset + it->byte_offset),
+        outputs.geometry.vertices);
 
     for(float(&v)[3] : vertices)
     {
@@ -164,12 +71,7 @@ struct FilterGeometry
       v[2] += 0.01;
     }
 
-    //auto b = (float*) outputs.geometry.buffers[0].data;
-    //for(int i = 0; i < 16; i++)
-    //{
-    //  b[i] += 0.01;
-    //}
-    outputs.geometry.buffers[0].dirty = true;
+    buf.dirty = true;
   }
 };
 }

--- a/include/avnd/binding/godot/node.hpp
+++ b/include/avnd/binding/godot/node.hpp
@@ -22,6 +22,7 @@
 #include <godot_cpp/variant/variant.hpp>
 #include <godot_cpp/variant/vector2.hpp>
 #include <godot_cpp/variant/vector3.hpp>
+#include <godot_cpp/variant/vector4.hpp>
 #include <magic_enum/magic_enum.hpp>
 
 #include <string>
@@ -80,6 +81,8 @@ constexpr godot::Variant::Type variant_type()
     return godot::Variant::COLOR;
   else if constexpr(avnd::rgb_parameter<C>)
     return godot::Variant::COLOR;
+  else if constexpr(avnd::xyzw_parameter<C>)
+    return godot::Variant::VECTOR4;
   else if constexpr(avnd::xyz_parameter<C>)
     return godot::Variant::VECTOR3;
   else if constexpr(avnd::xy_parameter<C>)
@@ -206,6 +209,15 @@ bool set_from_variant(C& field, const godot::Variant& v)
     field.value.g = static_cast<comp_t>(col.g);
     field.value.b = static_cast<comp_t>(col.b);
   }
+  else if constexpr(avnd::xyzw_parameter<C>)
+  {
+    godot::Vector4 vec = v;
+    using comp_t = std::decay_t<decltype(field.value.x)>;
+    field.value.x = static_cast<comp_t>(vec.x);
+    field.value.y = static_cast<comp_t>(vec.y);
+    field.value.z = static_cast<comp_t>(vec.z);
+    field.value.w = static_cast<comp_t>(vec.w);
+  }
   else if constexpr(avnd::xyz_parameter<C>)
   {
     godot::Vector3 vec = v;
@@ -262,6 +274,11 @@ godot::Variant to_variant(const C& field)
   else if constexpr(avnd::rgb_parameter<C>)
   {
     return godot::Color(field.value.r, field.value.g, field.value.b, 1.0f);
+  }
+  else if constexpr(avnd::xyzw_parameter<C>)
+  {
+    return godot::Vector4(
+        field.value.x, field.value.y, field.value.z, field.value.w);
   }
   else if constexpr(avnd::xyz_parameter<C>)
   {

--- a/include/avnd/binding/godot/texture_node.hpp
+++ b/include/avnd/binding/godot/texture_node.hpp
@@ -7,15 +7,24 @@
 
 #include <godot_cpp/classes/image.hpp>
 #include <godot_cpp/classes/image_texture.hpp>
+#include <godot_cpp/classes/texture2d.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
+
+#include <cstring>
 
 namespace godot_binding
 {
 
-/// Map an Avendish texture format enum to a Godot Image::Format.
+/// Map an Avendish texture format tag (compile-time) to a Godot Image::Format.
 ///
+/// Handles:
+/// - textures whose format is a static string, e.g. static constexpr auto format() { return "rgba"; }
+/// - textures whose format is a one-value enum tag, e.g. enum format { RGBA };
+///   (this is what halp::rgba_texture, rgb_texture, r8_texture, r32f_texture,
+///    rgba32f_texture use)
+/// - anything else falls back to a guess based on bytes_per_pixel, else RGBA8.
 template <typename F>
-godot::Image::Format godot_image_format() noexcept
+constexpr godot::Image::Format godot_image_format() noexcept
 {
   if constexpr(requires { std::string_view{F::format()}; })
   {
@@ -23,8 +32,10 @@ godot::Image::Format godot_image_format() noexcept
 
     if(fmt == "rgba" || fmt == "rgba8")
       return godot::Image::FORMAT_RGBA8;
-    else if(fmt == "r8" || fmt == "grayscale")
+    else if(fmt == "r8")
       return godot::Image::FORMAT_R8;
+    else if(fmt == "grayscale" || fmt == "l8")
+      return godot::Image::FORMAT_L8;
     else if(fmt == "rg8")
       return godot::Image::FORMAT_RG8;
     else if(fmt == "rgba16f")
@@ -39,17 +50,21 @@ godot::Image::Format godot_image_format() noexcept
       return godot::Image::FORMAT_RGH;
     else if(fmt == "rg32f")
       return godot::Image::FORMAT_RGF;
+    else if(fmt == "rgb32f")
+      return godot::Image::FORMAT_RGBF;
     else if(fmt == "rgb" || fmt == "rgb8")
       return godot::Image::FORMAT_RGB8;
     else
       return godot::Image::FORMAT_RGBA8;
   }
-  else if constexpr(std::is_enum_v<typename F::format>)
+  else if constexpr(requires { requires std::is_enum_v<typename F::format>; })
   {
     if constexpr(requires { F::RGBA; } || requires { F::RGBA8; })
       return godot::Image::FORMAT_RGBA8;
-    else if constexpr(requires { F::R8; } || requires { F::GRAYSCALE; })
+    else if constexpr(requires { F::R8; })
       return godot::Image::FORMAT_R8;
+    else if constexpr(requires { F::GRAYSCALE; } || requires { F::L8; })
+      return godot::Image::FORMAT_L8;
     else if constexpr(requires { F::RG8; })
       return godot::Image::FORMAT_RG8;
     else if constexpr(requires { F::RGBA16F; })
@@ -64,11 +79,88 @@ godot::Image::Format godot_image_format() noexcept
       return godot::Image::FORMAT_RGH;
     else if constexpr(requires { F::RG32F; })
       return godot::Image::FORMAT_RGF;
+    else if constexpr(requires { F::RGB32F; })
+      return godot::Image::FORMAT_RGBF;
     else if constexpr(requires { F::RGB; } || requires { F::RGB8; })
       return godot::Image::FORMAT_RGB8;
     else
       return godot::Image::FORMAT_RGBA8;
   }
+  else if constexpr(requires { std::size_t{F::bytes_per_pixel}; })
+  {
+    // No format information; guess from the static pixel stride.
+    if constexpr(F::bytes_per_pixel == 1)
+      return godot::Image::FORMAT_L8;
+    else if constexpr(F::bytes_per_pixel == 2)
+      return godot::Image::FORMAT_RG8;
+    else if constexpr(F::bytes_per_pixel == 3)
+      return godot::Image::FORMAT_RGB8;
+    else
+      return godot::Image::FORMAT_RGBA8;
+  }
+  else
+  {
+    return godot::Image::FORMAT_RGBA8;
+  }
+}
+
+/// Map a run-time texture format enum value (halp::custom_texture_base::texture_format
+/// style) to a Godot Image::Format. Unsupported formats fall back to RGBA8.
+template <typename E>
+godot::Image::Format godot_image_format_runtime(E fmt) noexcept
+{
+#define AVND_GODOT_MAP_FORMAT(av, gd)        \
+  if constexpr(requires { E::av; })          \
+    if(fmt == E::av)                         \
+      return godot::Image::gd;
+  AVND_GODOT_MAP_FORMAT(RGBA8, FORMAT_RGBA8)
+  // Godot has no BGRA8 CPU image format; same stride, swapped channels.
+  AVND_GODOT_MAP_FORMAT(BGRA8, FORMAT_RGBA8)
+  AVND_GODOT_MAP_FORMAT(R8, FORMAT_R8)
+  AVND_GODOT_MAP_FORMAT(RG8, FORMAT_RG8)
+  AVND_GODOT_MAP_FORMAT(RED_OR_ALPHA8, FORMAT_L8)
+  AVND_GODOT_MAP_FORMAT(RGBA16F, FORMAT_RGBAH)
+  AVND_GODOT_MAP_FORMAT(RGBA32F, FORMAT_RGBAF)
+  AVND_GODOT_MAP_FORMAT(R16F, FORMAT_RH)
+  AVND_GODOT_MAP_FORMAT(R32F, FORMAT_RF)
+  AVND_GODOT_MAP_FORMAT(RGB8, FORMAT_RGB8)
+#undef AVND_GODOT_MAP_FORMAT
+  return godot::Image::FORMAT_RGBA8;
+}
+
+/// Format of a concrete texture instance.
+/// Dispatches to the run-time mapping for dynamic-format textures
+/// (halp::custom_texture / halp::custom_variable_texture), and to the
+/// compile-time mapping for fixed-format ones.
+template <typename Tex>
+godot::Image::Format godot_image_format_of(const Tex& tex) noexcept
+{
+  if constexpr(requires {
+                 requires std::is_enum_v<
+                     std::remove_cvref_t<decltype(Tex::request_format)>>;
+               })
+    return godot_image_format_runtime(tex.request_format);
+  else if constexpr(requires {
+                      requires std::is_enum_v<
+                          std::remove_cvref_t<decltype(Tex::format)>>;
+                    })
+    return godot_image_format_runtime(tex.format);
+  else
+    return godot_image_format<Tex>();
+}
+
+/// Size in bytes of the pixel data of a texture instance.
+template <typename Tex>
+int godot_texture_bytesize(const Tex& tex) noexcept
+{
+  if constexpr(requires { int(tex.bytesize()); })
+    return tex.bytesize();
+  else if constexpr(requires { std::size_t{Tex::bytes_per_pixel}; })
+    return tex.width * tex.height * Tex::bytes_per_pixel;
+  else if constexpr(requires { int(tex.bytes_per_pixel()); })
+    return tex.width * tex.height * tex.bytes_per_pixel();
+  else
+    return tex.width * tex.height * 4;
 }
 
 /**
@@ -77,6 +169,17 @@ godot::Image::Format godot_image_format() noexcept
  * Each frame, runs the processor's operator() and uploads output textures
  * to Godot ImageTexture resources. The textures are exposed as properties
  * so they can be assigned to Sprite2D, TextureRect, etc.
+ *
+ * CPU texture inputs are exposed as settable Texture2D properties: when one
+ * is assigned, its image is read back, converted to the format expected by
+ * the port (halp::rgba_texture, rgb_texture, r8_texture, r32f_texture,
+ * rgba32f_texture, ...) and handed to the processor.
+ *
+ * Note: only 2D textures are supported. halp::texture_kind
+ * (texture_array / cubemap / texture_3d, declared through texture_target())
+ * only exists on GPU texture ports for now; CPU-side halp textures carry no
+ * layer/depth data, so there is nothing to feed Godot's Texture2DArray /
+ * Cubemap / ImageTexture3D with. See the report in the binding docs.
  */
 template <typename T>
 struct godot_texture_node : public godot::Node
@@ -85,10 +188,19 @@ struct godot_texture_node : public godot::Node
 
   static constexpr int tex_output_count
       = avnd::cpu_texture_output_introspection<T>::size;
+  static constexpr int tex_input_count
+      = avnd::cpu_texture_input_introspection<T>::size;
 
   godot::Ref<godot::ImageTexture> output_textures[tex_output_count > 0
                                                        ? tex_output_count
                                                        : 1];
+
+  // The Texture2D resources assigned by the user, and the CPU-side pixel
+  // storage (converted to the port's format) that the processor reads from.
+  godot::Ref<godot::Texture2D>
+      input_textures[tex_input_count > 0 ? tex_input_count : 1];
+  godot::PackedByteArray
+      input_buffers[tex_input_count > 0 ? tex_input_count : 1];
 
   godot_texture_node()
   {
@@ -104,6 +216,21 @@ struct godot_texture_node : public godot::Node
                 else if_possible(ctl.value = c.values[c.init])
                 else if_possible(ctl.value = c.init);
           }
+        });
+      }
+
+      // CPU texture input ports are plain views: make sure the processor
+      // sees an empty texture instead of indeterminate garbage until one
+      // is assigned.
+      if constexpr(tex_input_count > 0)
+      {
+        avnd::cpu_texture_input_introspection<T>::for_all(
+            [&]<auto Idx, typename C>(avnd::field_reflection<Idx, C>) {
+          auto& port = avnd::pfr::get<Idx>(effect.inputs());
+          port.texture.bytes = nullptr;
+          port.texture.width = 0;
+          port.texture.height = 0;
+          port.texture.changed = false;
         });
       }
     }
@@ -154,8 +281,21 @@ struct godot_texture_node : public godot::Node
     // Expose parameter properties
     godot_binding::get_property_list<T>(p_list);
 
+    // Expose input textures as assignable Texture2D properties
+    if constexpr(tex_input_count > 0)
+    {
+      avnd::cpu_texture_input_introspection<T>::for_all(
+          [&]<auto Idx, typename C>(avnd::field_reflection<Idx, C>) {
+        using inputs_t = typename avnd::inputs_type<T>::type;
+        auto tex_name
+            = godot::StringName(field_name<Idx, C, inputs_t>().data());
+        p_list->push_back(godot::PropertyInfo(
+            godot::Variant::OBJECT, tex_name,
+            godot::PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"));
+      });
+    }
+
     // Expose output textures as read-only properties
-    int tex_idx = 0;
     avnd::cpu_texture_output_introspection<T>::for_all(
         [&]<auto Idx, typename C>(avnd::field_reflection<Idx, C>) {
       using outputs_t = typename avnd::outputs_type<T>::type;
@@ -164,18 +304,63 @@ struct godot_texture_node : public godot::Node
       p_list->push_back(godot::PropertyInfo(
           godot::Variant::OBJECT, tex_name, godot::PROPERTY_HINT_RESOURCE_TYPE,
           "ImageTexture"));
-      ++tex_idx;
     });
   }
 
   bool do_set(const godot::StringName& p_name, const godot::Variant& p_value)
   {
+    // Check input textures first
+    if constexpr(tex_input_count > 0)
+    {
+      int tex_idx = 0;
+      bool found = false;
+      avnd::cpu_texture_input_introspection<T>::for_all(
+          [&]<auto Idx, typename C>(avnd::field_reflection<Idx, C>) {
+        if(found)
+          return;
+        using inputs_t = typename avnd::inputs_type<T>::type;
+        static const godot::StringName tex_name{
+            field_name<Idx, C, inputs_t>().data()};
+        if(tex_name == p_name)
+        {
+          set_input_texture<Idx>(tex_idx, p_value);
+          found = true;
+        }
+        ++tex_idx;
+      });
+      if(found)
+        return true;
+    }
+
     return godot_binding::set_property<T>(effect, p_name, p_value);
   }
 
   bool do_get(const godot::StringName& p_name, godot::Variant& r_ret) const
   {
-    // Check output textures first
+    // Check input textures first
+    if constexpr(tex_input_count > 0)
+    {
+      int tex_idx = 0;
+      bool found = false;
+      avnd::cpu_texture_input_introspection<T>::for_all(
+          [&]<auto Idx, typename C>(avnd::field_reflection<Idx, C>) {
+        if(found)
+          return;
+        using inputs_t = typename avnd::inputs_type<T>::type;
+        static const godot::StringName tex_name{
+            field_name<Idx, C, inputs_t>().data()};
+        if(tex_name == p_name)
+        {
+          r_ret = input_textures[tex_idx];
+          found = true;
+        }
+        ++tex_idx;
+      });
+      if(found)
+        return true;
+    }
+
+    // Then output textures
     int tex_idx = 0;
     bool found = false;
     avnd::cpu_texture_output_introspection<T>::for_all(
@@ -210,6 +395,55 @@ struct godot_texture_node : public godot::Node
   }
 
 private:
+  /// Assign a Godot Texture2D to the FieldIdx-th input port (which is the
+  /// tex_idx-th CPU texture input). The image is read back to the CPU,
+  /// converted to the format expected by the port, and kept alive in
+  /// input_buffers[tex_idx] until the next assignment.
+  template <auto FieldIdx>
+  void set_input_texture(int tex_idx, const godot::Variant& p_value)
+  {
+    auto& port = avnd::pfr::get<FieldIdx>(effect.inputs());
+
+    godot::Ref<godot::Texture2D> tex = p_value;
+    input_textures[tex_idx] = tex;
+
+    if(tex.is_null())
+    {
+      input_buffers[tex_idx] = godot::PackedByteArray{};
+      port.texture.bytes = nullptr;
+      port.texture.width = 0;
+      port.texture.height = 0;
+      port.texture.changed = true;
+      return;
+    }
+
+    godot::Ref<godot::Image> img = tex->get_image();
+    if(img.is_null() || img->is_empty())
+      return;
+
+    // get_image() returns a copy, so we can convert in-place.
+    if(img->is_compressed())
+    {
+      if(img->decompress() != godot::OK)
+        return;
+    }
+    if(img->has_mipmaps())
+      img->clear_mipmaps();
+
+    const auto fmt = godot_image_format_of(port.texture);
+    if(img->get_format() != fmt)
+      img->convert(fmt);
+
+    input_buffers[tex_idx] = img->get_data();
+
+    using bytes_ptr_t = decltype(port.texture.bytes);
+    port.texture.bytes
+        = reinterpret_cast<bytes_ptr_t>(input_buffers[tex_idx].ptrw());
+    port.texture.width = img->get_width();
+    port.texture.height = img->get_height();
+    port.texture.changed = true;
+  }
+
   void upload_textures()
   {
     int tex_idx = 0;
@@ -231,7 +465,8 @@ private:
   void upload_single_texture(
       Tex& tex, godot::Ref<godot::ImageTexture>& img_tex)
   {
-    const int byte_count = tex.width * tex.height * Tex::bytes_per_pixel;
+    const auto fmt = godot_image_format_of(tex);
+    const int byte_count = godot_texture_bytesize(tex);
 
     godot::PackedByteArray pba;
     pba.resize(byte_count);
@@ -239,10 +474,14 @@ private:
         byte_count);
 
     auto img = godot::Image::create_from_data(
-        tex.width, tex.height, false, godot_image_format<Tex>(), pba);
+        tex.width, tex.height, false, fmt, pba);
+    if(img.is_null())
+      return;
 
+    // ImageTexture::update requires identical size and format
     if(img_tex->get_width() != tex.width
-        || img_tex->get_height() != tex.height)
+        || img_tex->get_height() != tex.height
+        || img_tex->get_format() != fmt)
     {
       img_tex->set_image(img);
     }

--- a/include/avnd/binding/max/inputs.hpp
+++ b/include/avnd/binding/max/inputs.hpp
@@ -15,13 +15,15 @@
 namespace max
 {
 
-// GPU texture ports (halp::gpu_texture_input & co) have no CPU-side pixel data
-// that a jit matrix could be read into: they are ignored by the Max binding
-// for now instead of being treated as MOP matrix inputs.
+// GPU-side ports (halp::gpu_texture_input & co, samplers, images, render
+// pass attachments) have no CPU-side pixel data that a jit matrix could be
+// read into: they are ignored by the Max binding for now instead of being
+// treated as MOP matrix inputs.
 template <typename Field>
 concept max_jit_input
     = (avnd::matrix_port<Field> || avnd::tensor_port<Field>)
-      && !avnd::gpu_texture_port<Field>;
+      && !avnd::gpu_texture_port<Field> && !avnd::sampler_port<Field>
+      && !avnd::image_port<Field> && !avnd::attachment_port<Field>;
 
 template <typename Field>
 using is_max_jit_input_t = boost::mp11::mp_bool<max_jit_input<Field>>;

--- a/include/avnd/binding/max/jitter_texture_format.hpp
+++ b/include/avnd/binding/max/jitter_texture_format.hpp
@@ -5,6 +5,8 @@
 #include <boost/container/vector.hpp>
 
 #include <algorithm>
+#include <cstdint>
+#include <cstring>
 #include <type_traits>
 #include <string_view>
 
@@ -309,6 +311,15 @@ const max_texture_spec::Format& texture_spec(const Tex& t) noexcept
 }
 
 
+// Converts an incoming jit matrix (in_planes x in_type cells) into the packed
+// texel layout expected by the avendish input port (out_type).
+// Supported matrix inputs: 1 plane (gray), 2 planes (RG), 3 planes (RGB),
+// 4 planes (ARGB), each as char / long / float32 / float64 cells.
+// Supported conversion targets: R8, RG8, RG16, RGB8, RGBA8, RGBA32F.
+// Long cells are read with the same unsigned-full-range convention as the
+// pre-existing branches (jit long is signed int32, so this is lossy :( ).
+// Anything else (e.g. R16, float16 or 32-bit integer targets) returns nullptr
+// and the input port is left untouched.
 inline
     unsigned char* convert_input_texture(
         void* in_bytes, int in_width, int in_height, int in_planes, t_symbol* in_type,
@@ -329,6 +340,32 @@ inline
         switch(out_type) {
           case max_texture_spec::FormatEnum::R8:
             return (unsigned char*)in_bytes;
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              auto gray = src[i];
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              uint16_t gray = src[i] * 257; // 0..255 -> 0..65535
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
+            }
+            return temp_storage.data();
+          }
 
           case max_texture_spec::FormatEnum::RGBA8:
           {
@@ -390,6 +427,32 @@ inline
             for(int i = 0; i < in_n_pixels; i++)
             {
               dst[i] = (uint64_t(src[i]) * 255) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              uint8_t gray = (uint64_t(src[i]) * 255) / 4294967295UL;
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              uint16_t gray = (uint64_t(src[i]) * 65535) / 4294967295UL;
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
             }
             return temp_storage.data();
           }
@@ -458,6 +521,32 @@ inline
             return temp_storage.data();
           }
 
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              uint8_t gray = std::clamp(int(src[i] * 255.0f), 0, 255);
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              uint16_t gray = std::clamp(int(src[i] * 65535.0f), 0, 65535);
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
+            }
+            return temp_storage.data();
+          }
+
           case max_texture_spec::FormatEnum::RGBA8:
           {
             temp_storage.resize(in_n_pixels * 4);
@@ -522,6 +611,32 @@ inline
             return temp_storage.data();
           }
 
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              uint8_t gray = std::clamp(int(src[i] * 255.0), 0, 255);
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              uint16_t gray = std::clamp(int(src[i] * 65535.0), 0, 65535);
+              dst[i * 2 + 0] = gray;
+              dst[i * 2 + 1] = gray;
+            }
+            return temp_storage.data();
+          }
+
           case max_texture_spec::FormatEnum::RGBA8:
           {
             temp_storage.resize(in_n_pixels * 4);
@@ -572,6 +687,344 @@ inline
       }
       break;
 
+    case 2:
+      if(in_type == _jit_sym_char)
+      {
+        // RG8 to max_texture_spec::FormatEnum
+        auto src = (uint8_t*)in_bytes;
+        switch(out_type) {
+          case max_texture_spec::FormatEnum::R8:
+          {
+            // RG -> R: keep the red plane
+            temp_storage.resize(in_n_pixels);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i] = src[i * 2 + 0];
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+            return (unsigned char*)in_bytes;
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = src[i * 2 + 0] * 257; // 0..255 -> 0..65535
+              dst[i * 2 + 1] = src[i * 2 + 1] * 257;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGB8:
+          {
+            temp_storage.resize(in_n_pixels * 3);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 3 + 0] = src[i * 2 + 0];
+              dst[i * 3 + 1] = src[i * 2 + 1];
+              dst[i * 3 + 2] = 0;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA8:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = src[i * 2 + 0];
+              dst[i * 4 + 1] = src[i * 2 + 1];
+              dst[i * 4 + 2] = 0;
+              dst[i * 4 + 3] = 255;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA32F:
+          {
+            temp_storage.resize(in_n_pixels * 16);
+            auto dst = (float*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = src[i * 2 + 0] / 255.0f;
+              dst[i * 4 + 1] = src[i * 2 + 1] / 255.0f;
+              dst[i * 4 + 2] = 0.0f;
+              dst[i * 4 + 3] = 1.0f;
+            }
+            return temp_storage.data();
+          }
+
+          default:
+            break;
+        }
+      }
+      else if(in_type == _jit_sym_long)
+      {
+        // RG32UI to max_texture_spec::FormatEnum
+        auto src = (uint32_t*)in_bytes;
+        switch(out_type) {
+          case max_texture_spec::FormatEnum::R8:
+          {
+            // RG -> R: keep the red plane
+            temp_storage.resize(in_n_pixels);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i] = (uint64_t(src[i * 2 + 0]) * 255) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = (uint64_t(src[i * 2 + 0]) * 255) / 4294967295UL;
+              dst[i * 2 + 1] = (uint64_t(src[i * 2 + 1]) * 255) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = (uint64_t(src[i * 2 + 0]) * 65535) / 4294967295UL;
+              dst[i * 2 + 1] = (uint64_t(src[i * 2 + 1]) * 65535) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGB8:
+          {
+            temp_storage.resize(in_n_pixels * 3);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 3 + 0] = (uint64_t(src[i * 2 + 0]) * 255) / 4294967295UL;
+              dst[i * 3 + 1] = (uint64_t(src[i * 2 + 1]) * 255) / 4294967295UL;
+              dst[i * 3 + 2] = 0;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA8:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = (uint64_t(src[i * 2 + 0]) * 255) / 4294967295UL;
+              dst[i * 4 + 1] = (uint64_t(src[i * 2 + 1]) * 255) / 4294967295UL;
+              dst[i * 4 + 2] = 0;
+              dst[i * 4 + 3] = 255;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA32F:
+          {
+            temp_storage.resize(in_n_pixels * 16);
+            auto dst = (float*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = src[i * 2 + 0] / 4294967295.0f;
+              dst[i * 4 + 1] = src[i * 2 + 1] / 4294967295.0f;
+              dst[i * 4 + 2] = 0.0f;
+              dst[i * 4 + 3] = 1.0f;
+            }
+            return temp_storage.data();
+          }
+
+          default:
+            break;
+        }
+      }
+      else if(in_type == _jit_sym_float32)
+      {
+        // RG32F to max_texture_spec::FormatEnum
+        auto src = (float*)in_bytes;
+        switch(out_type) {
+          case max_texture_spec::FormatEnum::R8:
+          {
+            // RG -> R: keep the red plane
+            temp_storage.resize(in_n_pixels);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i] = std::clamp(int(src[i * 2 + 0] * 255.0f), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 2 + 0] * 255.0f), 0, 255);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 2 + 1] * 255.0f), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 2 + 0] * 65535.0f), 0, 65535);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 2 + 1] * 65535.0f), 0, 65535);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGB8:
+          {
+            temp_storage.resize(in_n_pixels * 3);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 3 + 0] = std::clamp(int(src[i * 2 + 0] * 255.0f), 0, 255);
+              dst[i * 3 + 1] = std::clamp(int(src[i * 2 + 1] * 255.0f), 0, 255);
+              dst[i * 3 + 2] = 0;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA8:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = std::clamp(int(src[i * 2 + 0] * 255.0f), 0, 255);
+              dst[i * 4 + 1] = std::clamp(int(src[i * 2 + 1] * 255.0f), 0, 255);
+              dst[i * 4 + 2] = 0;
+              dst[i * 4 + 3] = 255;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA32F:
+          {
+            temp_storage.resize(in_n_pixels * 16);
+            auto dst = (float*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = src[i * 2 + 0];
+              dst[i * 4 + 1] = src[i * 2 + 1];
+              dst[i * 4 + 2] = 0.0f;
+              dst[i * 4 + 3] = 1.0f;
+            }
+            return temp_storage.data();
+          }
+
+          default:
+            break;
+        }
+      }
+      else if(in_type == _jit_sym_float64)
+      {
+        // RG64F to max_texture_spec::FormatEnum
+        auto src = (double*)in_bytes;
+        switch(out_type) {
+          case max_texture_spec::FormatEnum::R8:
+          {
+            // RG -> R: keep the red plane
+            temp_storage.resize(in_n_pixels);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i] = std::clamp(int(src[i * 2 + 0] * 255.0), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 2 + 0] * 255.0), 0, 255);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 2 + 1] * 255.0), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 2 + 0] * 65535.0), 0, 65535);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 2 + 1] * 65535.0), 0, 65535);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGB8:
+          {
+            temp_storage.resize(in_n_pixels * 3);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 3 + 0] = std::clamp(int(src[i * 2 + 0] * 255.0), 0, 255);
+              dst[i * 3 + 1] = std::clamp(int(src[i * 2 + 1] * 255.0), 0, 255);
+              dst[i * 3 + 2] = 0;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA8:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = std::clamp(int(src[i * 2 + 0] * 255.0), 0, 255);
+              dst[i * 4 + 1] = std::clamp(int(src[i * 2 + 1] * 255.0), 0, 255);
+              dst[i * 4 + 2] = 0;
+              dst[i * 4 + 3] = 255;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RGBA32F:
+          {
+            temp_storage.resize(in_n_pixels * 16);
+            auto dst = (float*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 4 + 0] = (float)src[i * 2 + 0];
+              dst[i * 4 + 1] = (float)src[i * 2 + 1];
+              dst[i * 4 + 2] = 0.0f;
+              dst[i * 4 + 3] = 1.0f;
+            }
+            return temp_storage.data();
+          }
+
+          default:
+            break;
+        }
+      }
+      break;
+
     case 3:
       if(in_type == _jit_sym_char)
       {
@@ -585,6 +1038,30 @@ inline
             for(int i = 0; i < in_n_pixels; i++)
             {
               dst[i] = (src[i * 3 + 0] * 299 + src[i * 3 + 1] * 587 + src[i * 3 + 2] * 114) / 1000;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = src[i * 3 + 0];
+              dst[i * 2 + 1] = src[i * 3 + 1];
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = src[i * 3 + 0] * 257; // 0..255 -> 0..65535
+              dst[i * 2 + 1] = src[i * 3 + 1] * 257;
             }
             return temp_storage.data();
           }
@@ -637,6 +1114,30 @@ inline
             {
               uint64_t gray = (uint64_t(src[i * 3 + 0]) * 299 + uint64_t(src[i * 3 + 1]) * 587 + uint64_t(src[i * 3 + 2]) * 114) / 1000;
               dst[i] = (gray * 255) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = (uint64_t(src[i * 3 + 0]) * 255) / 4294967295UL;
+              dst[i * 2 + 1] = (uint64_t(src[i * 3 + 1]) * 255) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = (uint64_t(src[i * 3 + 0]) * 65535) / 4294967295UL;
+              dst[i * 2 + 1] = (uint64_t(src[i * 3 + 1]) * 65535) / 4294967295UL;
             }
             return temp_storage.data();
           }
@@ -703,6 +1204,30 @@ inline
             return temp_storage.data();
           }
 
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 3 + 0] * 255.0f), 0, 255);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 3 + 1] * 255.0f), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 3 + 0] * 65535.0f), 0, 65535);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 3 + 1] * 65535.0f), 0, 65535);
+            }
+            return temp_storage.data();
+          }
+
           case max_texture_spec::FormatEnum::RGB8:
           {
             temp_storage.resize(in_n_pixels * 3);
@@ -761,6 +1286,30 @@ inline
             {
               double gray = src[i * 3 + 0] * 0.299 + src[i * 3 + 1] * 0.587 + src[i * 3 + 2] * 0.114;
               dst[i] = std::clamp(int(gray * 255.0), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 3 + 0] * 255.0), 0, 255);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 3 + 1] * 255.0), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 3 + 0] * 65535.0), 0, 65535);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 3 + 1] * 65535.0), 0, 65535);
             }
             return temp_storage.data();
           }
@@ -830,6 +1379,32 @@ inline
             return temp_storage.data();
           }
 
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              // ARGB to RG
+              dst[i * 2 + 0] = src[i * 4 + 1]; // R
+              dst[i * 2 + 1] = src[i * 4 + 2]; // G
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              // ARGB to RG, 0..255 -> 0..65535
+              dst[i * 2 + 0] = src[i * 4 + 1] * 257; // R
+              dst[i * 2 + 1] = src[i * 4 + 2] * 257; // G
+            }
+            return temp_storage.data();
+          }
+
           case max_texture_spec::FormatEnum::RGB8:
           {
             temp_storage.resize(in_n_pixels * 3);
@@ -891,6 +1466,30 @@ inline
             {
               uint64_t gray = (uint64_t(src[i * 4 + 1]) * 299 + uint64_t(src[i * 4 + 2]) * 587 + uint64_t(src[i * 4 + 3]) * 114) / 1000;
               dst[i] = (gray * 255) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = (uint64_t(src[i * 4 + 1]) * 255) / 4294967295UL;
+              dst[i * 2 + 1] = (uint64_t(src[i * 4 + 2]) * 255) / 4294967295UL;
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = (uint64_t(src[i * 4 + 1]) * 65535) / 4294967295UL;
+              dst[i * 2 + 1] = (uint64_t(src[i * 4 + 2]) * 65535) / 4294967295UL;
             }
             return temp_storage.data();
           }
@@ -957,6 +1556,30 @@ inline
             return temp_storage.data();
           }
 
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 4 + 1] * 255.0f), 0, 255);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 4 + 2] * 255.0f), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 4 + 1] * 65535.0f), 0, 65535);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 4 + 2] * 65535.0f), 0, 65535);
+            }
+            return temp_storage.data();
+          }
+
           case max_texture_spec::FormatEnum::RGB8:
           {
             temp_storage.resize(in_n_pixels * 3);
@@ -1016,6 +1639,30 @@ inline
             {
               double gray = src[i * 4 + 1] * 0.299 + src[i * 4 + 2] * 0.587 + src[i * 4 + 3] * 0.114;
               dst[i] = std::clamp(int(gray * 255.0), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG8:
+          {
+            temp_storage.resize(in_n_pixels * 2);
+            auto dst = temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 4 + 1] * 255.0), 0, 255);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 4 + 2] * 255.0), 0, 255);
+            }
+            return temp_storage.data();
+          }
+
+          case max_texture_spec::FormatEnum::RG16:
+          {
+            temp_storage.resize(in_n_pixels * 4);
+            auto dst = (uint16_t*)temp_storage.data();
+            for(int i = 0; i < in_n_pixels; i++)
+            {
+              dst[i * 2 + 0] = std::clamp(int(src[i * 4 + 1] * 65535.0), 0, 65535);
+              dst[i * 2 + 1] = std::clamp(int(src[i * 4 + 2] * 65535.0), 0, 65535);
             }
             return temp_storage.data();
           }
@@ -1104,6 +1751,63 @@ inline void copy_texture_to_max(const max_texture_spec::Format& fmt, void* matri
       std::memcpy(dst, src, std::min(pixel_count * bytesize, tex_bytesize));
     }
   }
+  else if(fmt.type == _jit_sym_long)
+  {
+    // jit long cells are signed 32-bit.
+    int32_t* dst = static_cast<int32_t*>(matrix_data);
+
+    if(&fmt == &max_texture_spec::R16 || &fmt == &max_texture_spec::RG16
+       || &fmt == &max_texture_spec::D16)
+    {
+      // u16 -> i32 widening, lossless; single/dual-plane formats don't swizzle.
+      const uint16_t* src = static_cast<const uint16_t*>(tex_bytes);
+      const int N
+          = std::min(pixel_count * fmt.planes, int(tex_bytesize / sizeof(uint16_t)));
+      for(int i = 0; i < N; i++)
+        dst[i] = int32_t(src[i]);
+    }
+    else if(&fmt == &max_texture_spec::RGB10A2)
+    {
+      // Each texel is one packed 32-bit word: R in bits 0-9, G in bits 10-19,
+      // B in bits 20-29, A in bits 30-31. Unpack into the native ARGB plane
+      // order like the other 4-plane branches; values stay in 0-1023
+      // (0-3 for alpha), no rescaling is applied :(
+      const uint32_t* src = static_cast<const uint32_t*>(tex_bytes);
+      const int N = std::min(pixel_count, int(tex_bytesize / sizeof(uint32_t)));
+      for(int i = 0; i < N; i++)
+      {
+        const uint32_t p = src[i];
+        dst[i * 4 + 0] = int32_t((p >> 30) & 0x3);   // A
+        dst[i * 4 + 1] = int32_t((p >> 0) & 0x3FF);  // R
+        dst[i * 4 + 2] = int32_t((p >> 10) & 0x3FF); // G
+        dst[i * 4 + 3] = int32_t((p >> 20) & 0x3FF); // B
+      }
+    }
+    else if(&fmt == &max_texture_spec::RGBA32UI || &fmt == &max_texture_spec::RGBA32SI)
+    {
+      // Same RGBA -> ARGB swizzle as the char / float32 branches.
+      // The 32-bit pattern is copied as-is: RGBA32UI values > INT32_MAX
+      // come out negative since jit long is signed :(
+      const int32_t* src = static_cast<const int32_t*>(tex_bytes);
+      const int N
+          = std::min(pixel_count * 4, int(tex_bytesize / sizeof(int32_t))) & ~3;
+      for(int i = 0; i < N; i += 4)
+      {
+        dst[i + 0] = src[i + 3];
+        dst[i + 1] = src[i + 0];
+        dst[i + 2] = src[i + 1];
+        dst[i + 3] = src[i + 2];
+      }
+    }
+    else
+    {
+      // R32UI, RG32UI, R32SI, RG32SI (and D24 / D24S8, packed in 32-bit
+      // words): direct 32-bit copy per plane, no swizzle. Unsigned values
+      // > INT32_MAX come out negative since jit long is signed :(
+      const int bytesize = fmt.planes * sizeof(int32_t);
+      std::memcpy(dst, tex_bytes, std::min(pixel_count * bytesize, tex_bytesize));
+    }
+  }
   else if(fmt.type == _jit_sym_float32)
   {
     float* dst = static_cast<float*>(matrix_data);
@@ -1128,6 +1832,11 @@ inline void copy_texture_to_max(const max_texture_spec::Format& fmt, void* matri
       std::memcpy(dst, src, std::min(pixel_count * bytesize, tex_bytesize));
     }
   }
+  // Note: no Format in the max_texture_spec table maps to _jit_sym_float64:
+  // every texture format above fits in char / long / float32 planes, so there
+  // is intentionally no float64 branch here. R8UI / R8SI map to char planes
+  // and are handled by the char memcpy above (R8SI is a bit-pattern copy
+  // since jit char is unsigned :( ).
 }
 
 

--- a/include/avnd/binding/max/outputs.hpp
+++ b/include/avnd/binding/max/outputs.hpp
@@ -17,13 +17,15 @@
 namespace max
 {
 
-// GPU texture ports and render-target outputs have no CPU-side pixel data
-// that could be written into a jit matrix: they are ignored by the Max
-// binding for now instead of being treated as MOP matrix outputs.
+// GPU-side ports (textures, samplers, images, render pass attachments) and
+// render-target outputs have no CPU-side pixel data that could be written
+// into a jit matrix: they are ignored by the Max binding for now instead of
+// being treated as MOP matrix outputs.
 template <typename Field>
 concept max_jit_output
     = (avnd::matrix_port<Field> || avnd::tensor_port<Field>)
-      && !avnd::gpu_texture_port<Field>
+      && !avnd::gpu_texture_port<Field> && !avnd::sampler_port<Field>
+      && !avnd::image_port<Field> && !avnd::attachment_port<Field>
       && !avnd::gpu_render_target_output_port<Field>;
 
 template <typename Field>

--- a/include/avnd/binding/ossia/geometry.hpp
+++ b/include/avnd/binding/ossia/geometry.hpp
@@ -158,6 +158,17 @@ constexpr ossia::attribute_semantic semantic_for_attribute(const Attr& attr)
     // UI
     (ossia::attribute_semantic::selection, selection, selected, soft_selection),
 
+    // Per-instance data
+    (ossia::attribute_semantic::instance_color0, instance_color, instance_color0),
+    (ossia::attribute_semantic::instance_color1, instance_color1),
+    (ossia::attribute_semantic::instance_color2, instance_color2),
+    (ossia::attribute_semantic::instance_color3, instance_color3),
+    (ossia::attribute_semantic::instance_custom0, instance_custom, instance_custom0),
+    (ossia::attribute_semantic::instance_custom1, instance_custom1),
+    (ossia::attribute_semantic::instance_custom2, instance_custom2),
+    (ossia::attribute_semantic::instance_custom3, instance_custom3),
+    (ossia::attribute_semantic::instance_draw_id, instance_draw_id, draw_id),
+
     // User / general purpose
     (ossia::attribute_semantic::fx0, fx0),
     (ossia::attribute_semantic::fx1, fx1),
@@ -191,6 +202,7 @@ constexpr auto get_topology(const T& t) -> decltype(ossia::geometry::topology)
       (ossia::geometry::triangle_strip, triangle_strip, triangles_strip),
       (ossia::geometry::triangle_fan, triangle_fan, triangles_fan),
       (ossia::geometry::lines, line, lines),
+      (ossia::geometry::line_strip, line_strip, lines_strip),
       (ossia::geometry::points, point, points));
   // clang-format on
   return m(t, ossia::geometry::triangles);
@@ -447,6 +459,21 @@ void load_geometry(T& ctrl, ossia::geometry& geom)
           .buffer = aux.buffer,
           .byte_offset = aux.byte_offset,
           .byte_size = aux.byte_size});
+    }
+  }
+
+  // Auxiliary textures (cubemaps, LUTs, etc.)
+  if constexpr(requires { ctrl.auxiliary_textures; })
+  {
+    geom.auxiliary_textures.clear();
+    for(const auto& aux : ctrl.auxiliary_textures)
+    {
+      ossia::geometry::auxiliary_texture tex;
+      tex.name = aux.name;
+      tex.native_handle = aux.handle;
+      if constexpr(requires { aux.sampler_handle; })
+        tex.sampler_handle = aux.sampler_handle;
+      geom.auxiliary_textures.push_back(std::move(tex));
     }
   }
 
@@ -790,7 +817,9 @@ constexpr auto to_topology(auto v)
       (ossia::geometry::triangles, triangle, triangles),
       (ossia::geometry::triangle_strip, triangle_strip, triangles_strip),
       (ossia::geometry::triangle_fan, triangle_fan, triangles_fan),
-      (ossia::geometry::lines, line, lines), (ossia::geometry::points, point, points));
+      (ossia::geometry::lines, line, lines),
+      (ossia::geometry::line_strip, line_strip, lines_strip),
+      (ossia::geometry::points, point, points));
   return m(v, decltype(T::topology){});
 }
 

--- a/include/avnd/common/enums.hpp
+++ b/include/avnd/common/enums.hpp
@@ -57,6 +57,8 @@
  */
 
 #define AVND_NUM_ARGS_(                                                                \
+    _120, _119, _118, _117, _116, _115, _114, _113, _112, _111, _110, _109, _108,       \
+    _107, _106, _105, _104, _103, _102, _101,                                           \
     _100, _99, _98, _97, _96, _95, _94, _93, _92, _91, _90, _89, _88, _87, _86, _85,   \
     _84, _83, _82, _81, _80, _79, _78, _77, _76, _75, _74, _73, _72, _71, _70, _69,    \
     _68, _67, _66, _65, _64, _63, _62, _61, _60, _59, _58, _57, _56, _55, _54, _53,    \
@@ -67,7 +69,8 @@
   N
 #define AVND_NUM_ARGS(...)                                                              \
   AVND_NUM_ARGS_(                                                                       \
-      __VA_ARGS__, 100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, \
+      __VA_ARGS__, 120, 119, 118, 117, 116, 115, 114, 113, 112, 111, 110, 109, 108,   \
+      107, 106, 105, 104, 103, 102, 101, 100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, \
       83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64,   \
       63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44,   \
       43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24,   \
@@ -177,6 +180,26 @@
 #define AVND_FOREACH_98(M, A, ...) M(A) AVND_FOREACH_97(M, __VA_ARGS__)
 #define AVND_FOREACH_99(M, A, ...) M(A) AVND_FOREACH_98(M, __VA_ARGS__)
 #define AVND_FOREACH_100(M, A, ...) M(A) AVND_FOREACH_99(M, __VA_ARGS__)
+#define AVND_FOREACH_101(M, A, ...) M(A) AVND_FOREACH_100(M, __VA_ARGS__)
+#define AVND_FOREACH_102(M, A, ...) M(A) AVND_FOREACH_101(M, __VA_ARGS__)
+#define AVND_FOREACH_103(M, A, ...) M(A) AVND_FOREACH_102(M, __VA_ARGS__)
+#define AVND_FOREACH_104(M, A, ...) M(A) AVND_FOREACH_103(M, __VA_ARGS__)
+#define AVND_FOREACH_105(M, A, ...) M(A) AVND_FOREACH_104(M, __VA_ARGS__)
+#define AVND_FOREACH_106(M, A, ...) M(A) AVND_FOREACH_105(M, __VA_ARGS__)
+#define AVND_FOREACH_107(M, A, ...) M(A) AVND_FOREACH_106(M, __VA_ARGS__)
+#define AVND_FOREACH_108(M, A, ...) M(A) AVND_FOREACH_107(M, __VA_ARGS__)
+#define AVND_FOREACH_109(M, A, ...) M(A) AVND_FOREACH_108(M, __VA_ARGS__)
+#define AVND_FOREACH_110(M, A, ...) M(A) AVND_FOREACH_109(M, __VA_ARGS__)
+#define AVND_FOREACH_111(M, A, ...) M(A) AVND_FOREACH_110(M, __VA_ARGS__)
+#define AVND_FOREACH_112(M, A, ...) M(A) AVND_FOREACH_111(M, __VA_ARGS__)
+#define AVND_FOREACH_113(M, A, ...) M(A) AVND_FOREACH_112(M, __VA_ARGS__)
+#define AVND_FOREACH_114(M, A, ...) M(A) AVND_FOREACH_113(M, __VA_ARGS__)
+#define AVND_FOREACH_115(M, A, ...) M(A) AVND_FOREACH_114(M, __VA_ARGS__)
+#define AVND_FOREACH_116(M, A, ...) M(A) AVND_FOREACH_115(M, __VA_ARGS__)
+#define AVND_FOREACH_117(M, A, ...) M(A) AVND_FOREACH_116(M, __VA_ARGS__)
+#define AVND_FOREACH_118(M, A, ...) M(A) AVND_FOREACH_117(M, __VA_ARGS__)
+#define AVND_FOREACH_119(M, A, ...) M(A) AVND_FOREACH_118(M, __VA_ARGS__)
+#define AVND_FOREACH_120(M, A, ...) M(A) AVND_FOREACH_119(M, __VA_ARGS__)
 
 #define AVND_FOREACHSUB1(MACRO, ...) \
   AVND_FOREACHSUB1_(AVND_NUM_ARGS(__VA_ARGS__), MACRO, __VA_ARGS__)
@@ -282,6 +305,26 @@
 #define AVND_FOREACHSUB1_98(M, A, ...) M(A) AVND_FOREACHSUB1_97(M, __VA_ARGS__)
 #define AVND_FOREACHSUB1_99(M, A, ...) M(A) AVND_FOREACHSUB1_98(M, __VA_ARGS__)
 #define AVND_FOREACHSUB1_100(M, A, ...) M(A) AVND_FOREACHSUB1_99(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_101(M, A, ...) M(A) AVND_FOREACHSUB1_100(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_102(M, A, ...) M(A) AVND_FOREACHSUB1_101(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_103(M, A, ...) M(A) AVND_FOREACHSUB1_102(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_104(M, A, ...) M(A) AVND_FOREACHSUB1_103(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_105(M, A, ...) M(A) AVND_FOREACHSUB1_104(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_106(M, A, ...) M(A) AVND_FOREACHSUB1_105(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_107(M, A, ...) M(A) AVND_FOREACHSUB1_106(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_108(M, A, ...) M(A) AVND_FOREACHSUB1_107(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_109(M, A, ...) M(A) AVND_FOREACHSUB1_108(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_110(M, A, ...) M(A) AVND_FOREACHSUB1_109(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_111(M, A, ...) M(A) AVND_FOREACHSUB1_110(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_112(M, A, ...) M(A) AVND_FOREACHSUB1_111(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_113(M, A, ...) M(A) AVND_FOREACHSUB1_112(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_114(M, A, ...) M(A) AVND_FOREACHSUB1_113(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_115(M, A, ...) M(A) AVND_FOREACHSUB1_114(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_116(M, A, ...) M(A) AVND_FOREACHSUB1_115(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_117(M, A, ...) M(A) AVND_FOREACHSUB1_116(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_118(M, A, ...) M(A) AVND_FOREACHSUB1_117(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_119(M, A, ...) M(A) AVND_FOREACHSUB1_118(M, __VA_ARGS__)
+#define AVND_FOREACHSUB1_120(M, A, ...) M(A) AVND_FOREACHSUB1_119(M, __VA_ARGS__)
 
 #define AVND_ENUM_MATCHER_IMPL_IMPL(N)           \
   if constexpr(requires { decltype(value)::N; }) \

--- a/include/halp/geometry.hpp
+++ b/include/halp/geometry.hpp
@@ -13,7 +13,7 @@ enum class binding_classification : uint8_t
   per_vertex,
   per_instance
 };
-enum class attribute_semantic : uint32_t
+enum class attribute_semantic : uint16_t
 {
   // Core geometry
   position = 0,  // vec3.  Object-space position.
@@ -134,6 +134,17 @@ enum class attribute_semantic : uint32_t
 
   // UI
   selection = 1700, // float. Soft selection weight [0-1].
+
+  // Per-instance data
+  instance_color0 = 1800,                    // vec4. Per-instance color.
+  instance_color1 = instance_color0 + 1,     // vec4.
+  instance_color2 = instance_color0 + 2,     // vec4.
+  instance_color3 = instance_color0 + 3,     // vec4.
+  instance_custom0 = instance_color0 + 4,    // vec4. Per-instance custom data.
+  instance_custom1 = instance_color0 + 5,    // vec4.
+  instance_custom2 = instance_color0 + 6,    // vec4.
+  instance_custom3 = instance_color0 + 7,    // vec4.
+  instance_draw_id = instance_color0 + 8,    // int.  gl_DrawID-style index.
 
   // User / general purpose
   fx0 = 2000,    // float. General-purpose effect control.


### PR DESCRIPTION
Follow-ups to the semantic-tagging work (#98), addressing the gaps catalogued during the per-backend verification. Now rebased onto main after #98 and #99 merged.

### Contents

- **geometry: per-instance semantics, line_strip topology, aux texture output**
  - `halp::attribute_semantic` gains `instance_color0-3`, `instance_custom0-3`, `instance_draw_id` (1800–1808) matching `ossia::attribute_semantic`, and now shares its `uint16_t` underlying type. `AVND_FOREACH`/`AVND_FOREACHSUB1` extended to 120 entries (the matcher table crossed 100).
  - ossia binding: matcher entries for the per-instance semantics; `line_strip` in both topology conversions (previously degraded silently to the default); auxiliary textures bridged in the avnd → ossia direction too.
- **examples: port FilterGeometry to halp::dynamic_geometry** — the example carried a pre-semantic location-enum type that no longer compiled through the ossia bridge.
- **max: keep sampler, image and attachment ports out of the jit matrix sets** — same compile trap as the gpu texture ports.
- **max: complete the long-cell and RG texture conversion paths** — `copy_texture_to_max` gains the missing `_jit_sym_long` branch (R16/RG16/D16 widening, RGB10A2 unpack in ARGB plane order, 32-bit integer bit-pattern copies with documented signed-int32 lossiness); `convert_input_texture` accepts 2-plane (RG) matrices and RG8/RG16 ports accept 1/3/4-plane matrices. Verified with a standalone runtime test against a fake jit matrix.
- **godot: texture inputs, complete format mapping, xyzw properties** — CPU texture *inputs* were never exposed nor initialized (indeterminate memory reads); format mapping covers L8/RGB32F/custom_texture runtime formats (custom textures previously didn't compile through the node); xyzw parameters map to Vector4 in all godot wrappers instead of silently dropping `w`. Verified with two headless functional tests (texture filter input → output pixels, format/Vector4 round-trips) plus the 83-test smoke suite.

All halp/ossia changes are compile-verified against libossia master with gcc and clang (CI does not build the ossia binding), including enum value/size agreement asserts for every semantic.

https://claude.ai/code/session_014nNNDTMSawHutgQUigL6ei