### PR TITLE
touchdesigner: POP binding: gate buffer submission on `changed`, fix input buffer use-after-free

### DIFF
--- a/include/avnd/binding/touchdesigner/pop/particle_processor.hpp
+++ b/include/avnd/binding/touchdesigner/pop/particle_processor.hpp
@@ -21,6 +21,7 @@
 #include <POP_CPlusPlusBase.h>
 
 #include <string>
+#include <vector>
 
 namespace touchdesigner::POP
 {
@@ -52,6 +53,7 @@ struct particle_processor : public TD::POP_CPlusPlusBase
   avnd::effect_container<T> implementation;
   parameter_setup<T> param_setup;
   TD::POP_Context* context{};
+  std::vector<TD::OP_SmartRef<TD::POP_Buffer>> m_input_buffers;
 
   explicit particle_processor(const TD::OP_NodeInfo* info, TD::POP_Context* ctx)
       : context{ctx}
@@ -788,6 +790,10 @@ private:
     if(!buf.raw_data || buf.byte_size <= 0)
       return 0;
 
+    // Unchanged since last cook: keep the node's current output as-is.
+    if(!buf.changed)
+      return 0;
+
     // Interpret raw buffer as tightly packed float3 xyz positions
     constexpr uint32_t components = 3;
     uint32_t num_particles = buf.byte_size / (components * sizeof(float));
@@ -799,6 +805,7 @@ private:
         reinterpret_cast<const char*>(buf.raw_data),
         num_particles, components, components * sizeof(float));
 
+    buf.changed = false;
     return num_particles;
   }
 
@@ -807,6 +814,9 @@ private:
   {
     auto& buf = field.buffer;
     if(!buf.elements || buf.element_count <= 0)
+      return 0;
+
+    if(!buf.changed)
       return 0;
 
     using elem_type = std::decay_t<decltype(buf.elements[0])>;
@@ -823,6 +833,7 @@ private:
           reinterpret_cast<const char*>(buf.elements),
           num_particles, components, components * sizeof(float));
 
+      buf.changed = false;
       return num_particles;
     }
     else if constexpr(requires { elem_type{}.x; elem_type{}.y; elem_type{}.z; })
@@ -833,6 +844,7 @@ private:
           reinterpret_cast<const char*>(buf.elements),
           buf.element_count, components, sizeof(elem_type));
 
+      buf.changed = false;
       return buf.element_count;
     }
     else
@@ -852,6 +864,9 @@ private:
 
   void read_pop_inputs(const TD::OP_Inputs* inputs)
   {
+    // Release the buffers held for the previous cook.
+    m_input_buffers.clear();
+
     int input_index = 0;
     avnd::geometry_input_introspection<T>::for_all(
         avnd::get_inputs(implementation),
@@ -889,6 +904,10 @@ private:
     const float* pos_data = static_cast<const float*>(pos_buf->getData(nullptr));
     if(!pos_data)
       return;
+
+    // The geometry keeps pointing into this buffer for the rest of the cook:
+    // hold a ref until the next one.
+    m_input_buffers.push_back(std::move(pos_buf));
 
     // Get point count from the PointInfo
     TD::OP_SmartRef<TD::POP_Buffer> pt_info_buf = pop_input->getPointInfo(get_info, nullptr);


### PR DESCRIPTION
Two fixes in the TD POP particle processor binding:

**Only resubmit CPU buffer outputs that changed.** `write_single_buffer` ran unconditionally on every cook, so a node with `cookEveryFrameIfAsked` recreated and resubmitted the `P` attribute buffer plus the PointInfo/TopologyInfo buffers at cook rate even when the processor produced no new data — three fresh `POP_Buffer` allocations per cook handed to TD, each retiring the previous generation. With varying point counts this shows up as steadily growing (GPU) memory. The halp buffer protocol already tracks this (`create()` clears `changed`, `upload()` sets it); the binding now skips submission when `changed` is false and clears the flag after submitting. `changed` is part of the `cpu_raw_buffer`/`cpu_typed_buffer` concepts, so this is valid for any conforming port.

**Keep input attribute buffers alive for the duration of the cook.** `read_pop_to_geometry` stored `pos_buf->getData()` into the geometry's `raw_data` but let the `OP_SmartRef` release the buffer at end of scope — the processor then read freed memory during `invoke_effect`. The buffer ref is now held in a member vector and released at the start of the next cook's input read, per the documented pattern in `POP_Buffer::getData`.

https://claude.ai/code/session_01Uqi4nPayaz6WrZ7PwwoAiL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uqi4nPayaz6WrZ7PwwoAiL)_