### PR TITLE
td: link the object library so its deps reach the operator

### DIFF
--- a/cmake/avendish.touchdesigner.cmake
+++ b/cmake/avendish.touchdesigner.cmake
@@ -105,6 +105,12 @@ function(avnd_make_touchdesigner)
       Boost::boost
   )
 
+  # Link the object library (as the other back-ends do) so its usage requirements
+  # propagate to the GDExtension/operator.
+  if(TARGET ${AVND_TARGET})
+    target_link_libraries(${AVND_FX_TARGET} PUBLIC ${AVND_TARGET})
+  endif()
+
   if(AVND_LINK_LIBRARIES)
     target_link_libraries(${AVND_FX_TARGET} PRIVATE ${AVND_LINK_LIBRARIES})
   endif()


### PR DESCRIPTION
The TouchDesigner back-end was the only one not linking the per-object library, so usage requirements added via `avnd_addon_object(... DEPENDENCIES ...)` (e.g. onnxruntime in the ML template) never reached it. Link it like the other back-ends do.