### PR TITLE
config: bootstrap ScoreExternalAddon when building against a score source/SDK

### DIFF
--- a/AvendishConfig.cmake
+++ b/AvendishConfig.cmake
@@ -1,6 +1,16 @@
-# find_package(Avendish) entry point. Works both as a fresh dependency and when a host
-# (e.g. ossia score) already provides Avendish in its own tree: in the latter case the
-# avnd_* commands already exist, so we must not re-add the sources or re-find deps.
+# find_package(Avendish) entry point, in order:
+#  - a host already provides the avnd_* commands (e.g. score in-tree) -> use them.
+#  - SCORE_SOURCE_DIR / SCORE_SDK set -> route through ScoreExternalAddon (the normal
+#    external ossia score addon pathway: it sets up score and its SDK dependencies).
+#  - otherwise -> build Avendish from these sources.
+if(NOT COMMAND avnd_make_object AND NOT COMMAND avnd_score_plugin_add)
+  if(DEFINED SCORE_SOURCE_DIR AND EXISTS "${SCORE_SOURCE_DIR}/cmake/ScoreExternalAddon.cmake")
+    include("${SCORE_SOURCE_DIR}/cmake/ScoreExternalAddon.cmake")
+  elseif(DEFINED SCORE_SDK AND EXISTS "${SCORE_SDK}/lib/cmake/score/ScoreExternalAddon.cmake")
+    include("${SCORE_SDK}/lib/cmake/score/ScoreExternalAddon.cmake")
+  endif()
+endif()
+
 if(NOT COMMAND avnd_make_object AND NOT COMMAND avnd_score_plugin_add)
   include(CMakeFindDependencyMacro)
   find_dependency(Boost)


### PR DESCRIPTION
When an addon is built against an ossia score source tree or SDK (SCORE_SOURCE_DIR / SCORE_SDK set) but score isn't loaded yet, route find_package(Avendish) through ScoreExternalAddon — the canonical external-addon pathway — instead of fetching Boost/Threads standalone. This is what the addons' dev/SDK CI relies on; the migrated addons no longer include ScoreExternalAddon themselves, so AvendishConfig does it.