### PR TITLE
wasm: link embind via -lembind instead of deprecated --bind

### DIFF
--- a/cmake/avendish.wasm.cmake
+++ b/cmake/avendish.wasm.cmake
@@ -18,9 +18,6 @@ set(AVND_WASM_COMMON_LINK_FLAGS
   "-sALLOW_MEMORY_GROWTH=1"
   "-sEXPORTED_RUNTIME_METHODS=['HEAPF32','HEAPU8','HEAP32','HEAPU32','HEAPF64']"
   "-sEXPORTED_FUNCTIONS=['_malloc','_free']"
-  # embind: modern emscripten links it via -lembind; the old --bind alias no
-  # longer pulls in the library, causing undefined _embind_register_* symbols.
-  "-lembind"
 )
 
 set(AVND_WASM_COMMON_COMPILE_FLAGS
@@ -99,6 +96,11 @@ function(avnd_make_wasm)
     ${AVND_FX_TARGET}
     PUBLIC
       Avendish::Avendish_wasm
+      # embind must be linked AFTER the objects that reference it: modern
+      # emscripten links it via -lembind (the old --bind alias no longer pulls
+      # it in), and with --gc-sections it gets stripped unless it follows the
+      # objects in the link line — hence target_link_libraries, not link_options.
+      "-lembind"
   )
 
   # worklet + standalone page

--- a/cmake/avendish.wasm.cmake
+++ b/cmake/avendish.wasm.cmake
@@ -18,7 +18,9 @@ set(AVND_WASM_COMMON_LINK_FLAGS
   "-sALLOW_MEMORY_GROWTH=1"
   "-sEXPORTED_RUNTIME_METHODS=['HEAPF32','HEAPU8','HEAP32','HEAPU32','HEAPF64']"
   "-sEXPORTED_FUNCTIONS=['_malloc','_free']"
-  "--bind"
+  # embind: modern emscripten links it via -lembind; the old --bind alias no
+  # longer pulls in the library, causing undefined _embind_register_* symbols.
+  "-lembind"
 )
 
 set(AVND_WASM_COMMON_COMPILE_FLAGS


### PR DESCRIPTION
## Summary

Recent emscripten (emsdk `latest`) no longer links the embind library from the legacy `--bind` alias, so any wasm module using class bindings fails at link with:

```
wasm-ld: error: undefined symbol: _embind_register_class_function
```

Switches `AVND_WASM_COMMON_LINK_FLAGS` from `--bind` to `-lembind`, the supported way to link embind in current emscripten.

## Context

Surfaced while wiring the celtera avendish-*-processor-template repos to the new `ossia/actions/avnd-addon.yml` continuous-release workflow, which builds the wasm backend with `setup-emsdk@latest`. Every other backend (pd/max/clap/vst3/vintage/touchdesigner/python/godot/gstreamer) builds green; wasm was the lone holdout on this flag.

## Test plan

- [ ] avnd-addon.yml wasm lane goes green on the audio-processor-template once the template re-pins to this commit.
- [ ] Existing wasm examples still load (embind class registration works at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)