### PR TITLE
controls: fix enum control apply_control (T::enum_type doesn't exist)

### DIFF
--- a/include/avnd/wrappers/controls.hpp
+++ b/include/avnd/wrappers/controls.hpp
@@ -109,7 +109,10 @@ static void apply_control(T& ctl, avnd::string_ish auto&& v)
         }
         else if constexpr(avnd::enum_parameter<T>)
         {
-          using type = typename T::enum_type;
+          // The enum type is the type of the .value member, matching the
+          // enum_parameter concept (std::is_enum_v<decltype(T::value)>).
+          // T::enum_type does not exist on halp::enum_t.
+          using type = std::decay_t<decltype(ctl.value)>;
           ctl.value = static_cast<type>(k);
         }
         break;


### PR DESCRIPTION
## Summary

`apply_control`'s enum branch (`avnd/wrappers/controls.hpp`) referenced `typename T::enum_type`, which `halp::enum_t` doesn't provide — and neither does the `enum_parameter` concept, which is defined as `std::is_enum_v<std::decay_t<decltype(T::value)>>`. So any addon with an enum control failed to compile for the wasm backend:

```
controls.hpp:112: error: no type named 'enum_type' in 'halp::enum_t<...>'
```

Derives the enum type from the `.value` member instead, consistent with the concept.

## Context

Surfaced wiring the celtera avendish-*-processor-template repos to the new continuous-release CI. The data-processor template (which has an `Operation` enum control) hit it on the wasm lane; audio (no enum controls) didn't.

## Test plan

- [ ] data-processor-template wasm build goes green once it re-pins to this commit.
- [ ] Existing enum-control addons still behave (the cast is index→enumerator, unchanged semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)