### PR TITLE
cmake: give standalone addons a real base target

### DIFF
--- a/cmake/AvendishAddon.cmake
+++ b/cmake/AvendishAddon.cmake
@@ -12,10 +12,37 @@ else()
 endif()
 
 # avnd_addon_init(NAME <base_target>)
+#
+# Creates the addon "base target" -- the name addons attach shared sources / link
+# deps / include dirs to (target_sources(<base> PRIVATE shared.cpp),
+# target_link_libraries(<base> ...), etc.). In a score build that is the plugin
+# library. Standalone there is no single shipped artifact, but addons still write
+# the same calls, so we create a real compiled STATIC target that behaves the same
+# in both modes -- each object then links it (see avnd_addon_object) so the shared
+# code / usage requirements reach every object and, transitively, every back-end.
 macro(avnd_addon_init)
   cmake_parse_arguments(AA "" "NAME" "" ${ARGN})
   if(AVND_ADDON_SCORE)
     avnd_score_plugin_init(BASE_TARGET ${AA_NAME})
+  elseif(NOT TARGET ${AA_NAME})
+    # A generated empty TU guarantees a valid STATIC lib even when the addon never
+    # adds sources to it (CMake needs at least one source / a linker language).
+    set(_avnd_base_stub "${CMAKE_CURRENT_BINARY_DIR}/${AA_NAME}_avnd_base_stub.cpp")
+    if(NOT EXISTS "${_avnd_base_stub}")
+      file(WRITE "${_avnd_base_stub}"
+        "// Avendish standalone addon base target (intentionally empty).\n")
+    endif()
+    add_library(${AA_NAME} STATIC "${_avnd_base_stub}")
+    # Back-ends are typically shared objects (pd/max/... externals); the base's
+    # objects get linked into them, so they must be position-independent.
+    set_target_properties(${AA_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    # Carry the addon source root so the addon's own headers resolve by their
+    # in-repo angle path (<Addon/Foo.hpp>) -- in the base's shared sources, in
+    # every object that links it, and (transitively) in every back-end, including
+    # the generated prototype's #include <MAIN_FILE>. Subsumes the per-addon
+    # "deps INTERFACE lib + CMAKE_CURRENT_SOURCE_DIR" shim.
+    target_include_directories(${AA_NAME}
+      PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
   endif()
 endmacro()
 
@@ -61,6 +88,23 @@ macro(avnd_addon_object)
   else()
     if(NOT TARGET ${AA_C_NAME})
       add_library(${AA_C_NAME} STATIC ${AA_SOURCES})
+    endif()
+    # Link the addon base so its shared sources / deps / include dirs reach this
+    # object and, since each back-end links the object PUBLIC, every back-end too.
+    if(TARGET ${AA_BASE} AND NOT "${AA_BASE}" STREQUAL "${AA_C_NAME}")
+      target_link_libraries(${AA_C_NAME} PUBLIC ${AA_BASE})
+      # In a score build the objects are compiled *into* the base target, so the
+      # base's own (incl. PRIVATE) include dirs / definitions / options apply to
+      # them. Standalone each object is a separate target linking the base, so
+      # PRIVATE settings would not reach it -- replicate score's behaviour by
+      # inheriting the base's full build interface. PUBLIC so each back-end (which
+      # links the object) compiles its generated prototype + MAIN_FILE the same way.
+      target_include_directories(${AA_C_NAME} PUBLIC
+        $<TARGET_PROPERTY:${AA_BASE},INCLUDE_DIRECTORIES>)
+      target_compile_definitions(${AA_C_NAME} PUBLIC
+        $<TARGET_PROPERTY:${AA_BASE},COMPILE_DEFINITIONS>)
+      target_compile_options(${AA_C_NAME} PUBLIC
+        $<TARGET_PROPERTY:${AA_BASE},COMPILE_OPTIONS>)
     endif()
     if(AA_DEPENDENCIES)
       target_link_libraries(${AA_C_NAME} PUBLIC ${AA_DEPENDENCIES})


### PR DESCRIPTION
## Summary
- `avnd_addon_init`/`avnd_addon_finalize` were no-ops outside a score build, so the addon **base target** (the `NAME` passed to `init`) never existed standalone. Addons that attach shared sources / link deps / include dirs to it (`target_sources(<base> PRIVATE …)`, `target_link_libraries(<base> …)`, `target_include_directories(<base> …)`) failed to configure: *"Cannot specify sources for target … which is not built by this project."* This is the common shape for an addon with a vendored support library compiled once and shared across its objects (e.g. puara's puara-gestures + BioData).
- Standalone now creates the base as a real `STATIC` library (a generated empty TU keeps it valid when no sources are added) and links it `PUBLIC` into every object, so its shared code + usage requirements reach the object and, transitively, every back-end.
- The base also carries the addon source root on its include path — resolving intra-addon `<Addon/…>` angle includes and the generated prototype's `#include <MAIN_FILE>`, subsuming the per-addon "deps `INTERFACE` lib + `CMAKE_CURRENT_SOURCE_DIR`" shim several addons hand-roll today.
- Objects inherit the base's **full** build interface (incl. `PRIVATE` include dirs / definitions / options). In a score build the objects are compiled *into* the base so its PRIVATE settings apply to them; standalone they are separate targets, so this replicates that behaviour. Without it, an addon declaring its include dirs PRIVATE on the base fails to find its own headers when compiling the per-object back-ends.

Score-mode behaviour is unchanged — every addition is in the standalone (`NOT AVND_ADDON_SCORE`) branch.

## Test plan
- [x] Synthetic addon: base mutations both *after* `finalize` and *between* `init` and the objects → configures, builds, runs; base lib confirmed on the back-end link line.
- [x] Real **puara** (vendored puara-gestures + BioData on the base, include dirs declared PRIVATE): configures clean standalone; `puara_roll_dump` builds **and runs**; `puara_heart_dump` builds pulling BioData headers+lib through the base's PUBLIC link — **addon CMakeLists unchanged**.
- [ ] onnx standalone (blocked separately by an unguarded `score_common_setup()` + heavy onnxruntime build; not exercised here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)