### PR TITLE
dump: use the shared PCH only in avendish's own builds

### DIFF
--- a/cmake/avendish.dump.cmake
+++ b/cmake/avendish.dump.cmake
@@ -44,8 +44,8 @@ function(avnd_make_dump)
       Avendish::Avendish_dump yyjson
   )
 
-  # Reuse the shared PCH; skipped on MSVC (cf. pd/gstreamer).
-  if(NOT MSVC)
+  # Reuse the shared PCH when it exists (only in avendish's own builds).
+  if(NOT MSVC AND TARGET Avendish_dump_pch)
     target_precompile_headers(${AVND_FX_TARGET}
       REUSE_FROM
         Avendish_dump_pch
@@ -72,8 +72,10 @@ target_link_libraries(Avendish_dump INTERFACE Avendish yyjson)
 add_library(Avendish::Avendish_dump ALIAS Avendish_dump)
 
 # Shared PCH for all dump executables: the JSON writer, fmt, and the heavy
-# standard-library headers the generated TUs pull in.
-if(NOT MSVC)
+# standard-library headers the generated TUs pull in. Only when avendish is the
+# top-level build: addon/subproject builds compile few dump objects, and a
+# cross-directory REUSE_FROM is fragile across CMake versions.
+if(NOT MSVC AND CMAKE_SOURCE_DIR STREQUAL AVND_SOURCE_DIR)
   add_library(Avendish_dump_pch STATIC "${AVND_SOURCE_DIR}/src/dummy.cpp")
   target_link_libraries(Avendish_dump_pch
     PUBLIC


### PR DESCRIPTION
## Problem

The dump-binding shared PCH (`Avendish_dump_pch`) regressed the templates' **Portability** CI (clang-20, all backends off → only dump builds):

```
ninja: error: 'avnd_build/CMakeFiles/Avendish_dump_pch.dir/cmake_pch.hxx.pch',
  needed by 'CMakeFiles/my_processor_dump.dir/MyProcessor_dump.cpp.o',
  missing and no known rule to make it
```

When avendish is consumed as a **subproject** (an addon / template), the addon's dump target lives in a different directory scope than the PCH provider in avendish. `target_precompile_headers(REUSE_FROM)` across directories is fragile: it works on recent CMake (4.x) but the rule isn't emitted on the CI's older CMake, so the build breaks. Avendish's own example build is same-directory and unaffected — which is why only the addon/portability builds failed.

## Fix

Create and reuse the dump PCH **only when avendish is the top-level build** (`CMAKE_SOURCE_DIR STREQUAL AVND_SOURCE_DIR`), and guard the `REUSE_FROM` with `if(TARGET Avendish_dump_pch)`. Addon/subproject builds compile only a handful of dump objects, where the PCH barely helps anyway.

- avendish own build: PCH still created and used (compile-time win retained for the ~150 dump examples).
- addon/template build: no dump PCH referenced → no cross-directory `REUSE_FROM` → builds clean.

Validated locally with clang-20: avendish examples still use `-include-pch`; the template addon build (`my_processor_dump`) builds with zero PCH references.