### PR TITLE
max: cast jitter matrix data to unsigned char* for raw_data

### DIFF
--- a/include/avnd/binding/max/jitter_helpers.hpp
+++ b/include/avnd/binding/max/jitter_helpers.hpp
@@ -295,19 +295,19 @@ inline void matrix_to_buffer(void* matrix, Field& field)
   auto& tex = field.buffer;
   if(info.type == _jit_sym_char) {
     tex.byte_size = num_elements;
-    tex.raw_data = reinterpret_cast<const char*>(matrix_data);
+    tex.raw_data = reinterpret_cast<unsigned char*>(matrix_data);
   }
   else if(info.type == _jit_sym_long) {
     tex.byte_size = num_elements * sizeof(long);
-    tex.raw_data = reinterpret_cast<const char*>(matrix_data);
+    tex.raw_data = reinterpret_cast<unsigned char*>(matrix_data);
   }
   else if(info.type == _jit_sym_float32) {
     tex.byte_size = num_elements * sizeof(float);
-    tex.raw_data = reinterpret_cast<const char*>(matrix_data);
+    tex.raw_data = reinterpret_cast<unsigned char*>(matrix_data);
   }
   else if(info.type == _jit_sym_float64) {
     tex.byte_size = num_elements * sizeof(double);
-    tex.raw_data = reinterpret_cast<const char*>(matrix_data);
+    tex.raw_data = reinterpret_cast<unsigned char*>(matrix_data);
   }
   tex.changed = true;
 }


### PR DESCRIPTION
## Summary
The Max jitter readback helper `matrix_to_buffer` assigned matrix data to `halp::buffer::raw_data` via `reinterpret_cast<const char*>(matrix_data)`. But `raw_data` is `unsigned char*` (`halp/buffer.hpp:16`), so MSVC rejects all four assignments:

```
jitter_helpers.hpp(298,50): error C2440: '=': cannot convert from 'const char *' to 'unsigned char *'
```

`matrix_data` is a non-const `void*`, so the correct cast is straight to `unsigned char*` (no const involved).

## Impact
Unblocks the `standalone / max (windows/x86_64)` build of any avendish addon using the Max texture/jitter readback path (surfaced in score-addon-cv's readback objects: `cv_centroid_readback_max`, `cv_moments_readback_max`, `cv_pointlist_readback_max`).

## Test plan
- [ ] CI: Max Windows standalone build of an addon with jitter readback objects compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)