### PR TITLE
gstreamer: support xy/xyz/xyzw controls (GstValueArray)

### DIFF
--- a/include/avnd/binding/gstreamer/parameters.hpp
+++ b/include/avnd/binding/gstreamer/parameters.hpp
@@ -48,6 +48,32 @@ inline std::string canonical_name(const std::array<char, N>& symname)
   return canonical_name(std::string_view{symname.data(), symname.size()});
 }
 
+// halp xy / xyz / xyzw controls have no native GObject property type, so expose
+// them as a GstValueArray (GST_TYPE_ARRAY) whose element GParamSpec carries the
+// per-component scalar type + range.
+template <typename V>
+static GParamSpec* vec_array_param_spec(
+    const char* canonical, const char* name, const char* desc, double mn,
+    double mx, double init, int flags)
+{
+  using comp_t = std::remove_cvref_t<decltype(std::declval<V>().x)>;
+  GParamSpec* element{};
+  if constexpr(std::is_same_v<comp_t, float>)
+    element = g_param_spec_float(
+        "value", "value", "value", mn, mx, init, static_cast<GParamFlags>(flags));
+  else if constexpr(std::is_same_v<comp_t, double>)
+    element = g_param_spec_double(
+        "value", "value", "value", mn, mx, init, static_cast<GParamFlags>(flags));
+  else if constexpr(std::is_same_v<comp_t, unsigned int>)
+    element = g_param_spec_uint(
+        "value", "value", "value", mn, mx, init, static_cast<GParamFlags>(flags));
+  else
+    element = g_param_spec_int(
+        "value", "value", "value", mn, mx, init, static_cast<GParamFlags>(flags));
+  return gst_param_spec_array(
+      canonical, name, desc, element, static_cast<GParamFlags>(flags));
+}
+
 template <typename F>
   requires(avnd::has_range<F> && avnd::enum_ish_parameter<F>)
 static GParamSpec* param_spec()
@@ -88,6 +114,11 @@ static GParamSpec* param_spec()
     return g_param_spec_float(
         canonical.data(), name.data(), desc.data(), 0.f, 1.f, 0.f,
         static_cast<GParamFlags>(flags));
+  }
+  else if constexpr(avnd::xy_value<V>)
+  {
+    return vec_array_param_spec<V>(
+        canonical.data(), name.data(), desc.data(), -1e9, 1e9, 0., flags);
   }
   else
   {
@@ -161,6 +192,12 @@ static GParamSpec* param_spec()
     return g_param_spec_string(
         canonical.data(), name.data(), desc.data(), std::string_view(range.init).data(),
         static_cast<GParamFlags>(flags | G_PARAM_STATIC_STRINGS));
+  }
+  else if constexpr(avnd::xy_value<V>)
+  {
+    return vec_array_param_spec<V>(
+        canonical.data(), name.data(), desc.data(), range.min, range.max, range.init,
+        flags);
   }
   else
   {

--- a/include/avnd/binding/gstreamer/utils.hpp
+++ b/include/avnd/binding/gstreamer/utils.hpp
@@ -27,6 +27,52 @@ struct element
 template <typename T>
 struct metaclass;
 
+// Fixed-size numeric vector controls (halp xy / xyz / xyzw) have no native
+// GObject property type, so they are exposed as a GstValueArray (GST_TYPE_ARRAY)
+// holding their scalar components. These helpers translate one component at a
+// time, picking the GValue accessor that matches the component type.
+template <typename C>
+inline void append_vec_component(GValue* arr, C c)
+{
+  GValue tmp = G_VALUE_INIT;
+  if constexpr(std::is_same_v<C, float>)
+  {
+    g_value_init(&tmp, G_TYPE_FLOAT);
+    g_value_set_float(&tmp, c);
+  }
+  else if constexpr(std::is_same_v<C, double>)
+  {
+    g_value_init(&tmp, G_TYPE_DOUBLE);
+    g_value_set_double(&tmp, c);
+  }
+  else if constexpr(std::is_same_v<C, unsigned int>)
+  {
+    g_value_init(&tmp, G_TYPE_UINT);
+    g_value_set_uint(&tmp, c);
+  }
+  else
+  {
+    g_value_init(&tmp, G_TYPE_INT);
+    g_value_set_int(&tmp, static_cast<gint>(c));
+  }
+  gst_value_array_append_value(arr, &tmp);
+  g_value_unset(&tmp);
+}
+
+template <typename C>
+inline C read_vec_component(const GValue* arr, guint i)
+{
+  const GValue* e = gst_value_array_get_value(arr, i);
+  if constexpr(std::is_same_v<C, float>)
+    return g_value_get_float(e);
+  else if constexpr(std::is_same_v<C, double>)
+    return g_value_get_double(e);
+  else if constexpr(std::is_same_v<C, unsigned int>)
+    return g_value_get_uint(e);
+  else
+    return static_cast<C>(g_value_get_int(e));
+}
+
 struct get_property
 {
   GValue* value{};
@@ -47,9 +93,25 @@ struct get_property
   {
     // FIXME
   }
+  // A std::string satisfies both string_ish and iterable_ish; exclude strings
+  // here so they bind unambiguously to the string_ish overload above.
   void operator()(auto& param, const avnd::iterable_ish auto& v)
+    requires(!avnd::string_ish<std::remove_cvref_t<decltype(v)>>)
   {
     // FIXME
+  }
+  // halp xy / xyz / xyzw -> GstValueArray of 2..4 scalar components.
+  // One overload, constrained on xy_value (the common x,y); z and w are appended
+  // only when present, so xy / xyz / xyzw never form an ambiguous overload set.
+  void operator()(auto& param, const avnd::xy_value auto& v)
+  {
+    using comp_t = std::remove_cvref_t<decltype(v.x)>;
+    append_vec_component<comp_t>(value, v.x);
+    append_vec_component<comp_t>(value, v.y);
+    if constexpr(requires { v.z; })
+      append_vec_component<comp_t>(value, v.z);
+    if constexpr(requires { v.w; })
+      append_vec_component<comp_t>(value, v.w);
   }
   void operator()(auto& param, const int& v) { g_value_set_int(value, v); }
   void operator()(auto& param, const unsigned int& v) { g_value_set_uint(value, v); }
@@ -83,9 +145,28 @@ struct set_property
   {
     // FIXME
   }
+  // A std::string satisfies both string_ish and iterable_ish; exclude strings
+  // here so they bind unambiguously to the string_ish overload above.
   void operator()(auto& param, avnd::iterable_ish auto& v)
+    requires(!avnd::string_ish<std::remove_cvref_t<decltype(v)>>)
   {
     // FIXME
+  }
+  // halp xy / xyz / xyzw <- GstValueArray of 2..4 scalar components.
+  void operator()(auto& param, avnd::xy_value auto& v)
+  {
+    using comp_t = std::remove_cvref_t<decltype(v.x)>;
+    const guint n = gst_value_array_get_size(value);
+    if(n > 0)
+      v.x = read_vec_component<comp_t>(value, 0);
+    if(n > 1)
+      v.y = read_vec_component<comp_t>(value, 1);
+    if constexpr(requires { v.z; })
+      if(n > 2)
+        v.z = read_vec_component<comp_t>(value, 2);
+    if constexpr(requires { v.w; })
+      if(n > 3)
+        v.w = read_vec_component<comp_t>(value, 3);
   }
   void operator()(auto& param, int& v) { v = g_value_get_int(value); }
   void operator()(auto& param, unsigned int& v) { v = g_value_get_uint(value); }


### PR DESCRIPTION
## Problem
The gstreamer binding has no handling for halp's fixed-size numeric vector controls (`xy_type`/`xyz_type`/`xyzw_type`). An object with e.g. an `xy_spinboxes` control fails to build: no `get_property`/`set_property` overload matches the vector value, and the property installer silently falls back to a string `GParamSpec`. This blocks the gstreamer back-end of any texture object that uses an xy resolution control (surfaced by `score-addon-librediffusion`'s StreamDiffusion).

## Fix
Expose vector controls as a **`GstValueArray`** (`GST_TYPE_ARRAY`) of their scalar components — the idiomatic gstreamer representation for a fixed numeric tuple.

- **`parameters.hpp`** — `vec_array_param_spec<V>()` builds `gst_param_spec_array()` with an int/uint/float/double element spec carrying the per-component range. Wired into the ranged and range-less `param_spec()` overloads.
- **`utils.hpp`** — a single `get_property`/`set_property` overload constrained on `xy_value` (the common `x,y`), appending/reading `z`/`w` only when present via `if constexpr`, so xy/xyz/xyzw never form an ambiguous overload set. Handles int/float (and double/uint) components.

## Drive-by
`std::string` satisfies both `string_ish` and `iterable_ish`, so string controls became ambiguous once a non-scalar control forced the full overload set to be considered. Constrained the (empty `// FIXME`) `iterable_ish` overloads with `!string_ish`.

## Validation
Built `score-addon-librediffusion`'s gstreamer texture back-end locally (xy<int> "Resolution" + a string control) — the `streamdiffusion.so` plugin now compiles and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)