### PR TITLE
disableexceptions: add AVND_USES_EXCEPTIONS opt-out

### DIFF
--- a/cmake/avendish.cmake
+++ b/cmake/avendish.cmake
@@ -27,6 +27,12 @@ option(AVND_ENABLE_GSTREAMER     "Enable GStreamer backend"      ON)
 option(AVND_ENABLE_WASM          "Enable WebAssembly backend"    ON)
 option(AVND_ENABLE_FUZZ          "Enable libFuzzer harness (Clang only)" OFF)
 
+# Opt-in for add-ons that wrap a library whose API requires exceptions/RTTI (e.g.
+# onnxruntime). When ON, the DisableExceptions target becomes a no-op so the
+# back-ends that link it (pd / max / vst3 / example host / ...) build with
+# exceptions enabled. See cmake/avendish.disableexceptions.cmake.
+option(AVND_USES_EXCEPTIONS      "Add-on requires C++ exceptions/RTTI"   OFF)
+
 # Max/MSP externals link the static CRT (/MT) on Windows, as the official
 # max-sdk-base enforces globally. Set it here -- before the dependencies and the
 # addon's object library are created -- so everything linked into the external

--- a/cmake/avendish.disableexceptions.cmake
+++ b/cmake/avendish.disableexceptions.cmake
@@ -1,28 +1,40 @@
 add_library(DisableExceptions STATIC src/disable_exceptions.cpp)
 
-target_compile_definitions(DisableExceptions INTERFACE
-  BOOST_NO_RTTI=1
-  BOOST_NO_TYPEID=1
-  BOOST_NO_EXCEPTIONS=1
-)
-if(MSVC)
-  target_compile_options(DisableExceptions INTERFACE
-    /GR- # no rtti
-    /EHs- /EHc- # no exceptions
-  )
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  target_compile_options(DisableExceptions INTERFACE
-    -fno-exceptions
-    -fno-rtti
-  )
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
+# Most back-ends (pd, max, vst3, clap, vintage, gstreamer, the example host, ...)
+# link DisableExceptions to build the add-on glue without exceptions/RTTI. Some
+# add-ons cannot tolerate that: they wrap a library whose API throws -- e.g.
+# onnxruntime, whose C++ headers expand to `throw` -- so -fno-exceptions makes them
+# fail to even compile. Such an add-on sets AVND_USES_EXCEPTIONS before pulling in
+# Avendish. DisableExceptions then stays a valid link target (every back-end that
+# links it keeps working) but carries no exception/RTTI-stripping flags -- it becomes
+# a no-op -- and its boost::throw_exception stub is dropped so Boost's own (throwing)
+# implementation is used instead of one that abort()s.
+if(NOT AVND_USES_EXCEPTIONS)
+  target_compile_definitions(DisableExceptions PRIVATE AVND_DISABLE_EXCEPTIONS=1)
   target_compile_definitions(DisableExceptions INTERFACE
-    _LIBCPP_NO_EXCEPTIONS=1
+    BOOST_NO_RTTI=1
+    BOOST_NO_TYPEID=1
+    BOOST_NO_EXCEPTIONS=1
   )
-  target_compile_options(DisableExceptions INTERFACE
-    -fno-exceptions
-    -fno-rtti
-    -fno-unwind-tables
-    -fno-asynchronous-unwind-tables
-  )
+  if(MSVC)
+    target_compile_options(DisableExceptions INTERFACE
+      /GR- # no rtti
+      /EHs- /EHc- # no exceptions
+    )
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+    target_compile_options(DisableExceptions INTERFACE
+      -fno-exceptions
+      -fno-rtti
+    )
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
+    target_compile_definitions(DisableExceptions INTERFACE
+      _LIBCPP_NO_EXCEPTIONS=1
+    )
+    target_compile_options(DisableExceptions INTERFACE
+      -fno-exceptions
+      -fno-rtti
+      -fno-unwind-tables
+      -fno-asynchronous-unwind-tables
+    )
+  endif()
 endif()

--- a/src/disable_exceptions.cpp
+++ b/src/disable_exceptions.cpp
@@ -1,3 +1,10 @@
+// boost::throw_exception is only required when Boost is compiled with
+// BOOST_NO_EXCEPTIONS (the DisableExceptions interface). When an add-on opts into
+// exceptions via AVND_USES_EXCEPTIONS, DisableExceptions carries no such define, so
+// this stub must be dropped -- otherwise it would override Boost's real, throwing
+// implementation with one that abort()s. AVND_DISABLE_EXCEPTIONS is set (PRIVATE)
+// by avendish.disableexceptions.cmake only in the disabling case.
+#ifdef AVND_DISABLE_EXCEPTIONS
 #include <exception>
 #include <cstdlib>
 
@@ -9,3 +16,8 @@ void throw_exception(std::exception const& e, boost::source_location const&)
   std::abort();
 }
 } // namespace boost
+#else
+// Keep the translation unit non-empty so the static library always has a symbol
+// (avoids "archive has no index"/empty-object warnings on some toolchains).
+namespace avnd::detail { extern const int disable_exceptions_noop; const int disable_exceptions_noop = 0; }
+#endif


### PR DESCRIPTION
## Problem
The example host — and pd / max / vst3 / clap / vintage / gstreamer — link `DisableExceptions`, which forces `-fno-exceptions -fno-rtti`. That breaks any add-on wrapping a library whose API throws. Concretely, onnxruntime's C++ headers expand to `throw`, so an onnxruntime-based add-on fails to even compile its example host:

```
onnxruntime_cxx_api.h:219:5: error: exception handling disabled, use '-fexceptions' to enable
```

## Fix
Add an `AVND_USES_EXCEPTIONS` option (default `OFF`, so behaviour is unchanged). When an add-on sets it before pulling in Avendish:
- `DisableExceptions` stays a valid link target — every back-end that links it keeps working — but carries **no** exception/RTTI-stripping flags (a no-op);
- its `boost::throw_exception` stub (which `abort()`s) is dropped, so Boost's real, throwing implementation is used.

One switch covers every back-end instead of patching each `avendish.<backend>.cmake`. Verified locally: a heavyweight onnxruntime add-on's `*_example_host` and `*_python` targets compile + link with `-DAVND_USES_EXCEPTIONS=ON`, and the default-OFF path is byte-identical to before.