### PR TITLE
Fix MSVC build + Max/TouchDesigner texture I/O

### DIFF
--- a/cmake/avendish.max.cmake
+++ b/cmake/avendish.max.cmake
@@ -156,16 +156,7 @@ function(avnd_make_max)
       C74_USE_STRICT_TYPES=1
   )
 
-  # The Max SDK's variadic-call helpers (C74_VARFUN -> jit_object_method / object_method /
-  # jit_object_new ..., see c74support/.../ext_preprocessor.h) paste C74_VARFUN_<n> and
-  # rely on MSVC's *legacy* preprocessor rescan rules. Avendish (and halp's own
-  # HALP_FOREACH / halp_field_names) require the *conformant* preprocessor
-  # (-Zc:preprocessor, enabled PUBLIC on the Avendish core target), and the two collide in
-  # the same TU -- which is why these externals only build with clang-cl (clang handles
-  # both) and fail with cl.exe (C3861: 'C74_VARFUN_3' not found). We cannot drop to the
-  # legacy preprocessor here (it breaks halp_field_names: C4002), so instead force-include
-  # a tiny shim that redefines C74_VARFUN with a conformant-safe dispatch. The shim is a
-  # no-op on clang-cl and on the legacy preprocessor (it is guarded on _MSVC_TRADITIONAL==0).
+  # Make the Max SDK's C74_VARFUN work under MSVC's conformant preprocessor.
   if(MSVC AND NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
     target_compile_options(${AVND_FX_TARGET} PRIVATE
       "/FI${AVND_SOURCE_DIR}/include/avnd/binding/max/c74_varfun_conformant.hpp")

--- a/cmake/avendish.max.cmake
+++ b/cmake/avendish.max.cmake
@@ -156,6 +156,21 @@ function(avnd_make_max)
       C74_USE_STRICT_TYPES=1
   )
 
+  # The Max SDK's variadic-call helpers (C74_VARFUN -> jit_object_method / object_method /
+  # jit_object_new ..., see c74support/.../ext_preprocessor.h) paste C74_VARFUN_<n> and
+  # rely on MSVC's *legacy* preprocessor rescan rules. Avendish (and halp's own
+  # HALP_FOREACH / halp_field_names) require the *conformant* preprocessor
+  # (-Zc:preprocessor, enabled PUBLIC on the Avendish core target), and the two collide in
+  # the same TU -- which is why these externals only build with clang-cl (clang handles
+  # both) and fail with cl.exe (C3861: 'C74_VARFUN_3' not found). We cannot drop to the
+  # legacy preprocessor here (it breaks halp_field_names: C4002), so instead force-include
+  # a tiny shim that redefines C74_VARFUN with a conformant-safe dispatch. The shim is a
+  # no-op on clang-cl and on the legacy preprocessor (it is guarded on _MSVC_TRADITIONAL==0).
+  if(MSVC AND NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
+    target_compile_options(${AVND_FX_TARGET} PRIVATE
+      "/FI${AVND_SOURCE_DIR}/include/avnd/binding/max/c74_varfun_conformant.hpp")
+  endif()
+
   target_include_directories(${AVND_FX_TARGET} SYSTEM PRIVATE
       "${MAXSDK_MAX_INCLUDE_DIR}"
       "${MAXSDK_MSP_INCLUDE_DIR}"

--- a/cmake/avendish.sources.cmake
+++ b/cmake/avendish.sources.cmake
@@ -7,8 +7,8 @@ if(MSVC)
       PUBLIC
        -std:c++latest
        -Zi
-       "/FS" # serialize PDB writes: parallel cl.exe on one target share vcNNN.pdb (C1041) with -Zi
-       "/bigobj" # avendish's heavy template instantiation overruns the COFF section limit (C1128)
+       "/FS"
+       "/bigobj"
        "-permissive-"
        "-Zc:__cplusplus"
        "-Zc:enumTypes"
@@ -27,7 +27,7 @@ if(MSVC)
        "-permissive-"
        "-Zc:__cplusplus"
        "-Zc:inline"
-       "/bigobj" # heavy template instantiation can overrun the COFF section limit (C1128)
+       "/bigobj"
        -wd4244 # float -> int lossy conversion warning
        -wd4068 # disables warning C4068: unknown pragma 'GCC'
        -Werror=return-type

--- a/cmake/avendish.sources.cmake
+++ b/cmake/avendish.sources.cmake
@@ -7,6 +7,8 @@ if(MSVC)
       PUBLIC
        -std:c++latest
        -Zi
+       "/FS" # serialize PDB writes: parallel cl.exe on one target share vcNNN.pdb (C1041) with -Zi
+       "/bigobj" # avendish's heavy template instantiation overruns the COFF section limit (C1128)
        "-permissive-"
        "-Zc:__cplusplus"
        "-Zc:enumTypes"
@@ -25,6 +27,7 @@ if(MSVC)
        "-permissive-"
        "-Zc:__cplusplus"
        "-Zc:inline"
+       "/bigobj" # heavy template instantiation can overrun the COFF section limit (C1128)
        -wd4244 # float -> int lossy conversion warning
        -wd4068 # disables warning C4068: unknown pragma 'GCC'
        -Werror=return-type

--- a/include/avnd/binding/max/attributes_setup.hpp
+++ b/include/avnd/binding/max/attributes_setup.hpp
@@ -159,7 +159,7 @@ struct attribute_object_register<Processor, T>
     else if constexpr(std::is_enum_v<value_type>)
     {
       object_attr_setsym(
-          o, attr_name, gensym(avnd::enum_name(field.value).data()));
+          o, attr_name, enum_sym(field.value));
     }
     else if constexpr(avnd::iterable_ish<value_type>)
     {
@@ -197,7 +197,7 @@ struct attribute_object_register<Processor, T>
       {
         boost::container::small_vector<t_symbol*, 512> vec;
         for(auto& v : field.value)
-          vec.push_back(gensym(avnd::enum_name(v).data()));
+          vec.push_back(enum_sym(v));
         object_attr_setsym_array(o, attr_name, vec.size(), vec.data());
       }
       else

--- a/include/avnd/binding/max/c74_varfun_conformant.hpp
+++ b/include/avnd/binding/max/c74_varfun_conformant.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+// --- Max SDK C74_VARFUN compatibility shim for MSVC's conformant preprocessor ---
+//
+// The Max SDK implements its variadic-argument call helpers (jit_object_method,
+// object_method, jit_object_new, object_new, ... -- all defined as
+// `#define foo(...) C74_VARFUN(foo_imp, __VA_ARGS__)`) on top of C74_VARFUN in
+// c74support/max-includes/ext_preprocessor.h. There, C74_VARFUN pastes the
+// argument-count onto `C74_VARFUN_` and then appends the argument list through a
+// separate macro (C74_PASS_ARGS) that injects bare `(` / `)` tokens:
+//
+//   #define C74_VARFUN(IMPL, ...) \
+//       C74_JOIN_2(C74_VARFUN_, C74_NUM_ARGS(__VA_ARGS__)) C74_PASS_ARGS(IMPL, __VA_ARGS__)
+//
+// That pattern only re-triggers function-macro expansion under MSVC's *legacy*
+// preprocessor. Under the conformant preprocessor (/Zc:preprocessor, which
+// Avendish needs for halp's HALP_FOREACH / halp_field_names machinery), the
+// pasted `C74_VARFUN_3` is not recognised as a function-like macro when the `(`
+// arrives from a different expansion, so it is emitted verbatim and the compiler
+// fails with "C3861: 'C74_VARFUN_3': identifier not found". clang-cl's
+// preprocessor copes with both, which is why these externals build on CI (clang)
+// but not with cl.exe.
+//
+// We can't fall back to the legacy preprocessor for this TU (it breaks halp's
+// macros, e.g. C4002 on halp_field_names), so instead we redefine C74_VARFUN with
+// a dispatch whose argument-list parentheses live directly in the macro body --
+// the same shape halp itself uses (`HALP_FOREACH_##N(M, __VA_ARGS__)`), which the
+// conformant preprocessor expands correctly.
+//
+// This header is force-included (-FI) ahead of the SDK headers for max externals
+// built with cl.exe. It first pulls in ext_preprocessor.h to make sure the
+// original C74_VARFUN / C74_VARFUN_<n> / C74_NUM_ARGS / C74_JOIN_2 macros exist,
+// then overrides only C74_VARFUN. The override is guarded on the conformant
+// preprocessor (_MSVC_TRADITIONAL == 0), so it is a complete no-op under the
+// legacy preprocessor and under clang-cl (which does not define _MSVC_TRADITIONAL).
+
+#if defined(_MSVC_TRADITIONAL) && (_MSVC_TRADITIONAL == 0)
+
+// Ensure the SDK's variadic-call machinery is defined before we patch it. This is
+// a no-op when ext.h / jit.common.h already pulled it in (header guarded); it only
+// defines macros, so it is safe to include before the rest of the SDK (the
+// C74_VARFUN_<n> bodies cast to t_ptr_int, but that is only evaluated at the call
+// site, by which point ext.h has defined the type).
+#include <ext_preprocessor.h>
+
+#ifdef C74_VARFUN
+#undef C74_VARFUN
+#endif
+
+// One level of indirection so C74_NUM_ARGS(__VA_ARGS__) is fully expanded to a
+// digit before it is pasted onto `C74_VARFUN_`. The argument list `(__VA_ARGS__)`
+// is a literal token sequence in the macro body, so the conformant preprocessor
+// recognises `C74_VARFUN_<n>( ... )` as a function-macro invocation on rescan.
+#define C74_VARFUN_CONFORMANT_INVOKE_(N, ...) C74_JOIN_2(C74_VARFUN_, N)(__VA_ARGS__)
+#define C74_VARFUN(VARFUN_IMPL, ...) \
+  C74_VARFUN_CONFORMANT_INVOKE_(C74_NUM_ARGS(__VA_ARGS__), VARFUN_IMPL, __VA_ARGS__)
+
+#endif // _MSVC_TRADITIONAL == 0

--- a/include/avnd/binding/max/c74_varfun_conformant.hpp
+++ b/include/avnd/binding/max/c74_varfun_conformant.hpp
@@ -2,59 +2,19 @@
 
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
-// --- Max SDK C74_VARFUN compatibility shim for MSVC's conformant preprocessor ---
-//
-// The Max SDK implements its variadic-argument call helpers (jit_object_method,
-// object_method, jit_object_new, object_new, ... -- all defined as
-// `#define foo(...) C74_VARFUN(foo_imp, __VA_ARGS__)`) on top of C74_VARFUN in
-// c74support/max-includes/ext_preprocessor.h. There, C74_VARFUN pastes the
-// argument-count onto `C74_VARFUN_` and then appends the argument list through a
-// separate macro (C74_PASS_ARGS) that injects bare `(` / `)` tokens:
-//
-//   #define C74_VARFUN(IMPL, ...) \
-//       C74_JOIN_2(C74_VARFUN_, C74_NUM_ARGS(__VA_ARGS__)) C74_PASS_ARGS(IMPL, __VA_ARGS__)
-//
-// That pattern only re-triggers function-macro expansion under MSVC's *legacy*
-// preprocessor. Under the conformant preprocessor (/Zc:preprocessor, which
-// Avendish needs for halp's HALP_FOREACH / halp_field_names machinery), the
-// pasted `C74_VARFUN_3` is not recognised as a function-like macro when the `(`
-// arrives from a different expansion, so it is emitted verbatim and the compiler
-// fails with "C3861: 'C74_VARFUN_3': identifier not found". clang-cl's
-// preprocessor copes with both, which is why these externals build on CI (clang)
-// but not with cl.exe.
-//
-// We can't fall back to the legacy preprocessor for this TU (it breaks halp's
-// macros, e.g. C4002 on halp_field_names), so instead we redefine C74_VARFUN with
-// a dispatch whose argument-list parentheses live directly in the macro body --
-// the same shape halp itself uses (`HALP_FOREACH_##N(M, __VA_ARGS__)`), which the
-// conformant preprocessor expands correctly.
-//
-// This header is force-included (-FI) ahead of the SDK headers for max externals
-// built with cl.exe. It first pulls in ext_preprocessor.h to make sure the
-// original C74_VARFUN / C74_VARFUN_<n> / C74_NUM_ARGS / C74_JOIN_2 macros exist,
-// then overrides only C74_VARFUN. The override is guarded on the conformant
-// preprocessor (_MSVC_TRADITIONAL == 0), so it is a complete no-op under the
-// legacy preprocessor and under clang-cl (which does not define _MSVC_TRADITIONAL).
+// Conformant-preprocessor-safe redefinition of the Max SDK's C74_VARFUN dispatch.
+// No-op outside MSVC's conformant preprocessor (and on clang-cl).
 
 #if defined(_MSVC_TRADITIONAL) && (_MSVC_TRADITIONAL == 0)
 
-// Ensure the SDK's variadic-call machinery is defined before we patch it. This is
-// a no-op when ext.h / jit.common.h already pulled it in (header guarded); it only
-// defines macros, so it is safe to include before the rest of the SDK (the
-// C74_VARFUN_<n> bodies cast to t_ptr_int, but that is only evaluated at the call
-// site, by which point ext.h has defined the type).
 #include <ext_preprocessor.h>
 
 #ifdef C74_VARFUN
 #undef C74_VARFUN
 #endif
 
-// One level of indirection so C74_NUM_ARGS(__VA_ARGS__) is fully expanded to a
-// digit before it is pasted onto `C74_VARFUN_`. The argument list `(__VA_ARGS__)`
-// is a literal token sequence in the macro body, so the conformant preprocessor
-// recognises `C74_VARFUN_<n>( ... )` as a function-macro invocation on rescan.
 #define C74_VARFUN_CONFORMANT_INVOKE_(N, ...) C74_JOIN_2(C74_VARFUN_, N)(__VA_ARGS__)
 #define C74_VARFUN(VARFUN_IMPL, ...) \
   C74_VARFUN_CONFORMANT_INVOKE_(C74_NUM_ARGS(__VA_ARGS__), VARFUN_IMPL, __VA_ARGS__)
 
-#endif // _MSVC_TRADITIONAL == 0
+#endif

--- a/include/avnd/binding/max/jitter_texture_format.hpp
+++ b/include/avnd/binding/max/jitter_texture_format.hpp
@@ -207,7 +207,7 @@ const max_texture_spec::Format& texture_spec() noexcept
       return max_texture_spec::ARGB32F;
     else if(fmt == "r16f")
       return max_texture_spec::R16F;
-    else if(fmt == "r32")
+    else if(fmt == "r32f" || fmt == "r32")
       return max_texture_spec::R32F;
     else if(fmt == "rgb10a2")
       return max_texture_spec::RGB10A2;

--- a/include/avnd/binding/max/outputs.hpp
+++ b/include/avnd/binding/max/outputs.hpp
@@ -70,7 +70,7 @@ template <typename T>
   requires std::is_enum_v<T>
 inline void value_to_max(t_atom& atom, T v) noexcept
 {
-  atom = {.a_type = A_SYM, .a_w = {.w_sym = gensym(avnd::enum_name(v).data())}};
+  atom = {.a_type = A_SYM, .a_w = {.w_sym = enum_sym(v)}};
 }
 
 struct do_value_to_max_rec
@@ -113,7 +113,7 @@ struct do_value_to_max_rec
   void operator()(T v) noexcept
   {
     atoms.push_back(
-        {.a_type = A_SYM, .a_w = {.w_sym = gensym(avnd::enum_name(v).data())}});
+        {.a_type = A_SYM, .a_w = {.w_sym = enum_sym(v)}});
   }
 
   void operator()(const avnd::iterable_ish auto& v) noexcept

--- a/include/avnd/binding/max/processor_common.hpp
+++ b/include/avnd/binding/max/processor_common.hpp
@@ -22,9 +22,7 @@ struct processor_common
 
   }
 
-  // Max gives us a fixed ASSIST_MAX_STRING_LEN (500) buffer. Bound the copy and use
-  // the view's size rather than strcpy: get_description() may return a string_view
-  // that is not null-terminated, and a long description would overflow dst.
+  // Bounded copy into Max's fixed-size assist buffer.
   static void copy_assist(char* dst, std::string_view str)
   {
     snprintf(dst, ASSIST_MAX_STRING_LEN, "%.*s", (int)str.size(), str.data());

--- a/include/avnd/binding/max/processor_common.hpp
+++ b/include/avnd/binding/max/processor_common.hpp
@@ -9,6 +9,8 @@
 #include <avnd/binding/max/messages.hpp>
 #include <avnd/concepts/tensor.hpp>
 
+#include <cstdio>
+#include <string_view>
 
 namespace max
 {
@@ -20,12 +22,19 @@ struct processor_common
 
   }
 
+  // Max gives us a fixed ASSIST_MAX_STRING_LEN (500) buffer. Bound the copy and use
+  // the view's size rather than strcpy: get_description() may return a string_view
+  // that is not null-terminated, and a long description would overflow dst.
+  static void copy_assist(char* dst, std::string_view str)
+  {
+    snprintf(dst, ASSIST_MAX_STRING_LEN, "%.*s", (int)str.size(), str.data());
+  }
+
   static void get_inlet_description(long index, char *dst)
   {
     avnd::input_introspection<T>::for_nth(index, [dst] <typename Field> (const Field& port) {
       if constexpr(avnd::has_description<typename Field::type>) {
-        auto str = avnd::get_description<typename Field::type>();
-        strcpy(dst, str.data());
+        copy_assist(dst, avnd::get_description<typename Field::type>());
       }
     });
   }
@@ -34,8 +43,7 @@ struct processor_common
   {
     avnd::output_introspection<T>::for_nth(index, [dst] <typename Field> (const Field& port) {
       if constexpr(avnd::has_description<typename Field::type>) {
-        auto str = avnd::get_description<typename Field::type>();
-        strcpy(dst, str.data());
+        copy_assist(dst, avnd::get_description<typename Field::type>());
       }
     });
   }

--- a/include/avnd/binding/max/to_atoms.hpp
+++ b/include/avnd/binding/max/to_atoms.hpp
@@ -11,13 +11,7 @@
 
 namespace max
 {
-// magic_enum's enum_name() returns a std::string_view that is a substring of a
-// static signature buffer and is therefore NOT null-terminated. gensym() (and
-// the other Max C string APIs) read until a NUL, so handing them .data()
-// directly makes them run off the end and intern whatever trailing bytes follow
-// -- which is exactly the "weird unicode characters" seen in the Max window when
-// an object with an enum control is instantiated. Always copy the name into a
-// NUL-terminated buffer first.
+// gensym needs a NUL-terminated string; enum_name() returns a non-terminated view.
 template <typename E>
   requires std::is_enum_v<E>
 inline t_symbol* enum_sym(E v) noexcept

--- a/include/avnd/binding/max/to_atoms.hpp
+++ b/include/avnd/binding/max/to_atoms.hpp
@@ -7,8 +7,24 @@
 #include <boost/container/small_vector.hpp>
 #include <ext.h>
 
+#include <string>
+
 namespace max
 {
+// magic_enum's enum_name() returns a std::string_view that is a substring of a
+// static signature buffer and is therefore NOT null-terminated. gensym() (and
+// the other Max C string APIs) read until a NUL, so handing them .data()
+// directly makes them run off the end and intern whatever trailing bytes follow
+// -- which is exactly the "weird unicode characters" seen in the Max window when
+// an object with an enum control is instantiated. Always copy the name into a
+// NUL-terminated buffer first.
+template <typename E>
+  requires std::is_enum_v<E>
+inline t_symbol* enum_sym(E v) noexcept
+{
+  return gensym(std::string{avnd::enum_name(v)}.c_str());
+}
+
 struct to_list
 {
   boost::container::small_vector<t_atom, 256> atoms;
@@ -31,7 +47,7 @@ struct to_list
     requires std::is_enum_v<T>
   void operator()(T arg) noexcept
   {
-    atom_setsym(&atoms.emplace_back(), gensym(avnd::enum_name(arg).data()));
+    atom_setsym(&atoms.emplace_back(), enum_sym(arg));
   }
 
   void operator()(std::string_view v) noexcept
@@ -133,7 +149,7 @@ struct to_dict
     requires std::is_enum_v<T>
   void operator()(t_symbol* k, T&& arg) noexcept
   {
-    dictionary_appendstring(d, k, avnd::enum_name(arg).data());
+    dictionary_appendstring(d, k, std::string{avnd::enum_name(arg)}.c_str());
   }
 
   void operator()(t_symbol* k, const avnd::variant_ish auto& f) noexcept
@@ -245,7 +261,7 @@ struct set_atom
     requires std::is_enum_v<T>
   t_max_err operator()(t_atom* at, T arg) noexcept
   {
-    atom_setsym(at, gensym(avnd::enum_name(arg).data()));
+    atom_setsym(at, enum_sym(arg));
     return MAX_ERR_NONE;
   }
 };
@@ -310,7 +326,7 @@ struct to_atoms
   {
     if(auto atoms = allocate(1, ac, av); !atoms.empty())
     {
-      atom_setsym(&atoms[0], gensym(avnd::enum_name(arg).data()));
+      atom_setsym(&atoms[0], enum_sym(arg));
       return MAX_ERR_NONE;
     }
     return MAX_ERR_OUT_OF_MEM;
@@ -341,7 +357,7 @@ struct to_atoms
       else if constexpr(std::is_enum_v<span_val_type>)
       {
         for(auto& v : arg)
-          atom_setsym(&atoms[i], gensym(avnd::enum_name(v).data()));
+          atom_setsym(&atoms[i], enum_sym(v));
       }
       return MAX_ERR_NONE;
     }

--- a/include/avnd/binding/touchdesigner/CHOP_AUDIO.prototype.cpp.in
+++ b/include/avnd/binding/touchdesigner/CHOP_AUDIO.prototype.cpp.in
@@ -26,7 +26,7 @@ DLLEXPORT
 void FillCHOPPluginInfo(TD::CHOP_PluginInfo* info)
 {
   info->apiVersion = TD::CHOPCPlusPlusAPIVersion;
-  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_OPTYPE@");
+  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_PROCESSOR_TYPE@");
 }
 
 DLLEXPORT

--- a/include/avnd/binding/touchdesigner/CHOP_MESSAGE.prototype.cpp.in
+++ b/include/avnd/binding/touchdesigner/CHOP_MESSAGE.prototype.cpp.in
@@ -26,7 +26,7 @@ DLLEXPORT
 void FillCHOPPluginInfo(TD::CHOP_PluginInfo* info)
 {
   info->apiVersion = TD::CHOPCPlusPlusAPIVersion;
-  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_OPTYPE@");
+  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_PROCESSOR_TYPE@");
 }
 
 DLLEXPORT

--- a/include/avnd/binding/touchdesigner/DAT.prototype.cpp.in
+++ b/include/avnd/binding/touchdesigner/DAT.prototype.cpp.in
@@ -26,7 +26,7 @@ DLLEXPORT
 void FillDATPluginInfo(TD::DAT_PluginInfo* info)
 {
   info->apiVersion = TD::DATCPlusPlusAPIVersion;
-  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_OPTYPE@");
+  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_PROCESSOR_TYPE@");
 }
 
 DLLEXPORT

--- a/include/avnd/binding/touchdesigner/POP.prototype.cpp.in
+++ b/include/avnd/binding/touchdesigner/POP.prototype.cpp.in
@@ -26,7 +26,7 @@ DLLEXPORT
 void FillPOPPluginInfo(TD::POP_PluginInfo* info)
 {
   (void)info->setAPIVersion(TD::POPCPlusPlusAPIVersion);
-  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_OPTYPE@");
+  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_PROCESSOR_TYPE@");
 }
 
 DLLEXPORT

--- a/include/avnd/binding/touchdesigner/SOP.prototype.cpp.in
+++ b/include/avnd/binding/touchdesigner/SOP.prototype.cpp.in
@@ -26,7 +26,7 @@ DLLEXPORT
 void FillSOPPluginInfo(TD::SOP_PluginInfo* info)
 {
   info->apiVersion = TD::SOPCPlusPlusAPIVersion;
-  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_OPTYPE@");
+  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_PROCESSOR_TYPE@");
 }
 
 DLLEXPORT

--- a/include/avnd/binding/touchdesigner/TOP.prototype.cpp.in
+++ b/include/avnd/binding/touchdesigner/TOP.prototype.cpp.in
@@ -26,20 +26,10 @@ DLLEXPORT
 void FillTOPPluginInfo(TD::TOP_PluginInfo* info)
 {
   info->apiVersion = TD::TOPCPlusPlusAPIVersion;
-  // TD does not rely on the C++ default member initializer here: the struct it
-  // hands us is zero-filled, so executeMode would otherwise be 0
-  // (TOP_ExecuteMode::Unsupported), which makes TD reject/crash the operator on
-  // instantiation. The CPUMem path is exactly what texture_processor implements
-  // (createOutputBuffer / uploadBuffer). Mirrors the SDK BasicFilterTOP sample.
   info->executeMode = TD::TOP_ExecuteMode::CPUMem;
   touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_PROCESSOR_TYPE@");
 }
 
-// NB: TOP (and POP) Create/Destroy take a *_Context* second argument -- unlike
-// CHOP/DAT/SOP which take only OP_NodeInfo*. The SDK loader calls these through
-// CREATETOPINSTANCE = TOP_CPlusPlusBase*(*)(const OP_NodeInfo*, TOP_Context*) and
-// DESTROYTOPINSTANCE = void(*)(TOP_CPlusPlusBase*, TOP_Context*)
-// (CPlusPlus_Common.h). Declaring the 1-arg form is an ABI mismatch.
 DLLEXPORT
 TD::TOP_CPlusPlusBase* CreateTOPInstance(const TD::OP_NodeInfo* info, TD::TOP_Context* context)
 {

--- a/include/avnd/binding/touchdesigner/TOP.prototype.cpp.in
+++ b/include/avnd/binding/touchdesigner/TOP.prototype.cpp.in
@@ -26,17 +26,28 @@ DLLEXPORT
 void FillTOPPluginInfo(TD::TOP_PluginInfo* info)
 {
   info->apiVersion = TD::TOPCPlusPlusAPIVersion;
-  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_OPTYPE@");
+  // TD does not rely on the C++ default member initializer here: the struct it
+  // hands us is zero-filled, so executeMode would otherwise be 0
+  // (TOP_ExecuteMode::Unsupported), which makes TD reject/crash the operator on
+  // instantiation. The CPUMem path is exactly what texture_processor implements
+  // (createOutputBuffer / uploadBuffer). Mirrors the SDK BasicFilterTOP sample.
+  info->executeMode = TD::TOP_ExecuteMode::CPUMem;
+  touchdesigner::configure_opInfo<type>(info->customOPInfo, "@AVND_C_NAME@", "@AVND_PROCESSOR_TYPE@");
 }
 
+// NB: TOP (and POP) Create/Destroy take a *_Context* second argument -- unlike
+// CHOP/DAT/SOP which take only OP_NodeInfo*. The SDK loader calls these through
+// CREATETOPINSTANCE = TOP_CPlusPlusBase*(*)(const OP_NodeInfo*, TOP_Context*) and
+// DESTROYTOPINSTANCE = void(*)(TOP_CPlusPlusBase*, TOP_Context*)
+// (CPlusPlus_Common.h). Declaring the 1-arg form is an ABI mismatch.
 DLLEXPORT
-TD::TOP_CPlusPlusBase* CreateTOPInstance(const TD::OP_NodeInfo* info)
+TD::TOP_CPlusPlusBase* CreateTOPInstance(const TD::OP_NodeInfo* info, TD::TOP_Context* context)
 {
-  return new td::texture_processor<type>(info, static_cast<TD::TOP_Context*>(info->context));
+  return new td::texture_processor<type>(info, context);
 }
 
 DLLEXPORT
-void DestroyTOPInstance(TD::TOP_CPlusPlusBase* instance)
+void DestroyTOPInstance(TD::TOP_CPlusPlusBase* instance, TD::TOP_Context* context)
 {
   delete static_cast<td::texture_processor<type>*>(instance);
 }

--- a/include/avnd/binding/touchdesigner/configure.hpp
+++ b/include/avnd/binding/touchdesigner/configure.hpp
@@ -103,8 +103,7 @@ inline void configure_opInfo(TD::OP_CustomOPInfo& op, std::string_view nm, std::
   std::string nm2 = sanitize_td_name(nm);
   op.opType->setString(nm2.c_str());
   op.opLabel->setString(nm2.c_str());
-  // opIcon wants up to three letters/digits; guard against names shorter than
-  // three characters (nm2 is sanitized but can be as short as one char).
+  // opIcon: up to three letters/digits.
   char icon[4]{0, 0, 0, 0};
   for(std::size_t i = 0; i < 3 && i < nm2.size(); ++i)
     icon[i] = nm2[i];

--- a/include/avnd/binding/touchdesigner/configure.hpp
+++ b/include/avnd/binding/touchdesigner/configure.hpp
@@ -103,7 +103,11 @@ inline void configure_opInfo(TD::OP_CustomOPInfo& op, std::string_view nm, std::
   std::string nm2 = sanitize_td_name(nm);
   op.opType->setString(nm2.c_str());
   op.opLabel->setString(nm2.c_str());
-  char icon[4]{nm2[0],nm2[1],nm2[2],0};
+  // opIcon wants up to three letters/digits; guard against names shorter than
+  // three characters (nm2 is sanitized but can be as short as one char).
+  char icon[4]{0, 0, 0, 0};
+  for(std::size_t i = 0; i < 3 && i < nm2.size(); ++i)
+    icon[i] = nm2[i];
   op.opIcon->setString(icon);
 
   if constexpr (avnd::has_name<type>)

--- a/include/avnd/binding/touchdesigner/top/texture_processor.hpp
+++ b/include/avnd/binding/touchdesigner/top/texture_processor.hpp
@@ -35,13 +35,8 @@ struct texture_processor : public TD::TOP_CPlusPlusBase
   // Track if we need to process
   bool needs_cook{true};
 
-  // downloadTexture() returns the pixels in an OP_SmartRef that OWNS the data:
-  // when the last ref is released the result (and its buffer) is deleted. The
-  // avnd texture ports only store a *pointer* to that buffer, and the processor
-  // reads it later (in invoke_effect during execute()), so the refs must outlive
-  // that call. Hold them here for the duration of the cook; cleared at the start
-  // of each execute(). Without this the download result was a local that freed
-  // its buffer before the processor ran -> use-after-free.
+  // Hold the downloaded textures alive until after the processor has run: the
+  // OP_SmartRef owns the pixel buffer the avnd texture ports point into.
   std::vector<TD::OP_SmartRef<TD::OP_TOPDownloadResult>> download_results;
 
   explicit texture_processor(const TD::OP_NodeInfo* info, TD::TOP_Context* ctx)
@@ -73,8 +68,6 @@ struct texture_processor : public TD::TOP_CPlusPlusBase
     // Update parameter values from TouchDesigner
     update_controls(inputs);
 
-    // Release the previous cook's download results, then keep this cook's alive
-    // until after invoke_effect() has consumed the pixels (see member comment).
     download_results.clear();
 
     // Handle texture inputs - download from GPU to CPU
@@ -177,24 +170,17 @@ private:
   {
     auto& tex = field.texture;
 
-    // Set up download options
+    // Download to top-down CPU memory (avnd convention).
     TD::OP_TOPInputDownloadOptions opts;
     opts.pixelFormat = top_input->textureDesc.pixelFormat;
-    // GPU textures are bottom-up; avnd/halp CPU textures and the CV algorithms
-    // use the top-down image convention (row 0 = top). Flip on download so the
-    // processor sees a conventional image; the output upload flips back below.
     opts.verticalFlip = true;
 
-    // Download the texture from GPU
     TD::OP_SmartRef<TD::OP_TOPDownloadResult> download_result =
         top_input->downloadTexture(opts, nullptr);
 
     if(!download_result)
       return;
 
-    // Update Avendish texture structure. getData() returns a pointer OWNED by
-    // download_result, so we must keep the ref alive past invoke_effect() --
-    // done by moving it into download_results below.
     tex.width = download_result->textureDesc.width;
     tex.height = download_result->textureDesc.height;
     tex.bytes = static_cast<unsigned char*>(download_result->getData());
@@ -287,8 +273,6 @@ private:
     upload_info.textureDesc.pixelFormat = fmt.format;
     upload_info.textureDesc.aspectX = tex.width;
     upload_info.textureDesc.aspectY = tex.height;
-    // avnd textures are top-down (see download_matrix's verticalFlip note), so
-    // tell TD the first row is the top row -- keeps a passthrough identity.
     upload_info.firstPixel = TD::TOP_FirstPixel::TopLeft;
     upload_info.colorBufferIndex = 0;
 

--- a/include/avnd/binding/touchdesigner/top/texture_processor.hpp
+++ b/include/avnd/binding/touchdesigner/top/texture_processor.hpp
@@ -16,6 +16,8 @@
 
 #include <TOP_CPlusPlusBase.h>
 
+#include <vector>
+
 namespace touchdesigner::TOP
 {
 
@@ -32,6 +34,15 @@ struct texture_processor : public TD::TOP_CPlusPlusBase
 
   // Track if we need to process
   bool needs_cook{true};
+
+  // downloadTexture() returns the pixels in an OP_SmartRef that OWNS the data:
+  // when the last ref is released the result (and its buffer) is deleted. The
+  // avnd texture ports only store a *pointer* to that buffer, and the processor
+  // reads it later (in invoke_effect during execute()), so the refs must outlive
+  // that call. Hold them here for the duration of the cook; cleared at the start
+  // of each execute(). Without this the download result was a local that freed
+  // its buffer before the processor ran -> use-after-free.
+  std::vector<TD::OP_SmartRef<TD::OP_TOPDownloadResult>> download_results;
 
   explicit texture_processor(const TD::OP_NodeInfo* info, TD::TOP_Context* ctx)
       : context{ctx}
@@ -61,6 +72,10 @@ struct texture_processor : public TD::TOP_CPlusPlusBase
   {
     // Update parameter values from TouchDesigner
     update_controls(inputs);
+
+    // Release the previous cook's download results, then keep this cook's alive
+    // until after invoke_effect() has consumed the pixels (see member comment).
+    download_results.clear();
 
     // Handle texture inputs - download from GPU to CPU
     if constexpr(avnd::matrix_input_introspection<T>::size > 0)
@@ -165,6 +180,10 @@ private:
     // Set up download options
     TD::OP_TOPInputDownloadOptions opts;
     opts.pixelFormat = top_input->textureDesc.pixelFormat;
+    // GPU textures are bottom-up; avnd/halp CPU textures and the CV algorithms
+    // use the top-down image convention (row 0 = top). Flip on download so the
+    // processor sees a conventional image; the output upload flips back below.
+    opts.verticalFlip = true;
 
     // Download the texture from GPU
     TD::OP_SmartRef<TD::OP_TOPDownloadResult> download_result =
@@ -173,7 +192,9 @@ private:
     if(!download_result)
       return;
 
-    // Update Avendish texture structure
+    // Update Avendish texture structure. getData() returns a pointer OWNED by
+    // download_result, so we must keep the ref alive past invoke_effect() --
+    // done by moving it into download_results below.
     tex.width = download_result->textureDesc.width;
     tex.height = download_result->textureDesc.height;
     tex.bytes = static_cast<unsigned char*>(download_result->getData());
@@ -185,8 +206,7 @@ private:
       map_pixel_format(download_result->textureDesc.pixelFormat, tex);
     }
 
-    // Keep the download result alive (stored as member if needed)
-    // For now, we process immediately so the temp reference is fine
+    download_results.push_back(std::move(download_result));
   }
 
   // Upload texture from Avendish to TD
@@ -267,7 +287,9 @@ private:
     upload_info.textureDesc.pixelFormat = fmt.format;
     upload_info.textureDesc.aspectX = tex.width;
     upload_info.textureDesc.aspectY = tex.height;
-    upload_info.firstPixel = TD::TOP_FirstPixel::BottomLeft;
+    // avnd textures are top-down (see download_matrix's verticalFlip note), so
+    // tell TD the first row is the top row -- keeps a passthrough identity.
+    upload_info.firstPixel = TD::TOP_FirstPixel::TopLeft;
     upload_info.colorBufferIndex = 0;
 
     // Upload to TouchDesigner


### PR DESCRIPTION
These externals built on CI (clang-cl) but failed to build with MSVC `cl.exe`, the Max externals logged garbage to the Max window, and the TouchDesigner TOPs crashed on instantiation. This fixes all three, validated against the Max SDK and the TouchDesigner Custom OP SDK (APIVersion 11). Full Debug build of the `score-addon-cv` object set now produces all Max/TD/Godot/dump artifacts with 0 errors.

## Build (MSVC cl.exe)
- **`C74_VARFUN` C3861**: the Max SDK's variadic-call macros need MSVC's *legacy* preprocessor, but halp's `HALP_FOREACH`/`halp_field_names` need the *conformant* one (`-Zc:preprocessor`); they collide in one TU (clang-cl tolerates both). Added a force-included shim `max/c74_varfun_conformant.hpp` redefining `C74_VARFUN` conformant-safe, guarded `_MSVC_TRADITIONAL==0` (no-op on clang-cl / legacy). Dropping to the legacy preprocessor is *not* an option — it miscompiles `halp_field_names` (warning C4002).
- `/bigobj` (C1128) and `/FS` (C1041 PDB) added to the MSVC flag sets.

## Max / Jitter
- **Unicode garbage in the Max window**: `avnd::enum_name()` (magic_enum) returns a non-NUL-terminated `string_view`; `.data()` to `gensym`/`dictionary_appendstring` over-reads. New `max::enum_sym()` copies to a NUL-terminated buffer; applied at all enum sites.
- Runtime texture format `"r32f"` was only matched as `"r32"` → fixed.
- Assist: unbounded `strcpy` into Max's 500-byte buffer → bounded `snprintf`.

## TouchDesigner TOP
- **Crash on instantiation**: `executeMode` never set (zero-filled → `Unsupported`) and `Create/DestroyTOPInstance` declared the 1-arg form vs the SDK's 2-arg (`TOP_Context*`) ABI. Both fixed.
- `@AVND_OPTYPE@` was never defined → `minInputs/maxInputs` unset; prototypes now use `@AVND_PROCESSOR_TYPE@`.
- **Use-after-free**: the `downloadTexture()` `OP_SmartRef` (owns the pixels) was freed before the processor ran; now held alive through the cook.
- Consistent top-down orientation; `opIcon` hardened for short names.

> Note: a companion non-avendish fix was needed locally — the TouchDesigner `CustomOperatorSamples/include/*.h` are git symlinks that Windows checks out as broken stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBxEDLByHhZdcfMtLShyCg