### PR TITLE
wasm: cache AVND_WASM_JS_DIR so addon builds emit html/js companions

### DIFF
--- a/cmake/avendish.wasm.cmake
+++ b/cmake/avendish.wasm.cmake
@@ -7,7 +7,11 @@ if(NOT EMSCRIPTEN)
   return()
 endif()
 
-set(AVND_WASM_JS_DIR "${AVND_SOURCE_DIR}/include/avnd/binding/wasm/js")
+# Cached so avnd_make_wasm (and the packaging helpers) still see it when called
+# from another directory scope -- e.g. an addon's avnd_addon_object, where
+# avendish is add_subdirectory'd and this file-scope set() would otherwise be
+# invisible, silently skipping all the configure_file/copy steps.
+set(AVND_WASM_JS_DIR "${AVND_SOURCE_DIR}/include/avnd/binding/wasm/js" CACHE INTERNAL "")
 
 set(AVND_WASM_COMMON_LINK_FLAGS
   "-sWASM=1"


### PR DESCRIPTION
## Problem

The released wasm package for avendish-based score addons (e.g. [score-addon-puara `continuous`](https://github.com/ossia/score-addon-puara/releases/tag/continuous)) contains only the bare `<port>.mjs` + `<port>.wasm` per object — **no** `<port>.html` demo pages, no `-standalone.js` / `-worklet.js`, no shared `avnd-*.js` runtime, and the WAM2 subdirs hold only the copied module (no `index.js`/`node.js`/`processor.js`/`gui.js`/`descriptor.json`). The generated landing `index.html` therefore has an **empty link list** — there's nothing to link to.

## Root cause

`AVND_WASM_JS_DIR` is a file-scope variable set at the top of `cmake/avendish.wasm.cmake`. When avendish is consumed via `add_subdirectory` (the `find_package(Avendish)` → `avnd_addon_object` path used by the addon templates), `avnd_make_wasm` is invoked from the **addon's** directory scope, where that variable is not visible. Every `configure_file` / `copy_if_different` guarded by `EXISTS "${AVND_WASM_JS_DIR}/..."` then silently no-ops. The modules still build (they only need headers), so the failure is invisible until you open the packaged `index.html`.

## Fix

Mark `AVND_WASM_JS_DIR` `CACHE INTERNAL` so it survives across directory scopes, exactly like `AVND_SOURCE_DIR`. One line.

## Verification

Reproduced an addon build (`avendish-audio-processor-template`, `CATEGORY all`, `-DAVND_ENABLE_WASM=ON`) with avendish add_subdirectory'd:
- **Before:** `build/wasm/` empty of companions; `my_processor.html` generated nowhere.
- **After:** `build/wasm/` contains `my_processor.html`, `my_processor-standalone.js`, `my_processor-worklet.js`, the WAM2 templates under `wasm/wam/my_processor/` (`index.js`, `node.js`, `processor.js`, `gui.js`, `descriptor.json`, `package.json`, …), and the shared-runtime POST_BUILD copies are wired.

The `package-wasm-addon` action's `*.html` glob then finds the per-port pages and the landing `index.html` link list is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)