### PR TITLE
Help / example patch generation (phase 0: tool + plumbing)

### DIFF
--- a/HELP_PATCH_GENERATION_PLAN.md
+++ b/HELP_PATCH_GENERATION_PLAN.md
@@ -1,5 +1,14 @@
 # Automatic help / example patch generation — implementation plan
 
+> **Status (all phases implemented, PR #126):** generator tool + override/generation
+> plumbing (P0); full Pure Data `-help.pd` emitter (P1); Max `.maxhelp` + `help/`
+> packaging (P2); Godot `.tscn` and TouchDesigner Python builder + `examples/`
+> packaging (P3); Python example + Pd column pagination (P4). Per-control
+> descriptions already flow through the dump — authors just declare them. TD `.tox`
+> text-synthesis (§5.3) is validated but deferred to a future iteration in favour of
+> the builder script + `EXAMPLE_TD` override; in-GUI verification of Max/Godot/TD
+> outputs is the remaining manual follow-up.
+
 ## 1. Goal
 
 Every object that avendish builds should ship with a **help / example patch** in the

--- a/HELP_PATCH_GENERATION_PLAN.md
+++ b/HELP_PATCH_GENERATION_PLAN.md
@@ -1,0 +1,322 @@
+# Automatic help / example patch generation — implementation plan
+
+## 1. Goal
+
+Every object that avendish builds should ship with a **help / example patch** in the
+idiom of each backend, so users discover and learn an object the way they expect:
+
+- **Pure Data** → `<c_name>-help.pd`
+- **Max/MSP** → `<c_name>.maxhelp` (interactive) complementing the existing `<c_name>.maxref.xml` (reference)
+- **TouchDesigner** → an example component / builder
+- **Godot** → an example `.tscn` scene
+- **Others (best-effort)** → Python example script, ossia/score example, vst3/clap default preset
+
+Two sources, in priority order:
+
+1. **Per-object override** — when registering an object, the author may point to an
+   explicit, hand-authored help/example file *per backend*. It is copied verbatim to
+   the right place in that backend's package.
+2. **Automatically generated** — otherwise a generator produces a *rich* patch from the
+   object's introspection: a titled header, a description, a **live interactive demo**
+   (a sensible widget wired to each control inlet, an indicator on each outlet), and
+   labelled *inlets / outlets / arguments / messages* sections with explanation text.
+   When metadata is thin it falls back to a functional scaffold.
+
+## 2. What already exists (reuse, don't reinvent)
+
+| Piece | File | State |
+|---|---|---|
+| **Dump backend** → `dump/<c_name>.json` (complete introspection: metadata, ports, parameters, widgets, ranges, enum choices, messages, audio, tags) | `include/avnd/binding/dump/DumpCBOR.hpp`, `cmake/avendish.dump.cmake` (`AVND_DUMP_PATH`) | ✅ working — **this is our single source of truth** |
+| **maxref pipeline**: JSON + inja template → `.maxref.xml`, copied to `max/docs/refpages/` | `examples/Demos/JSONToMaxref.cpp`, `examples/Demos/maxref_template.xml`, `cmake/avendish.max.cmake:243-263` | ✅ working — **the architectural model to follow** |
+| **PD help seed** (the "started work"): templated C++ emitting `.pd` netlist; audio chain `osc~→object→clip~→dac~`, controls→`hsl`/`tgl`/`floatatom`→msg→inlet | `examples/Demos/GeneratePdHelp.cpp` | ⚠️ partial: enum/string stubbed, object hard-coded in `main()`, not in CMake |
+| **Multi-backend emitter** (JSON-driven): `.maxpat`, `.pd`, TD `.py`, Godot `.gd`, Python, wasm | `tooling/gen_tester_patches.py` | ✅ working but emits *test* patches — **reference for layout/wiring logic** |
+| **Packaging**: per-object registration → per-backend package assembly | `cmake/AvendishAddon.cmake` (`avnd_addon_object`), `cmake/avendish.packaging.cmake` (`avnd_addon_package`, `avnd_create_*_addon_package`) | ✅ working — **where overrides + doc copying hook in** |
+| **Introspection** | `include/avnd/wrappers/metadatas.hpp`, `include/avnd/wrappers/widgets.hpp`, `include/avnd/introspection/*` | ✅ complete |
+
+## 3. Architecture — a JSON-driven generator tool
+
+Mirror the maxref pipeline exactly. Add **one standalone C++ tool**, built once,
+invoked per object at build time, consuming `dump/<c_name>.json`:
+
+```
+examples/Demos/GeneratePatches.cpp   →  tool target `generate_patches`
+  (links inja + nlohmann_json, same deps as json_to_maxref; see cmake/avendish.tools.cmake)
+
+invocation (per object, per backend):
+  generate_patches --backend pd   dump/<c_name>.json  out/pd/<c_name>-help.pd
+  generate_patches --backend max  dump/<c_name>.json  out/max/help/<c_name>.maxhelp
+  generate_patches --backend godot dump/<c_name>.json out/godot/examples/<c_name>.tscn
+  ...
+```
+
+Why JSON-driven (not the compile-time templated approach of `GeneratePdHelp.cpp`):
+
+- The dump JSON already captures **100%** of introspection — nothing is lost.
+- **No per-object recompile** of a generator; the `*_dump` executable already exists.
+- One tool, uniform across backends, integrated like `json_to_maxref`.
+- Same build-dependency footprint as today (inja + nlohmann/yyjson already present).
+- `GeneratePdHelp.cpp`'s widget logic and `gen_tester_patches.py`'s per-backend wiring
+  port directly into the emitters.
+
+Internal structure of the tool:
+
+```
+GeneratePatches.cpp
+├── model:      parse JSON → a normalized in-memory description
+│               (object{name,c_name,category,description,author,...},
+│                ports[]{kind, name, widget, value_type, range{min,max,init},
+│                        enum_choices[], unit, description, is_attribute},
+│                messages[]{name, args[]}, audio{in_ch,out_ch,in_bus,out_bus})
+├── layout:     a shared layout engine (grid/columns, coordinate allocation,
+│               section dividers) — backend-agnostic geometry
+├── widgets:    backend-agnostic "what control for this port" decision
+│               (from widget_type + value_type + range), then per-backend realisation
+└── emitters/
+    ├── pd.hpp       → .pd netlist  (#N canvas / #X obj/msg/text/floatatom/connect)
+    ├── max.hpp      → .maxhelp     (JSON patcher: boxes[], lines[])
+    ├── td.hpp       → TD builder   (Python network-builder script + snippet)
+    ├── godot.hpp    → .tscn        (Godot text scene format)
+    ├── python.hpp   → example .py
+    └── score.hpp    → example score / preset
+```
+
+## 4. Normalized port → widget mapping
+
+The decision table the emitters share (driven by `widget` + `value_type` + `range` from
+the dump). Each backend realises the abstract widget with its native UI object.
+
+| Abstract control | Pd object | Max box | source signal |
+|---|---|---|---|
+| float slider (min/max/init) | `hsl <w> <h> <min> <max> ...` | `slider`/`live.dial` w/ range | `widget=slider/knob`, float |
+| int number | `floatatom` (or `nbx`) | `number` / `live.numbox` | int |
+| toggle / bool | `tgl 15 ...` | `toggle` | `widget=toggle`, bool |
+| enum / combobox | message-list (`hradio` + symbol msgs, or `else/pad`-style) | `umenu` with items | `widget=combobox`, `enum_choices[]` |
+| bang / impulse | `bng 15 ...` | `button` | `widget=bang` |
+| string / lineedit | `symbolatom` / `msg` | `textedit` / `message` | `widget=lineedit`, string |
+| color | swatch + `pack`/message triplet | `swatch` | `widget=color` |
+| xy / xyz / xyzw | `nbx`×N + `pack` | `nodes` / `number`×N | `widget=xy*` |
+| range slider | two `nbx` + `pack` | `rslider` | `widget=range_slider` |
+| audio inlet | `osc~ 220` (demo source) | `cycle~ 220` | audio bus/channel in |
+| audio outlet | `clip~ -0.95 0.95` → `dac~` / `snake~`+meter | `*~ 0.1`→`ezdac~` | audio bus/channel out |
+| value/number outlet | `floatatom` / `number` sink | `number` / `print` | control output |
+| message inlet (method) | `msg <name> <defaults>` → inlet | `message` → inlet | from `messages[]` |
+| callback / event outlet | `print <name>` | `print <name>` | callback output |
+
+`class_attribute`-tagged inputs (already distinguished in the dump and maxref template)
+become **attributes** (Max `@attr` examples / Pd creation args), not hot inlets.
+
+## 5. Backend-by-backend design
+
+### 5.1 Pure Data — `<c_name>-help.pd` (PRIMARY, finishes the started work)
+
+Format: the flat Pd netlist (`#N canvas …; #X obj …; #X msg …; #X text …; #X floatatom …;
+#X connect <src> <outlet> <dst> <inlet>;`). Connection indices are object creation order
+— the layout engine must track that, exactly as `GeneratePdHelp.cpp` does today.
+
+Port the existing seed (`GeneratePdHelp.cpp`) into the `pd` emitter and complete it:
+
+- **Header**: title bar (`cnv` with object name), an avendish/library badge (mirroring
+  ELSE's header — see `Documentation/9.else/*-help.pd` for the canonical layout).
+- **Description**: `#X text` block from `description` / `short_description`.
+- **Live demo**: instantiate `<c_name>` (with default creation args from attributes), wire
+  a widget per control inlet (table §4), `osc~` sources for audio in, `clip~`→`dac~` for
+  audio out, `floatatom`/`print` on outlets.
+- **Sections**: divider `cnv` bars labelled *inlets / outlets / arguments / messages*
+  with one `#X text` per item: `N) <type> – <name>: <description>`.
+- **Complete the stubs**: enum (emit the choice list as messages / `hradio`), string
+  (`symbolatom`/message), color/xy/range (table §4).
+- Optional **example subpatch** (`#N canvas … example`) for richer real-world usage when
+  the object carries an `example` annotation (see §7).
+
+Package destination: `pd/` next to the `.pd_*` external (Pd finds `<name>-help.pd` on the
+path). Wire into `avnd_make_pd` like maxref is wired into `avnd_make_max`.
+
+### 5.2 Max/MSP — `<c_name>.maxhelp`
+
+`.maxhelp` is a **JSON patcher** (same schema as `.maxpat`): a `patcher` with `boxes[]`
+(each `box` has `maxclass`, `text`, `patching_rect`, in/outlet counts) and `lines[]`
+(`patchline` with `source`/`destination` `[boxid, port]`). Emit with nlohmann::json.
+
+- Header via `comment`/`panel` boxes; description `comment`.
+- Live demo: instantiate the object box, wire native UI boxes (`slider`, `live.dial`,
+  `toggle`, `umenu`, `button`, `number`, `swatch`) per table §4; `cycle~`→object→`*~`→`ezdac~`
+  for audio; `number`/`print` sinks on outlets.
+- A `bpatcher`/tab layout section listing inlets/outlets/attributes with `comment` text.
+- This **complements** the existing `.maxref.xml` (reference doc) — keep both; the
+  `.maxref.xml` already ships to `max/docs/refpages/`.
+
+Package destination: `max/help/<c_name>.maxhelp` (Max searches `help/` in a package).
+Add a `help/` copy step to `avnd_create_max_addon_package` (alongside the `docs/refpages/`
+copy at `avendish.packaging.cmake:114-119`).
+
+### 5.3 TouchDesigner — example `.tox` component (RESOLVED: text-synthesis via toecollapse)
+
+`.toe`/`.tox` are binary, **but** TouchDesigner ships official converters —
+`toeexpand.exe` / `toecollapse.exe` (in `…/Derivative/TouchDesigner/bin`, present on this
+machine) — that expand a `.tox` into a **plain-text directory** and collapse it back. This
+was verified empirically: a `.tox` expands to `<name>.tox.dir/` + `<name>.tox.toc`, and
+`toecollapse` rebuilds a valid `.tox` from that directory (round-trip confirmed; the format
+is cross-platform and version-tolerant — a macOS-authored `.tox` collapsed fine on Windows).
+
+So the primary TD path is **text synthesis** (no GUI, scriptable, CI-friendly):
+
+1. Ship a tiny **template** expanded directory (a Base/Container COMP: `.n`, `.panel`,
+   `.build`, `.toc`).
+2. The `td` emitter writes, from the dump:
+   - `<name>.cparm` — custom-parameter **definitions** (one per control, on pages), using
+     the decoded TD param-type IDs:
+
+     | avendish control | TD param type ID | notes |
+     |---|---|---|
+     | float | `772804865` | min/max/default/clamp columns |
+     | int | `772804866` | |
+     | toggle/bool | (toggle ID) | on/off |
+     | string/lineedit | `772804868` | |
+     | enum/combobox | `772804879` | trailing `N name1 "Label 1" …` choice list |
+     | color (RGB/RGBA) | `772809473` | multi-component |
+     | xy | `772813313` | 2 components |
+     | xyz | `772813569` | 3 components |
+     | TOP reference (texture) | `772804874` | for TOP operators |
+
+   - `<name>.parm` — **init values** per control (`Name <flag> <value> [expression]`).
+   - `<name>.n` — optional demo operators (an `LFO CHOP`/`Noise TOP` driving a parameter
+     via an expression like `op('lfo1')['chan1']`, mirroring the sample we inspected) and a
+     `Text DAT` carrying the object description + per-parameter help.
+3. Run `toecollapse <name>.tox.dir` → real `<name>.tox`.
+
+Only the small bundled `toecollapse` binary is needed at generation time (discoverable via
+`TOUCHDESIGNER_SDK_PATH` / a `TOUCHDESIGNER_APP` cache var); no TD license/GUI. Guard the
+step so the build still succeeds where `toecollapse` is absent (emit the `.dir` text + a
+README and skip the collapse).
+
+- **Fallback / alternative**: a TD **Python builder** script (`<c_name>.example.py`,
+  extending `gen_tester_patches.py::gen_td()`) that builds the network and `comp.save()`s a
+  `.tox` when run inside TD — useful for authors, not required in CI.
+- **Override**: author ships a hand-built `.tox` via `EXAMPLE_TD` (§6).
+
+Package destination: TD packages currently ship only `Plugins/`. Add an `examples/` folder
+to `avnd_create_touchdesigner_package` and place the `.tox` (+ description) there.
+
+### 5.4 Godot — example `.tscn` scene
+
+`.tscn` **is a text format** → fully auto-generatable. Emit a scene that:
+
+- instantiates the generated node/class (`[node name="..." type="<ClassName>"]`),
+- sets a few representative exported properties from `range.init`,
+- adds a `Label`/comment with the description and a minimal driver (e.g. an
+  `AnimationPlayer` or script stub sweeping a parameter) where useful.
+
+Package destination: add `examples/` (or `addons/<name>/examples/`) to
+`avnd_create_godot_package`. The `.gd` logic in `gen_tester_patches.py::gen_godot()` is the
+starting point.
+
+### 5.5 Others (best-effort)
+
+- **Python**: an example `.py` (import the module, construct, set params, run) — extend
+  `gen_tester_patches.py::gen_python()`. Ship next to the `.pyd`/`.so`.
+- **ossia/score**: an example `.score`/`.js` snippet (score already consumes avendish).
+- **vst3 / clap**: no "patch" concept — emit a **default preset** (`.vstpreset` /
+  clap state) capturing init values, plus a generated `README`/parameter list. Lowest
+  priority.
+
+## 6. Per-object override mechanism (packaging)
+
+The natural hook is `avnd_addon_object()` (`cmake/AvendishAddon.cmake:51`) and the
+single-object `avnd_make_*`. Add optional per-backend file arguments:
+
+```cmake
+avnd_addon_object(
+  BASE myaddon C_NAME my_obj CLASS MyObj SOURCES MyObj.hpp
+  HELP_PD      examples/help/my_obj-help.pd      # explicit Pd help
+  HELP_MAX     examples/help/my_obj.maxhelp      # explicit Max help
+  EXAMPLE_TD   examples/help/my_obj.tox          # explicit TD component
+  EXAMPLE_GODOT examples/help/my_obj.tscn        # explicit Godot scene
+)
+```
+
+Implementation:
+
+1. Each `avnd_make_<backend>` stores the override (if given) in a target property
+   (`AVND_HELP_PD`, `AVND_HELP_MAX`, `AVND_EXAMPLE_TD`, …), and otherwise registers a
+   custom target that runs `generate_patches --backend <b> <dump.json> <generated>` and
+   stores the generated path in the same property — exactly how `AVND_MAX_MAXREF_XML` is
+   set at `avendish.max.cmake:260`.
+2. `avnd_create_<backend>_addon_package` reads the property and copies **override if set,
+   else generated** into the backend's help/example location (best-effort, via the
+   existing `avendish.packaging.copy_optional.cmake` helper so a missing file never breaks
+   the build).
+
+This gives the requested behaviour: explicit per-object/per-backend file → expected place;
+otherwise the auto-generated one.
+
+## 7. Metadata additions to objects (optional, improves richness)
+
+To let auto-generation be genuinely explanatory (and to make the "rich" tier shine), add a
+few **optional** metadata fields read by the dump (all already follow the
+`metadatas.hpp` getter-fallback pattern):
+
+- Per-**control** `description` / `tooltip` — surfaced in the inlet/outlet section text.
+  (Today only object-level `description` exists; per-control help is the main gap.)
+- Per-control `step` for sliders (range currently exposes only min/max/init).
+- Object-level `example` text and optional `see_also` list (for the Pd example subpatch /
+  Max "see also").
+
+These are additive; objects without them get synthesized text ("float, 0–127, default 64").
+
+## 8. CMake / packaging integration summary
+
+| Backend | generator output (build dir) | package destination | hook |
+|---|---|---|---|
+| Pd | `pd/<c_name>-help.pd` | `<pkg>/<c_name>-help.pd` | extend `avnd_make_pd` + `avnd_create_pd*_package` |
+| Max | `max/help/<c_name>.maxhelp` | `<pkg>/help/<c_name>.maxhelp` | extend `avnd_make_max` + `avnd_create_max_addon_package` |
+| Max (ref, existing) | `max/<c_name>.maxref.xml` | `<pkg>/docs/refpages/…` | already done |
+| TouchDesigner | `td/<c_name>.example.py` (+ `.tox` override) | `<pkg>/examples/…` | extend `avnd_make_touchdesigner` + packager |
+| Godot | `godot/examples/<c_name>.tscn` | `<pkg>/examples/…` | extend `avnd_make_godot` + packager |
+| Python | `python/<c_name>_example.py` | next to module | extend python packaging |
+
+All generation is **best-effort** and guarded (like `AVND_DISABLE_AUTOMAXREF`), with a
+global `AVND_DISABLE_AUTOHELP` escape hatch.
+
+## 9. Phasing
+
+- **Phase 0 — scaffolding**: create `GeneratePatches.cpp` tool + CMake target; JSON model
+  parser; shared layout engine; `--backend` dispatch. Add `AVND_*_HELP`/`AVND_EXAMPLE_*`
+  target properties + override plumbing in `avnd_addon_object`/`avnd_make_*` (no emitters
+  yet). *Exit: tool builds, runs, emits an empty stub per backend; overrides copy through.*
+- **Phase 1 — Pure Data (finish the started work)**: full `pd` emitter — header, demo,
+  sections, all widget kinds incl. the enum/string/color/xy stubs; wire into `avnd_make_pd`
+  + Pd packaging. Validate generated `-help.pd` opens cleanly in Pd/plugdata for a spread of
+  example objects (audio, message, controls, enum). *Exit: every Pd object ships a help patch.*
+- **Phase 2 — Max `.maxhelp`**: `max` emitter (JSON patcher) + `help/` packaging; validate
+  in Max. *Exit: every Max object ships `.maxhelp` + existing `.maxref.xml`.*
+- **Phase 3 — Godot `.tscn`** (text, easy) **then TouchDesigner** (script + override).
+- **Phase 4 — Python / score / presets** (best-effort) + per-control description metadata
+  (§7) to upgrade fidelity across all emitters.
+
+## 10. Testing & validation
+
+- **Format validity**: parse every generated `.pd` (canvas/connect index integrity) and
+  `.maxhelp` (JSON schema) in CI; for `.tscn`, load headless in Godot (the smoke-test rig
+  at `avendish.godot.cmake:221` already does headless loads).
+- **Open-without-error**: extend `tooling/run_backend_tests.py` to open each generated help
+  patch headless (`pd --nogui`, Max via `AUTOQUIT`, Godot headless) and assert no error /
+  the object instantiates.
+- **Coverage report**: assert every registered example object produced (override or
+  generated) a help/example for each enabled backend; `log()` any object that fell back to
+  scaffold so thin metadata is visible.
+- **Golden snapshots** for a few representative objects to catch layout regressions.
+
+## 11. Open questions / risks
+
+- ~~**TD `.tox`/`.toe` are binary**~~ **RESOLVED** — `toeexpand`/`toecollapse` (bundled with
+  TD, verified locally) round-trip a `.tox` to/from plain text, so we synthesize the expanded
+  directory and collapse it (§5.3). Only the small `toecollapse` binary is needed at gen time;
+  remaining work is mapping the rest of the control kinds to TD param-type IDs.
+- **Max `.maxhelp` fidelity** — the JSON patcher schema is large; start from a minimal
+  validated skeleton (instantiate + 1 widget + 1 line) and grow.
+- **Pd enum UX** — Pd has no native combobox; options are `hradio`+symbol messages or a
+  message list. Pick one convention (recommend `hradio` for ≤8 choices, message list above).
+- **Layout for large objects** — many controls need pagination/columns; the layout engine
+  must wrap gracefully.
+- **Per-control descriptions** don't exist yet (§7) — until added, "rich" text is
+  synthesized from type/range/widget.

--- a/cmake/avendish.cmake
+++ b/cmake/avendish.cmake
@@ -269,6 +269,7 @@ include(avendish.tools)
 
 include(avendish.ui.qt)
 include(avendish.dump)
+include(avendish.help)
 include(avendish.max)
 include(avendish.gstreamer)
 include(avendish.pd)

--- a/cmake/avendish.godot.cmake
+++ b/cmake/avendish.godot.cmake
@@ -87,7 +87,7 @@ set(AVND_GODOT_SOURCES
 
 # PROCESSOR_TYPE: NODE (default), AUDIO_EFFECT, TEXTURE, BUFFER, or GEOMETRY
 function(avnd_make_godot)
-  cmake_parse_arguments(AVND "" "PROCESSOR_TYPE;TARGET;MAIN_FILE;MAIN_CLASS;C_NAME" "" ${ARGN})
+  cmake_parse_arguments(AVND "" "PROCESSOR_TYPE;TARGET;MAIN_FILE;MAIN_CLASS;C_NAME;EXAMPLE_GODOT" "" ${ARGN})
 
   if(NOT AVND_PROCESSOR_TYPE)
     set(AVND_PROCESSOR_TYPE "NODE")
@@ -213,6 +213,17 @@ function(avnd_make_godot)
   )
 
   avnd_common_setup("${AVND_TARGET}" "${AVND_FX_TARGET}")
+
+  # Example scene: instantiates the registered class (avnd_<c_name><suffix>).
+  avnd_generate_help(
+    FX_TARGET     "${AVND_FX_TARGET}"
+    SOURCE_TARGET "${AVND_TARGET}"
+    BACKEND       godot
+    DESTINATION   "godot/examples/$<IF:${multi_config},$<CONFIG>/,>${AVND_C_NAME}${_AVND_GODOT_SUFFIX}.tscn"
+    PROPERTY      AVND_GODOT_EXAMPLE
+    OVERRIDE      "${AVND_EXAMPLE_GODOT}"
+    EXTRA_ARG     "avnd_${AVND_C_NAME}${_AVND_GODOT_SUFFIX}"
+  )
 
   # Headless smoke test: load the extension in godot --headless and check
   # that the class registers. Runs for any project that has a godot

--- a/cmake/avendish.help.cmake
+++ b/cmake/avendish.help.cmake
@@ -1,0 +1,62 @@
+# Help / example patch generation.
+#
+# For a given backend, ship either an explicit per-object override file (copied
+# verbatim) or, failing that, an auto-generated patch produced by the
+# `generate_patches` tool from the object's dump JSON. Mirrors the maxref wiring
+# in avendish.max.cmake.
+#
+# avnd_generate_help(
+#   FX_TARGET     <module-target>     # backend target, owns the result property
+#   SOURCE_TARGET <object-target>     # carries AVND_DUMP_PATH
+#   BACKEND       <pd|max|godot|td|python>
+#   DESTINATION   <output-path>       # may contain $<CONFIG> generator exprs
+#   PROPERTY      <AVND_..._HELP>     # property set to DESTINATION on FX_TARGET
+#   [OVERRIDE     <file>]             # explicit hand-authored file
+# )
+function(avnd_generate_help)
+  cmake_parse_arguments(AVND ""
+    "FX_TARGET;SOURCE_TARGET;BACKEND;DESTINATION;PROPERTY;OVERRIDE" "" ${ARGN})
+
+  if(AVND_DISABLE_AUTOHELP)
+    return()
+  endif()
+
+  # 1) Explicit per-object override: copy it verbatim to the expected place.
+  if(AVND_OVERRIDE)
+    if(NOT IS_ABSOLUTE "${AVND_OVERRIDE}")
+      set(AVND_OVERRIDE "${CMAKE_CURRENT_SOURCE_DIR}/${AVND_OVERRIDE}")
+    endif()
+    if(EXISTS "${AVND_OVERRIDE}")
+      add_custom_target(${AVND_FX_TARGET}_help ALL
+          ${CMAKE_COMMAND} -E copy_if_different
+            "${AVND_OVERRIDE}" "${AVND_DESTINATION}"
+          DEPENDS "${AVND_OVERRIDE}"
+          BYPRODUCTS "${AVND_DESTINATION}"
+        )
+      set_target_properties(${AVND_FX_TARGET}
+        PROPERTIES "${AVND_PROPERTY}" "${AVND_DESTINATION}")
+      return()
+    else()
+      message(WARNING
+        "avnd_generate_help: override '${AVND_OVERRIDE}' not found for "
+        "${AVND_FX_TARGET} (${AVND_BACKEND}); falling back to auto-generation")
+    endif()
+  endif()
+
+  # 2) Auto-generate from the dump JSON.
+  if(NOT TARGET generate_patches)
+    return()
+  endif()
+  get_target_property(_dump_path ${AVND_SOURCE_TARGET} AVND_DUMP_PATH)
+  if(NOT _dump_path)
+    return()
+  endif()
+
+  add_custom_target(${AVND_FX_TARGET}_help ALL
+      generate_patches "${AVND_BACKEND}" "${_dump_path}" "${AVND_DESTINATION}"
+      DEPENDS "${_dump_path}" generate_patches
+      BYPRODUCTS "${AVND_DESTINATION}"
+    )
+  set_target_properties(${AVND_FX_TARGET}
+    PROPERTIES "${AVND_PROPERTY}" "${AVND_DESTINATION}")
+endfunction()

--- a/cmake/avendish.help.cmake
+++ b/cmake/avendish.help.cmake
@@ -15,7 +15,7 @@
 # )
 function(avnd_generate_help)
   cmake_parse_arguments(AVND ""
-    "FX_TARGET;SOURCE_TARGET;BACKEND;DESTINATION;PROPERTY;OVERRIDE" "" ${ARGN})
+    "FX_TARGET;SOURCE_TARGET;BACKEND;DESTINATION;PROPERTY;OVERRIDE;EXTRA_ARG" "" ${ARGN})
 
   if(AVND_DISABLE_AUTOHELP)
     return()
@@ -47,13 +47,16 @@ function(avnd_generate_help)
   if(NOT TARGET generate_patches)
     return()
   endif()
+  if(NOT TARGET ${AVND_SOURCE_TARGET})
+    return()
+  endif()
   get_target_property(_dump_path ${AVND_SOURCE_TARGET} AVND_DUMP_PATH)
   if(NOT _dump_path)
     return()
   endif()
 
   add_custom_target(${AVND_FX_TARGET}_help ALL
-      generate_patches "${AVND_BACKEND}" "${_dump_path}" "${AVND_DESTINATION}"
+      generate_patches "${AVND_BACKEND}" "${_dump_path}" "${AVND_DESTINATION}" ${AVND_EXTRA_ARG}
       DEPENDS "${_dump_path}" generate_patches
       BYPRODUCTS "${AVND_DESTINATION}"
     )

--- a/cmake/avendish.max.cmake
+++ b/cmake/avendish.max.cmake
@@ -87,7 +87,7 @@ function(avnd_make_max)
     return()
   endif()
 
-  cmake_parse_arguments(AVND "" "TARGET;MAIN_FILE;MAIN_CLASS;C_NAME;PROCESSOR_TYPE" "" ${ARGN})
+  cmake_parse_arguments(AVND "" "TARGET;MAIN_FILE;MAIN_CLASS;C_NAME;PROCESSOR_TYPE;HELP_PATCH" "" ${ARGN})
 
   if(AVND_PROCESSOR_TYPE STREQUAL "GEOMETRY" AND NOT (APPLE OR WIN32))
     return()
@@ -261,6 +261,17 @@ EXPORTS
       )
     endif()
   endif()
+
+  # Interactive help patch: <c_name>.maxhelp in the package's help/ folder
+  # (Max searches help/ for <name>.maxhelp). Complements the .maxref.xml above.
+  avnd_generate_help(
+    FX_TARGET     "${AVND_FX_TARGET}"
+    SOURCE_TARGET "${AVND_TARGET}"
+    BACKEND       max
+    DESTINATION   "max/help/$<IF:${multi_config},$<CONFIG>/,>${AVND_C_NAME}.maxhelp"
+    PROPERTY      AVND_MAX_HELP
+    OVERRIDE      "${AVND_HELP_PATCH}"
+  )
 endfunction()
 
 add_library(Avendish_max INTERFACE)

--- a/cmake/avendish.packaging.cmake
+++ b/cmake/avendish.packaging.cmake
@@ -119,6 +119,21 @@ function(avnd_create_max_addon_package)
         VERBATIM)
     endif()
 
+    get_target_property(_maxhelp ${_external} AVND_MAX_HELP)
+    if(_maxhelp)
+      # Interactive help patch (avnd_generate_help). Best-effort, same rationale
+      # as the maxref above: a missing help patch must not fail packaging.
+      if(TARGET "${_external}_help")
+        add_dependencies("${_external}" "${_external}_help")
+      endif()
+      get_property(_pkgdir GLOBAL PROPERTY AVND_PACKAGING_DIR)
+      add_custom_command(TARGET ${_external} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+          "-DSRC=${CMAKE_BINARY_DIR}/${_maxhelp}" "-DDST=${_pkg}/help"
+          -P "${_pkgdir}/avendish.packaging.copy_optional.cmake"
+        VERBATIM)
+    endif()
+
     if(WIN32)
       add_custom_command(TARGET ${_external} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${_external}>" "${_pkg}/externals/"

--- a/cmake/avendish.packaging.cmake
+++ b/cmake/avendish.packaging.cmake
@@ -193,6 +193,19 @@ function(avnd_create_touchdesigner_package)
       COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${_external}>" "${_plugins}/"
       COMMENT "Packaging TouchDesigner plugin: ${_external}"
       VERBATIM)
+
+    get_target_property(_td_example ${_external} AVND_TD_EXAMPLE)
+    if(_td_example)
+      if(TARGET "${_external}_help")
+        add_dependencies("${_external}" "${_external}_help")
+      endif()
+      get_property(_pkgdir GLOBAL PROPERTY AVND_PACKAGING_DIR)
+      add_custom_command(TARGET ${_external} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+          "-DSRC=${CMAKE_BINARY_DIR}/${_td_example}" "-DDST=${_pkg}/examples"
+          -P "${_pkgdir}/avendish.packaging.copy_optional.cmake"
+        VERBATIM)
+    endif()
   endforeach()
 
   # SUPPORT libs live next to the plugins (the OS loader / our get_module_folder()
@@ -249,6 +262,19 @@ function(avnd_create_godot_package)
       ${_copy}
       COMMENT "Packaging Godot GDExtension: ${_external}"
       VERBATIM)
+
+    get_target_property(_gd_example ${_external} AVND_GODOT_EXAMPLE)
+    if(_gd_example)
+      if(TARGET "${_external}_help")
+        add_dependencies("${_external}" "${_external}_help")
+      endif()
+      get_property(_pkgdir GLOBAL PROPERTY AVND_PACKAGING_DIR)
+      add_custom_command(TARGET ${_external} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+          "-DSRC=${CMAKE_BINARY_DIR}/${_gd_example}" "-DDST=${_pkg}/examples"
+          -P "${_pkgdir}/avendish.packaging.copy_optional.cmake"
+        VERBATIM)
+    endif()
   endforeach()
 
   # Rewrite each .gdextension so its [libraries] res:// paths point at

--- a/cmake/avendish.pd.cmake
+++ b/cmake/avendish.pd.cmake
@@ -49,7 +49,7 @@ target_link_libraries(Avendish_pd_pch
 avnd_common_setup("" "Avendish_pd_pch")
 
 function(avnd_make_pd)
-  cmake_parse_arguments(AVND "" "TARGET;MAIN_FILE;MAIN_CLASS;C_NAME" "" ${ARGN})
+  cmake_parse_arguments(AVND "" "TARGET;MAIN_FILE;MAIN_CLASS;C_NAME;HELP_PATCH" "" ${ARGN})
 
   string(MAKE_C_IDENTIFIER "${AVND_MAIN_CLASS}" MAIN_OUT_FILE)
 
@@ -129,6 +129,17 @@ function(avnd_make_pd)
   endif()
 
   avnd_common_setup("${AVND_TARGET}" "${AVND_FX_TARGET}")
+
+  # Ship a help patch: <c_name>-help.pd next to the external (Pd finds it on the
+  # path). Use the explicit HELP_PATCH override if given, else auto-generate.
+  avnd_generate_help(
+    FX_TARGET     "${AVND_FX_TARGET}"
+    SOURCE_TARGET "${AVND_TARGET}"
+    BACKEND       pd
+    DESTINATION   "pd/$<IF:${multi_config},$<CONFIG>/,>${AVND_C_NAME}-help.pd"
+    PROPERTY      AVND_PD_HELP
+    OVERRIDE      "${AVND_HELP_PATCH}"
+  )
 endfunction()
 
 add_library(Avendish_pd INTERFACE)

--- a/cmake/avendish.python.cmake
+++ b/cmake/avendish.python.cmake
@@ -25,7 +25,7 @@ function(avnd_make_python)
     return()
   endif()
 
-  cmake_parse_arguments(AVND "" "TARGET;MAIN_FILE;MAIN_CLASS;C_NAME" "" ${ARGN})
+  cmake_parse_arguments(AVND "" "TARGET;MAIN_FILE;MAIN_CLASS;C_NAME;EXAMPLE_PY" "" ${ARGN})
 
   string(MAKE_C_IDENTIFIER "${AVND_MAIN_CLASS}" MAIN_OUT_FILE)
 
@@ -77,6 +77,16 @@ function(avnd_make_python)
   )
 
   avnd_common_setup("${AVND_TARGET}" "${AVND_FX_TARGET}")
+
+  # Usage example next to the module.
+  avnd_generate_help(
+    FX_TARGET     "${AVND_FX_TARGET}"
+    SOURCE_TARGET "${AVND_TARGET}"
+    BACKEND       python
+    DESTINATION   "python/examples/$<IF:${multi_config},$<CONFIG>/,>${AVND_C_NAME}_example.py"
+    PROPERTY      AVND_PYTHON_EXAMPLE
+    OVERRIDE      "${AVND_EXAMPLE_PY}"
+  )
 endfunction()
 
 add_library(Avendish_python INTERFACE)

--- a/cmake/avendish.tools.cmake
+++ b/cmake/avendish.tools.cmake
@@ -12,3 +12,15 @@ endif()
 # Demo: generate matching pd help patches
 add_executable(generate_pd_help examples/Demos/GeneratePdHelp.cpp)
 target_link_libraries(generate_pd_help PRIVATE Avendish)
+
+# Help / example patch generator: consumes an object's dump JSON and emits a
+# help/example patch for one backend (pd, max, godot, td, python).
+# See HELP_PATCH_GENERATION_PLAN.md.
+if(TARGET nlohmann_json::nlohmann_json)
+  message("Building generate_patches")
+  add_executable(generate_patches examples/Demos/GeneratePatches.cpp)
+  if(NOT MSVC)
+    target_compile_options(generate_patches PRIVATE -std=c++20)
+  endif()
+  target_link_libraries(generate_patches PRIVATE nlohmann_json::nlohmann_json)
+endif()

--- a/cmake/avendish.touchdesigner.cmake
+++ b/cmake/avendish.touchdesigner.cmake
@@ -43,7 +43,7 @@ set(AVND_TD_SOURCES
 
 # Function to create a TouchDesigner Custom operator OP from an Avendish processor
 function(avnd_make_touchdesigner)
-  cmake_parse_arguments(AVND "" "PROCESSOR_TYPE;TARGET;MAIN_FILE;MAIN_CLASS;C_NAME" "LINK_LIBRARIES" ${ARGN})
+  cmake_parse_arguments(AVND "" "PROCESSOR_TYPE;TARGET;MAIN_FILE;MAIN_CLASS;C_NAME;EXAMPLE_TD" "LINK_LIBRARIES" ${ARGN})
 
   # No operator family: the object has no TD-mappable processor category.
   # Skip instead of failing on a missing "<empty>.prototype.cpp.in"; pick one
@@ -172,6 +172,19 @@ function(avnd_make_touchdesigner)
   # Installation (optional)
   # TouchDesigner plugins typically go in <Project>/Plugins/
   # install(TARGETS ${AVND_FX_TARGET} LIBRARY DESTINATION "Plugins")
+
+  # Example: a Python network-builder script (an avendish TD operator is a
+  # compiled Custom OP, so a .tox can only reference it once installed; ship a
+  # builder script, or a hand-authored .tox via EXAMPLE_TD).
+  avnd_generate_help(
+    FX_TARGET     "${AVND_FX_TARGET}"
+    SOURCE_TARGET "${AVND_TARGET}"
+    BACKEND       td
+    DESTINATION   "td/examples/$<IF:${multi_config},$<CONFIG>/,>${AVND_C_NAME}.example.py"
+    PROPERTY      AVND_TD_EXAMPLE
+    OVERRIDE      "${AVND_EXAMPLE_TD}"
+    EXTRA_ARG     "${AVND_C_NAME}"
+  )
 
   message(STATUS "Configured TouchDesigner: ${AVND_FX_TARGET}")
 endfunction()

--- a/examples/Demos/GeneratePatches.cpp
+++ b/examples/Demos/GeneratePatches.cpp
@@ -1,0 +1,317 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Generate help / example patches for an avendish object, for one backend, from
+// the object's introspection dump (dump/<c_name>.json produced by the dump
+// backend). This is the JSON-driven generalization of GeneratePdHelp.cpp; it is
+// invoked per object at build time, mirroring json_to_maxref.
+//
+//   generate_patches <backend> <input.json> <output-path>
+//
+// backend ∈ { pd, max, godot, td, python }
+//
+// Phase 0: scaffolding — the model parser, the per-backend dispatch and minimal
+// but valid stub emitters. Phases 1-4 flesh out each emitter (see
+// HELP_PATCH_GENERATION_PLAN.md).
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace
+{
+using json = nlohmann::json;
+
+// ---------------------------------------------------------------------------
+// Normalized model: a backend-agnostic view of the dump JSON. The emitters work
+// against this rather than poking at the raw JSON, so the dump schema is parsed
+// in exactly one place.
+// ---------------------------------------------------------------------------
+struct range_t
+{
+  std::optional<double> min, max, init;
+};
+
+struct port_t
+{
+  std::string name;
+  std::string description;
+  std::string type; // parameter / audio / midi / texture / message / callback / ...
+
+  // type == "parameter"
+  std::string value_type; // float / int / bool / string / enum / unknown
+  bool is_control = false;
+  bool is_value_port = false;
+  std::optional<range_t> range;
+  std::vector<std::string> choices; // enum
+  std::optional<json> default_value;
+  std::string widget;
+
+  // type == "audio"
+  std::string audio_sample_format; // float / double
+  std::string audio_port_format;   // sample / channel / bus
+};
+
+struct message_t
+{
+  std::string name;
+  std::vector<std::string> arguments;
+  std::string return_type;
+};
+
+struct model_t
+{
+  std::string name;
+  std::string c_name;
+  std::string uuid;
+  std::string category;
+  std::string description;
+  std::string short_description;
+  std::string author;
+  std::string version;
+
+  std::vector<port_t> inputs;
+  std::vector<port_t> outputs;
+  std::vector<message_t> messages;
+};
+
+std::string str(const json& o, const char* key, std::string_view fallback = {})
+{
+  if(auto it = o.find(key); it != o.end() && it->is_string())
+    return it->get<std::string>();
+  return std::string{fallback};
+}
+
+range_t parse_range(const json& r)
+{
+  range_t out;
+  if(auto it = r.find("min"); it != r.end() && it->is_number())
+    out.min = it->get<double>();
+  if(auto it = r.find("max"); it != r.end() && it->is_number())
+    out.max = it->get<double>();
+  if(auto it = r.find("init"); it != r.end() && it->is_number())
+    out.init = it->get<double>();
+  return out;
+}
+
+port_t parse_port(const json& p)
+{
+  port_t out;
+  out.name = str(p, "name", "port");
+  out.description = str(p, "description");
+  out.type = str(p, "type", "unknown");
+
+  if(auto pit = p.find("parameter"); pit != p.end())
+  {
+    const json& par = *pit;
+    out.value_type = str(par, "value_type", "unknown");
+    out.is_control = par.value("control", false);
+    out.is_value_port = par.value("value_port", false);
+    out.widget = str(par, "widget");
+    if(auto rit = par.find("range"); rit != par.end())
+      out.range = parse_range(*rit);
+    if(auto cit = par.find("choices"); cit != par.end() && cit->is_array())
+      for(const auto& c : *cit)
+        if(c.is_string())
+          out.choices.push_back(c.get<std::string>());
+    if(auto dit = par.find("default"); dit != par.end())
+      out.default_value = *dit;
+  }
+  if(auto ait = p.find("audio"); ait != p.end())
+  {
+    out.audio_sample_format = str(*ait, "sample_format");
+    out.audio_port_format = str(*ait, "port_format");
+  }
+  return out;
+}
+
+model_t parse_model(const json& j)
+{
+  model_t m;
+  if(auto it = j.find("metadatas"); it != j.end())
+  {
+    const json& md = *it;
+    m.name = str(md, "name", "Object");
+    m.c_name = str(md, "c_name", m.name);
+    m.uuid = str(md, "uuid");
+    m.category = str(md, "category");
+    m.description = str(md, "description");
+    m.short_description = str(md, "short_description");
+    m.author = str(md, "author");
+    m.version = str(md, "version");
+  }
+  if(auto it = j.find("inputs"); it != j.end() && it->is_array())
+    for(const auto& p : *it)
+      m.inputs.push_back(parse_port(p));
+  if(auto it = j.find("outputs"); it != j.end() && it->is_array())
+    for(const auto& p : *it)
+      m.outputs.push_back(parse_port(p));
+  if(auto it = j.find("messages"); it != j.end() && it->is_array())
+  {
+    for(const auto& msg : *it)
+    {
+      message_t mm;
+      mm.name = str(msg, "name", "message");
+      mm.return_type = str(msg, "return");
+      if(auto ait = msg.find("arguments"); ait != msg.end() && ait->is_array())
+        for(const auto& a : *ait)
+          mm.arguments.push_back(a.is_string() ? a.get<std::string>() : a.dump());
+      m.messages.push_back(mm);
+    }
+  }
+  return m;
+}
+
+std::string blurb(const model_t& m)
+{
+  if(!m.short_description.empty())
+    return m.short_description;
+  if(!m.description.empty())
+    return m.description;
+  return "auto-generated help patch";
+}
+
+// ---------------------------------------------------------------------------
+// Emitters. Phase 0: minimal but valid output that instantiates the object and
+// carries the title/description, so later phases can flesh out the demo,
+// sections and per-port text without changing the plumbing.
+// ---------------------------------------------------------------------------
+
+// Pure Data netlist (#N canvas / #X obj / #X text / #X connect ...).
+void emit_pd(const model_t& m, std::ostream& out)
+{
+  out << "#N canvas 50 50 620 440 12;\n";
+  out << "#X text 18 16 " << m.name << " \\, " << blurb(m)
+      << " (auto-generated help -- WIP);\n";
+  // Instantiate the object so the patch is already meaningful.
+  out << "#X obj 18 80 " << m.c_name << ";\n";
+}
+
+// Max/MSP .maxhelp is a JSON patcher (same schema family as .maxpat).
+void emit_max(const model_t& m, std::ostream& out)
+{
+  json patcher;
+  patcher["fileversion"] = 1;
+  patcher["appversion"]
+      = {{"major", 8}, {"minor", 0}, {"revision", 0}, {"architecture", "x64"},
+         {"modernui", 1}};
+  patcher["rect"] = {50, 50, 620, 440};
+  patcher["boxes"] = json::array();
+
+  auto comment = json::object();
+  comment["box"]
+      = {{"id", "obj-1"},
+         {"maxclass", "comment"},
+         {"text", m.name + " - " + blurb(m) + " (auto-generated help - WIP)"},
+         {"patching_rect", {18.0, 16.0, 400.0, 20.0}}};
+  patcher["boxes"].push_back(comment);
+
+  auto object = json::object();
+  object["box"]
+      = {{"id", "obj-2"}, {"maxclass", "newobj"}, {"text", m.c_name},
+         {"numinlets", 1}, {"numoutlets", 0},
+         {"patching_rect", {18.0, 80.0, 120.0, 22.0}}};
+  patcher["boxes"].push_back(object);
+
+  patcher["lines"] = json::array();
+
+  json doc;
+  doc["patcher"] = patcher;
+  out << doc.dump(2) << '\n';
+}
+
+// Godot text scene (.tscn). Phase 0: a Node placeholder + the description; the
+// real generated/extension class is referenced in a later phase.
+void emit_godot(const model_t& m, std::ostream& out)
+{
+  out << "[gd_scene format=3]\n\n";
+  out << "; " << m.name << " - " << blurb(m) << " (auto-generated example - WIP)\n\n";
+  out << "[node name=\"" << m.name << "Example\" type=\"Node\"]\n";
+}
+
+// TouchDesigner: the real path is text-synthesis + toecollapse (Phase 3). Phase
+// 0 emits a placeholder describing the object's parameters as plain text.
+void emit_td(const model_t& m, std::ostream& out)
+{
+  out << "# TouchDesigner example for " << m.name << " (" << m.c_name << ")\n";
+  out << "# " << blurb(m) << "\n";
+  out << "# Auto-generated placeholder -- real .tox synthesis lands in Phase 3.\n";
+  out << "# Parameters:\n";
+  for(const auto& p : m.inputs)
+    out << "#   - " << p.name << " (" << (p.value_type.empty() ? p.type : p.value_type)
+        << ")\n";
+}
+
+// Python example script.
+void emit_python(const model_t& m, std::ostream& out)
+{
+  out << "# Auto-generated example for " << m.name << " (WIP)\n";
+  out << "# " << blurb(m) << "\n";
+  out << "import " << m.c_name << " as obj\n";
+}
+
+int run(const std::string& backend, const std::string& in_path,
+        const std::string& out_path)
+{
+  std::ifstream in(in_path);
+  if(!in)
+  {
+    std::cerr << "generate_patches: cannot open input '" << in_path << "'\n";
+    return 2;
+  }
+
+  json j;
+  try
+  {
+    in >> j;
+  }
+  catch(const std::exception& e)
+  {
+    std::cerr << "generate_patches: invalid JSON in '" << in_path << "': " << e.what()
+              << '\n';
+    return 3;
+  }
+
+  const model_t m = parse_model(j);
+
+  std::ofstream out(out_path, std::ios::binary);
+  if(!out)
+  {
+    std::cerr << "generate_patches: cannot open output '" << out_path << "'\n";
+    return 4;
+  }
+
+  if(backend == "pd")
+    emit_pd(m, out);
+  else if(backend == "max" || backend == "maxhelp")
+    emit_max(m, out);
+  else if(backend == "godot")
+    emit_godot(m, out);
+  else if(backend == "td" || backend == "touchdesigner")
+    emit_td(m, out);
+  else if(backend == "python")
+    emit_python(m, out);
+  else
+  {
+    std::cerr << "generate_patches: unknown backend '" << backend << "'\n";
+    return 5;
+  }
+  return 0;
+}
+}
+
+int main(int argc, char** argv)
+{
+  if(argc != 4)
+  {
+    std::cerr
+        << "Usage: generate_patches <backend> <input.json> <output-path>\n"
+           "  backend: pd | max | godot | td | python\n";
+    return 1;
+  }
+  return run(argv[1], argv[2], argv[3]);
+}

--- a/examples/Demos/GeneratePatches.cpp
+++ b/examples/Demos/GeneratePatches.cpp
@@ -181,14 +181,325 @@ std::string blurb(const model_t& m)
 // sections and per-port text without changing the plumbing.
 // ---------------------------------------------------------------------------
 
-// Pure Data netlist (#N canvas / #X obj / #X text / #X connect ...).
+// --- Pure Data helpers -----------------------------------------------------
+
+// The selector the Pd binding routes control messages by: the control name with
+// every character outside [a-zA-Z0-9.~] replaced by '_' (mirrors
+// avnd::fixup_identifier with pd::valid_char_for_name). A message
+// [<selector> <value>( sent to the object's left inlet sets that control.
+std::string pd_selector(std::string_view name)
+{
+  std::string s;
+  s.reserve(name.size());
+  for(char c : name)
+  {
+    const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9') || c == '.' || c == '~';
+    s += ok ? c : '_';
+  }
+  return s;
+}
+
+// Escape Pd's structural characters in free text (comments / message contents).
+std::string pd_escape(std::string_view s)
+{
+  std::string r;
+  r.reserve(s.size());
+  for(char c : s)
+  {
+    if(c == ',' || c == ';' || c == '\\')
+      r += '\\';
+    r += c;
+  }
+  return r;
+}
+
+std::string trim_num(double v)
+{
+  std::string s = std::to_string(v);
+  if(s.find('.') != std::string::npos)
+  {
+    while(!s.empty() && s.back() == '0')
+      s.pop_back();
+    if(!s.empty() && s.back() == '.')
+      s.pop_back();
+  }
+  return s;
+}
+
+// Accumulates objects (each gets an index in creation order) and connections,
+// which Pd references by that index. Objects are written first, connections
+// after.
+struct pd_patch
+{
+  std::vector<std::string> objects;
+  std::vector<std::string> connections;
+
+  int add(std::string line)
+  {
+    objects.push_back(std::move(line));
+    return static_cast<int>(objects.size()) - 1;
+  }
+  void connect(int src, int outlet, int dst, int inlet)
+  {
+    connections.push_back(
+        "#X connect " + std::to_string(src) + " " + std::to_string(outlet) + " "
+        + std::to_string(dst) + " " + std::to_string(inlet) + ";");
+  }
+  void text(int x, int y, std::string_view t)
+  {
+    add("#X text " + std::to_string(x) + " " + std::to_string(y) + " "
+        + pd_escape(t) + ";");
+  }
+  // A section-header divider bar, in the ELSE help-patch idiom.
+  void divider(int x, int y, std::string_view label)
+  {
+    add("#X obj " + std::to_string(x) + " " + std::to_string(y)
+        + " cnv 3 550 3 empty empty " + pd_escape(label)
+        + " 8 12 0 13 #dcdcdc #000000 0;");
+  }
+  void write(std::ostream& o, int w, int h) const
+  {
+    o << "#N canvas 50 50 " << w << " " << h << " 12;\n";
+    for(const auto& l : objects)
+      o << l << '\n';
+    for(const auto& c : connections)
+      o << c << '\n';
+  }
+};
+
+// Emit the widget that drives one control. Returns {widget_index, message_index}
+// where the message [selector ...( is wired to the object's left inlet. Returns
+// widget_index = -1 when only a message box (no live widget) is produced.
+struct pd_driver { int widget = -1; int message = -1; };
+
+pd_driver pd_emit_control(pd_patch& p, const port_t& c, int x, int y)
+{
+  const std::string sel = pd_selector(c.name);
+  pd_driver d;
+
+  auto msg = [&](const std::string& body) {
+    d.message = p.add(
+        "#X msg " + std::to_string(x + 150) + " " + std::to_string(y) + " " + body
+        + ";");
+  };
+
+  if(c.value_type == "bool" || c.widget == "toggle" || c.widget == "checkbox")
+  {
+    d.widget = p.add(
+        "#X obj " + std::to_string(x) + " " + std::to_string(y)
+        + " tgl 17 0 empty empty empty 17 7 0 10 #fcfcfc #000000 #000000 0 1;");
+    msg(sel + " \\$1");
+  }
+  else if(c.value_type == "enum" && !c.choices.empty())
+  {
+    const int n = static_cast<int>(c.choices.size());
+    d.widget = p.add(
+        "#X obj " + std::to_string(x) + " " + std::to_string(y) + " hradio 17 1 "
+        + std::to_string(n)
+        + " 0 empty empty empty 0 -8 0 10 #fcfcfc #000000 #000000 0;");
+    msg(sel + " \\$1"); // enum settable by index
+  }
+  else if(c.value_type == "string")
+  {
+    d.widget = p.add(
+        "#X obj " + std::to_string(x) + " " + std::to_string(y)
+        + " symbolatom 12 0 0 0 - - - 0;");
+    msg(sel + " \\$1");
+  }
+  else if(c.value_type == "int")
+  {
+    d.widget
+        = p.add("#X floatatom " + std::to_string(x) + " " + std::to_string(y)
+                + " 5 0 0 0 - - - 0;");
+    msg(sel + " \\$1");
+  }
+  else if(c.value_type == "float")
+  {
+    if(c.range && c.range->min && c.range->max)
+    {
+      d.widget = p.add(
+          "#X obj " + std::to_string(x) + " " + std::to_string(y) + " hsl 128 15 "
+          + trim_num(*c.range->min) + " " + trim_num(*c.range->max)
+          + " 0 0 empty empty empty -2 -8 0 10 #fcfcfc #000000 #000000 0 1;");
+    }
+    else
+    {
+      d.widget
+          = p.add("#X floatatom " + std::to_string(x) + " " + std::to_string(y)
+                  + " 5 0 0 0 - - - 0;");
+    }
+    msg(sel + " \\$1");
+  }
+  else
+  {
+    // bang / impulse, or a complex/multi-component control: emit an editable
+    // message box the user can click, prefilled with the selector.
+    msg(sel);
+  }
+
+  if(d.widget >= 0 && d.message >= 0)
+    p.connect(d.widget, 0, d.message, 0);
+  return d;
+}
+
+std::string pd_port_typestr(const port_t& c)
+{
+  if(c.type == "parameter")
+  {
+    std::string s = c.value_type.empty() ? "control" : c.value_type;
+    if(c.range && c.range->min && c.range->max)
+      s += " (" + trim_num(*c.range->min) + ".." + trim_num(*c.range->max) + ")";
+    return s;
+  }
+  if(c.type == "audio")
+    return "signal";
+  return c.type;
+}
+
+// Pure Data netlist help patch: title, description, a live interactive demo
+// (a widget wired to each control's left-inlet message, osc~ sources for audio
+// in, clip~/dac~ for audio out, sinks on outlets), and labelled
+// inlets/outlets/arguments sections.
 void emit_pd(const model_t& m, std::ostream& out)
 {
-  out << "#N canvas 50 50 620 440 12;\n";
-  out << "#X text 18 16 " << m.name << " \\, " << blurb(m)
-      << " (auto-generated help -- WIP);\n";
-  // Instantiate the object so the patch is already meaningful.
-  out << "#X obj 18 80 " << m.c_name << ";\n";
+  pd_patch p;
+
+  // --- header: title + library badge ---
+  p.add("#X obj 4 5 cnv 15 360 42 empty empty " + pd_escape(m.name)
+        + " 20 20 2 37 #e0e0e0 #000000 0;");
+  p.add("#X obj 470 5 cnv 15 130 42 empty empty avendish 12 13 0 18 #7c7c7c "
+        "#e0e4dc 0;");
+
+  // --- description ---
+  p.text(8, 54, blurb(m));
+
+  // --- the object (created early so its index is known to connections) ---
+  std::vector<const port_t*> controls, audio_in;
+  for(const auto& c : m.inputs)
+  {
+    if(c.type == "parameter")
+      controls.push_back(&c);
+    else if(c.type == "audio")
+      audio_in.push_back(&c);
+  }
+
+  const int demo_top = 92;
+  const int row = 30;
+  const int controls_h = static_cast<int>(controls.size()) * row;
+  const int msgs_h = static_cast<int>(m.messages.size()) * row;
+  const int y_obj = demo_top + controls_h + msgs_h + 50;
+
+  const std::string create = m.c_name.empty() ? m.name : m.c_name;
+  const int obj_idx = p.add(
+      "#X obj 24 " + std::to_string(y_obj) + " " + pd_escape(create) + ";");
+
+  // --- controls: one driver per control, wired to the left inlet ---
+  int y = demo_top;
+  for(const auto* c : controls)
+  {
+    pd_driver d = pd_emit_control(p, *c, 24, y);
+    if(d.message >= 0)
+      p.connect(d.message, 0, obj_idx, 0);
+    p.text(320, y, c->name + " - " + pd_port_typestr(*c)
+                       + (c->description.empty() ? "" : ": " + c->description));
+    y += row;
+  }
+
+  // --- messages: clickable message boxes into the left inlet ---
+  for(const auto& msg : m.messages)
+  {
+    std::string body = pd_selector(msg.name);
+    const int mi = p.add(
+        "#X msg 24 " + std::to_string(y) + " " + body + ";");
+    p.connect(mi, 0, obj_idx, 0);
+    p.text(320, y, "message: " + msg.name);
+    y += row;
+  }
+
+  // --- audio inputs: osc~ sources into the signal inlets ---
+  int ax = 24;
+  for(std::size_t k = 0; k < audio_in.size(); ++k)
+  {
+    const int osc = p.add(
+        "#X obj " + std::to_string(ax) + " " + std::to_string(y_obj - 40)
+        + " osc~ 220;");
+    p.connect(osc, 0, obj_idx, static_cast<int>(k));
+    ax += 70;
+  }
+
+  // --- outputs: sinks in dump order (= outlet order) ---
+  int dac_idx = -1;
+  int ox = 24, oy = y_obj + 44;
+  for(std::size_t i = 0; i < m.outputs.size(); ++i)
+  {
+    const port_t& o = m.outputs[i];
+    if(o.type == "audio")
+    {
+      const int clip = p.add(
+          "#X obj " + std::to_string(ox) + " " + std::to_string(oy)
+          + " clip~ -0.95 0.95;");
+      p.connect(obj_idx, static_cast<int>(i), clip, 0);
+      if(dac_idx < 0)
+        dac_idx = p.add("#X obj 24 " + std::to_string(oy + 40) + " dac~;");
+      p.connect(clip, 0, dac_idx, static_cast<int>(i) % 2);
+      ox += 70;
+    }
+    else if(o.type == "message" || o.type == "callback")
+    {
+      const int pr = p.add(
+          "#X obj " + std::to_string(ox) + " " + std::to_string(oy) + " print "
+          + pd_selector(o.name) + ";");
+      p.connect(obj_idx, static_cast<int>(i), pr, 0);
+      ox += 90;
+    }
+    else
+    {
+      const int fa = p.add(
+          "#X floatatom " + std::to_string(ox) + " " + std::to_string(oy)
+          + " 5 0 0 0 - - - 0;");
+      p.connect(obj_idx, static_cast<int>(i), fa, 0);
+      ox += 60;
+    }
+  }
+
+  // --- reference sections (text only) below the demo ---
+  int sy = (dac_idx >= 0 ? y_obj + 44 + 80 : oy + 40);
+  if(sy < y_obj + 90)
+    sy = y_obj + 90;
+  p.divider(8, sy, "inlets");
+  sy += 18;
+  p.text(20, sy, "left inlet: any [name value( message sets the matching control");
+  sy += 18;
+  for(const auto* c : controls)
+  {
+    p.text(20, sy, pd_selector(c->name) + " - " + pd_port_typestr(*c)
+                       + (c->description.empty() ? "" : ": " + c->description));
+    sy += 16;
+  }
+  for(const auto& msg : m.messages)
+  {
+    p.text(20, sy, pd_selector(msg.name) + " - message");
+    sy += 16;
+  }
+
+  if(!m.outputs.empty())
+  {
+    sy += 8;
+    p.divider(8, sy, "outlets");
+    sy += 18;
+    int oi = 0;
+    for(const auto& o : m.outputs)
+    {
+      p.text(20, sy, std::to_string(oi++) + ") " + o.name + " - "
+                         + pd_port_typestr(o)
+                         + (o.description.empty() ? "" : ": " + o.description));
+      sy += 16;
+    }
+  }
+
+  const int height = sy + 40;
+  p.write(out, 620, height < 300 ? 300 : height);
 }
 
 // Max/MSP .maxhelp is a JSON patcher (same schema family as .maxpat).

--- a/examples/Demos/GeneratePatches.cpp
+++ b/examples/Demos/GeneratePatches.cpp
@@ -15,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <optional>
@@ -187,7 +188,7 @@ std::string blurb(const model_t& m)
 // every character outside [a-zA-Z0-9.~] replaced by '_' (mirrors
 // avnd::fixup_identifier with pd::valid_char_for_name). A message
 // [<selector> <value>( sent to the object's left inlet sets that control.
-std::string pd_selector(std::string_view name)
+std::string selector(std::string_view name)
 {
   std::string s;
   s.reserve(name.size());
@@ -275,7 +276,7 @@ struct pd_driver { int widget = -1; int message = -1; };
 
 pd_driver pd_emit_control(pd_patch& p, const port_t& c, int x, int y)
 {
-  const std::string sel = pd_selector(c.name);
+  const std::string sel = selector(c.name);
   pd_driver d;
 
   auto msg = [&](const std::string& body) {
@@ -409,7 +410,7 @@ void emit_pd(const model_t& m, std::ostream& out)
   // --- messages: clickable message boxes into the left inlet ---
   for(const auto& msg : m.messages)
   {
-    std::string body = pd_selector(msg.name);
+    std::string body = selector(msg.name);
     const int mi = p.add(
         "#X msg 24 " + std::to_string(y) + " " + body + ";");
     p.connect(mi, 0, obj_idx, 0);
@@ -449,7 +450,7 @@ void emit_pd(const model_t& m, std::ostream& out)
     {
       const int pr = p.add(
           "#X obj " + std::to_string(ox) + " " + std::to_string(oy) + " print "
-          + pd_selector(o.name) + ";");
+          + selector(o.name) + ";");
       p.connect(obj_idx, static_cast<int>(i), pr, 0);
       ox += 90;
     }
@@ -473,13 +474,13 @@ void emit_pd(const model_t& m, std::ostream& out)
   sy += 18;
   for(const auto* c : controls)
   {
-    p.text(20, sy, pd_selector(c->name) + " - " + pd_port_typestr(*c)
+    p.text(20, sy, selector(c->name) + " - " + pd_port_typestr(*c)
                        + (c->description.empty() ? "" : ": " + c->description));
     sy += 16;
   }
   for(const auto& msg : m.messages)
   {
-    p.text(20, sy, pd_selector(msg.name) + " - message");
+    p.text(20, sy, selector(msg.name) + " - message");
     sy += 16;
   }
 
@@ -502,37 +503,163 @@ void emit_pd(const model_t& m, std::ostream& out)
   p.write(out, 620, height < 300 ? 300 : height);
 }
 
-// Max/MSP .maxhelp is a JSON patcher (same schema family as .maxpat).
+// Max/MSP .maxhelp is a JSON patcher (same schema family as .maxpat). Controls
+// are driven exactly like Pd: a [selector value( message into the object's left
+// inlet (the binding registers an "anything" A_GIMME method), with the same
+// name normalization.
+struct max_patch
+{
+  json boxes = json::array();
+  json lines = json::array();
+  int n = 0;
+
+  std::string box(
+      std::string_view maxclass, std::string_view text, double x, double y,
+      double w, double h, int nin = 1, int nout = 1)
+  {
+    std::string id = "obj-" + std::to_string(++n);
+    json b;
+    b["id"] = id;
+    b["maxclass"] = maxclass;
+    b["numinlets"] = nin;
+    b["numoutlets"] = nout;
+    b["patching_rect"] = {x, y, w, h};
+    if(!text.empty())
+      b["text"] = text;
+    if(nout > 0)
+      b["outlettype"] = std::vector<std::string>(static_cast<std::size_t>(nout), "");
+    boxes.push_back(json{{"box", b}});
+    return id;
+  }
+  void line(const std::string& s, int so, const std::string& d, int di)
+  {
+    lines.push_back(json{
+        {"patchline",
+         {{"source", {s, so}}, {"destination", {d, di}}}}});
+  }
+  void write(std::ostream& o) const
+  {
+    json p;
+    p["patcher"] = {
+        {"fileversion", 1},
+        {"appversion",
+         {{"major", 8}, {"minor", 5}, {"revision", 0}, {"architecture", "x64"},
+          {"modernui", 1}}},
+        {"classnamespace", "box"},
+        {"rect", {80.0, 80.0, 900.0, 600.0}},
+        {"boxes", boxes},
+        {"lines", lines}};
+    json doc;
+    doc["patcher"] = p["patcher"];
+    o << doc.dump(2) << '\n';
+  }
+};
+
 void emit_max(const model_t& m, std::ostream& out)
 {
-  json patcher;
-  patcher["fileversion"] = 1;
-  patcher["appversion"]
-      = {{"major", 8}, {"minor", 0}, {"revision", 0}, {"architecture", "x64"},
-         {"modernui", 1}};
-  patcher["rect"] = {50, 50, 620, 440};
-  patcher["boxes"] = json::array();
+  max_patch p;
 
-  auto comment = json::object();
-  comment["box"]
-      = {{"id", "obj-1"},
-         {"maxclass", "comment"},
-         {"text", m.name + " - " + blurb(m) + " (auto-generated help - WIP)"},
-         {"patching_rect", {18.0, 16.0, 400.0, 20.0}}};
-  patcher["boxes"].push_back(comment);
+  p.box("comment", m.name, 40, 16, 400, 20, 1, 0);
+  p.box("comment", blurb(m), 40, 38, 600, 20, 1, 0);
 
-  auto object = json::object();
-  object["box"]
-      = {{"id", "obj-2"}, {"maxclass", "newobj"}, {"text", m.c_name},
-         {"numinlets", 1}, {"numoutlets", 0},
-         {"patching_rect", {18.0, 80.0, 120.0, 22.0}}};
-  patcher["boxes"].push_back(object);
+  std::vector<const port_t*> controls, audio_in;
+  for(const auto& c : m.inputs)
+  {
+    if(c.type == "parameter")
+      controls.push_back(&c);
+    else if(c.type == "audio")
+      audio_in.push_back(&c);
+  }
 
-  patcher["lines"] = json::array();
+  const double row = 36;
+  const double demo_top = 90;
+  const double y_obj
+      = demo_top + (controls.size() + m.messages.size()) * row + 60;
 
-  json doc;
-  doc["patcher"] = patcher;
-  out << doc.dump(2) << '\n';
+  const std::string create = m.c_name.empty() ? m.name : m.c_name;
+  const std::string obj = p.box(
+      "newobj", create, 40, y_obj, 240, 22,
+      std::max<int>(1, static_cast<int>(audio_in.size())),
+      std::max<int>(1, static_cast<int>(m.outputs.size())));
+
+  double y = demo_top;
+  for(const auto* c : controls)
+  {
+    const std::string sel = selector(c->name);
+    std::string widget, body = sel + " $1";
+    std::string maxclass;
+    if(c->value_type == "bool")
+      maxclass = "toggle";
+    else if(c->value_type == "int" || c->value_type == "enum")
+      maxclass = "number";
+    else if(c->value_type == "float")
+      maxclass = "flonum";
+    else if(c->value_type == "string")
+      maxclass = ""; // message-only
+    else
+    {
+      maxclass = "button";
+      body = sel; // bang / impulse
+    }
+
+    if(!maxclass.empty())
+    {
+      widget = p.box(maxclass, "", 40, y, 50, 22);
+      const std::string msg = p.box("message", body, 200, y, 140, 22);
+      p.line(widget, 0, msg, 0);
+      p.line(msg, 0, obj, 0);
+    }
+    else
+    {
+      const std::string msg = p.box("message", sel + " value", 200, y, 140, 22);
+      p.line(msg, 0, obj, 0);
+    }
+    p.box("comment", c->name + " - " + pd_port_typestr(*c)
+                         + (c->description.empty() ? "" : ": " + c->description),
+          350, y, 240, 20, 1, 0);
+    y += row;
+  }
+
+  for(const auto& msg : m.messages)
+  {
+    const std::string mb = p.box("message", selector(msg.name), 40, y, 140, 22);
+    p.line(mb, 0, obj, 0);
+    y += row;
+  }
+
+  double ax = 40;
+  for(std::size_t k = 0; k < audio_in.size(); ++k)
+  {
+    const std::string src = p.box("newobj", "cycle~ 220", ax, y_obj - 40, 90, 22);
+    p.line(src, 0, obj, static_cast<int>(k));
+    ax += 100;
+  }
+
+  double ox = 40;
+  const double oy = y_obj + 50;
+  std::string dac;
+  for(std::size_t i = 0; i < m.outputs.size(); ++i)
+  {
+    const port_t& o = m.outputs[i];
+    if(o.type == "audio")
+    {
+      const std::string g = p.box("newobj", "*~ 0.2", ox, oy, 60, 22);
+      p.line(obj, static_cast<int>(i), g, 0);
+      if(dac.empty())
+        dac = p.box("newobj", "ezdac~", 40, oy + 40, 45, 45, 2, 0);
+      p.line(g, 0, dac, static_cast<int>(i) % 2);
+      ox += 80;
+    }
+    else
+    {
+      const std::string pr
+          = p.box("newobj", "print " + selector(o.name), ox, oy, 140, 22, 1, 0);
+      p.line(obj, static_cast<int>(i), pr, 0);
+      ox += 150;
+    }
+  }
+
+  p.write(out);
 }
 
 // Godot text scene (.tscn). Phase 0: a Node placeholder + the description; the
@@ -588,6 +715,13 @@ int run(const std::string& backend, const std::string& in_path,
   }
 
   const model_t m = parse_model(j);
+
+  if(const auto parent = std::filesystem::path(out_path).parent_path();
+     !parent.empty())
+  {
+    std::error_code ec;
+    std::filesystem::create_directories(parent, ec);
+  }
 
   std::ofstream out(out_path, std::ios::binary);
   if(!out)

--- a/examples/Demos/GeneratePatches.cpp
+++ b/examples/Demos/GeneratePatches.cpp
@@ -248,10 +248,17 @@ struct pd_patch
         "#X connect " + std::to_string(src) + " " + std::to_string(outlet) + " "
         + std::to_string(dst) + " " + std::to_string(inlet) + ";");
   }
-  void text(int x, int y, std::string_view t)
+  // Emit a comment with an explicit character width (the `, f <n>` flag) so Pd's
+  // line-wrapping is deterministic, and return the vertical space it occupies in
+  // pixels. Callers advance Y by this so a comment that wraps to several lines
+  // never collides with the next one.
+  int text(int x, int y, std::string_view t, int width_chars = 60)
   {
     add("#X text " + std::to_string(x) + " " + std::to_string(y) + " "
-        + pd_escape(t) + ";");
+        + pd_escape(t) + ", f " + std::to_string(width_chars) + ";");
+    const int len = static_cast<int>(t.size());
+    const int lines = len <= width_chars ? 1 : (len + width_chars - 1) / width_chars;
+    return lines * 15; // ~one line height at font size 12
   }
   // A section-header divider bar, in the ELSE help-patch idiom.
   void divider(int x, int y, std::string_view label)
@@ -374,7 +381,7 @@ void emit_pd(const model_t& m, std::ostream& out)
         "#e0e4dc 0;");
 
   // --- description ---
-  p.text(8, 54, blurb(m));
+  p.text(8, 54, blurb(m), 86);
 
   // --- the object (created early so its index is known to connections) ---
   std::vector<const port_t*> controls, audio_in;
@@ -471,34 +478,25 @@ void emit_pd(const model_t& m, std::ostream& out)
   if(sy < y_obj + 90)
     sy = y_obj + 90;
   p.divider(8, sy, "inlets");
-  sy += 18;
-  p.text(20, sy, "left inlet: any [name value( message sets the matching control");
-  sy += 18;
+  sy += 20;
+  sy += p.text(
+      20, sy, "left inlet: any [name value( message sets the matching control");
   for(const auto* c : controls)
-  {
-    p.text(20, sy, selector(c->name) + " - " + pd_port_typestr(*c)
-                       + (c->description.empty() ? "" : ": " + c->description));
-    sy += 16;
-  }
+    sy += p.text(20, sy, selector(c->name) + " - " + pd_port_typestr(*c)
+                             + (c->description.empty() ? "" : ": " + c->description));
   for(const auto& msg : m.messages)
-  {
-    p.text(20, sy, selector(msg.name) + " - message");
-    sy += 16;
-  }
+    sy += p.text(20, sy, selector(msg.name) + " - message");
 
   if(!m.outputs.empty())
   {
-    sy += 8;
+    sy += 10;
     p.divider(8, sy, "outlets");
-    sy += 18;
+    sy += 20;
     int oi = 0;
     for(const auto& o : m.outputs)
-    {
-      p.text(20, sy, std::to_string(oi++) + ") " + o.name + " - "
-                         + pd_port_typestr(o)
-                         + (o.description.empty() ? "" : ": " + o.description));
-      sy += 16;
-    }
+      sy += p.text(20, sy, std::to_string(oi++) + ") " + o.name + " - "
+                               + pd_port_typestr(o)
+                               + (o.description.empty() ? "" : ": " + o.description));
   }
 
   const int ncols = nctrl > 0 ? (nctrl + rows_per_col - 1) / rows_per_col : 1;

--- a/examples/Demos/GeneratePatches.cpp
+++ b/examples/Demos/GeneratePatches.cpp
@@ -15,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -387,34 +388,35 @@ void emit_pd(const model_t& m, std::ostream& out)
 
   const int demo_top = 92;
   const int row = 30;
-  const int controls_h = static_cast<int>(controls.size()) * row;
+  const int rows_per_col = 18; // wrap long control lists into columns
+  const int col_w = 330;
+  const int nctrl = static_cast<int>(controls.size());
+  const int tallest = nctrl > 0 ? std::min(nctrl, rows_per_col) : 0;
   const int msgs_h = static_cast<int>(m.messages.size()) * row;
-  const int y_obj = demo_top + controls_h + msgs_h + 50;
+  const int y_obj = demo_top + tallest * row + msgs_h + 50;
 
   const std::string create = m.c_name.empty() ? m.name : m.c_name;
   const int obj_idx = p.add(
       "#X obj 24 " + std::to_string(y_obj) + " " + pd_escape(create) + ";");
 
-  // --- controls: one driver per control, wired to the left inlet ---
-  int y = demo_top;
-  for(const auto* c : controls)
+  // --- controls: one driver per control, wired to the left inlet; per-control
+  // descriptions live in the inlets section below to keep the demo compact ---
+  for(int i = 0; i < nctrl; ++i)
   {
-    pd_driver d = pd_emit_control(p, *c, 24, y);
+    const int cx = 24 + (i / rows_per_col) * col_w;
+    const int cy = demo_top + (i % rows_per_col) * row;
+    pd_driver d = pd_emit_control(p, *controls[i], cx, cy);
     if(d.message >= 0)
       p.connect(d.message, 0, obj_idx, 0);
-    p.text(320, y, c->name + " - " + pd_port_typestr(*c)
-                       + (c->description.empty() ? "" : ": " + c->description));
-    y += row;
   }
 
   // --- messages: clickable message boxes into the left inlet ---
+  int y = demo_top + tallest * row + 10;
   for(const auto& msg : m.messages)
   {
-    std::string body = selector(msg.name);
     const int mi = p.add(
-        "#X msg 24 " + std::to_string(y) + " " + body + ";");
+        "#X msg 24 " + std::to_string(y) + " " + selector(msg.name) + ";");
     p.connect(mi, 0, obj_idx, 0);
-    p.text(320, y, "message: " + msg.name);
     y += row;
   }
 
@@ -499,8 +501,10 @@ void emit_pd(const model_t& m, std::ostream& out)
     }
   }
 
+  const int ncols = nctrl > 0 ? (nctrl + rows_per_col - 1) / rows_per_col : 1;
+  const int width = std::max(620, 24 + ncols * col_w + 80);
   const int height = sy + 40;
-  p.write(out, 620, height < 300 ? 300 : height);
+  p.write(out, width, height < 300 ? 300 : height);
 }
 
 // Max/MSP .maxhelp is a JSON patcher (same schema family as .maxpat). Controls
@@ -662,38 +666,152 @@ void emit_max(const model_t& m, std::ostream& out)
   p.write(out);
 }
 
-// Godot text scene (.tscn). Phase 0: a Node placeholder + the description; the
-// real generated/extension class is referenced in a later phase.
-void emit_godot(const model_t& m, std::ostream& out)
+// Godot text scene (.tscn) — fully text-emittable. Instantiates the
+// extension-registered class and sets a few exported properties to their init
+// values. `cls` is the registered class name (avnd_<c_name><suffix>); when
+// absent we fall back to avnd_<c_name>.
+bool valid_gd_ident(std::string_view s)
 {
+  if(s.empty())
+    return false;
+  if(!((s[0] >= 'a' && s[0] <= 'z') || (s[0] >= 'A' && s[0] <= 'Z') || s[0] == '_'))
+    return false;
+  for(char c : s)
+    if(!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+         || c == '_'))
+      return false;
+  return true;
+}
+
+std::string gd_node_name(std::string_view s)
+{
+  std::string r;
+  for(char c : s)
+    r += (c == '.' || c == ':' || c == '@' || c == '/' || c == '%' || c == ' ')
+             ? '_'
+             : c;
+  return r.empty() ? std::string{"Example"} : r;
+}
+
+void emit_godot(const model_t& m, std::ostream& out, const std::string& cls)
+{
+  const std::string klass
+      = !cls.empty() ? cls
+                     : "avnd_" + (m.c_name.empty() ? m.name : m.c_name);
+
   out << "[gd_scene format=3]\n\n";
-  out << "; " << m.name << " - " << blurb(m) << " (auto-generated example - WIP)\n\n";
-  out << "[node name=\"" << m.name << "Example\" type=\"Node\"]\n";
+  out << "; " << m.name << " - " << blurb(m) << " (auto-generated example)\n\n";
+  out << "[node name=\"" << gd_node_name(m.name) << "\" type=\"" << klass << "\"]\n";
+
+  // Exported properties (Avendish parameters). Property names are the control
+  // names verbatim; emit assignments for the ones that are valid identifiers.
+  for(const auto& c : m.inputs)
+  {
+    if(c.type != "parameter" || !valid_gd_ident(c.name))
+      continue;
+    if(c.value_type == "float" || c.value_type == "int")
+    {
+      double v = 0.0;
+      if(c.range && c.range->init)
+        v = *c.range->init;
+      else if(c.default_value && c.default_value->is_number())
+        v = c.default_value->get<double>();
+      out << c.name << " = " << trim_num(v) << "\n";
+    }
+    else if(c.value_type == "bool")
+    {
+      bool v = c.default_value && c.default_value->is_boolean()
+               && c.default_value->get<bool>();
+      out << c.name << " = " << (v ? "true" : "false") << "\n";
+    }
+    else if(c.value_type == "enum")
+    {
+      out << c.name << " = 0\n";
+    }
+  }
 }
 
-// TouchDesigner: the real path is text-synthesis + toecollapse (Phase 3). Phase
-// 0 emits a placeholder describing the object's parameters as plain text.
-void emit_td(const model_t& m, std::ostream& out)
+// TouchDesigner example: a Python network-builder script. An avendish TD
+// operator is a compiled Custom OP plugin, so a network can only reference it
+// once the plugin is installed -- the robust shippable artifact is a builder
+// script (run inside TD) or an author-provided .tox via the EXAMPLE_TD override.
+// `optype` is the registered Custom OP type (passed by CMake); falls back to the
+// c_name.
+void emit_td(const model_t& m, std::ostream& out, const std::string& optype)
 {
-  out << "# TouchDesigner example for " << m.name << " (" << m.c_name << ")\n";
+  const std::string ty = optype.empty() ? m.c_name : optype;
+  out << "# TouchDesigner example builder for " << m.name << "\n";
   out << "# " << blurb(m) << "\n";
-  out << "# Auto-generated placeholder -- real .tox synthesis lands in Phase 3.\n";
-  out << "# Parameters:\n";
-  for(const auto& p : m.inputs)
-    out << "#   - " << p.name << " (" << (p.value_type.empty() ? p.type : p.value_type)
-        << ")\n";
+  out << "#\n";
+  out << "# Run inside TouchDesigner (paste into a Text DAT and run it, or call\n";
+  out << "# build(op('/')) ) to create an example network for this operator.\n";
+  out << "# A hand-authored .tox can be shipped instead via the EXAMPLE_TD override.\n\n";
+  out << "OPERATOR_TYPE = " << '"' << ty << '"' << "\n\n";
+  out << "# Parameters (name, type, range/default):\n";
+  for(const auto& c : m.inputs)
+  {
+    if(c.type != "parameter")
+      continue;
+    out << "#   - " << c.name << " : " << pd_port_typestr(c);
+    if(!c.description.empty())
+      out << " - " << c.description;
+    out << "\n";
+  }
+  out << "\n";
+  out << "def build(parent):\n";
+  out << "    n = parent.create(OPERATOR_TYPE, " << '"' << m.c_name << "_example"
+      << '"' << ")\n";
+  for(const auto& c : m.inputs)
+  {
+    if(c.type != "parameter")
+      continue;
+    double v = 0.0;
+    if(c.range && c.range->init)
+      v = *c.range->init;
+    else if(c.default_value && c.default_value->is_number())
+      v = c.default_value->get<double>();
+    // Custom parameters appear under n.par.<Name> (TD capitalizes the first
+    // letter of the tuplet name); leave the assignment for the user to confirm.
+    out << "    # n.par." << c.name << " = " << trim_num(v) << "\n";
+  }
+  out << "    return n\n";
 }
 
-// Python example script.
+// Python example script: import the module and exercise the object.
 void emit_python(const model_t& m, std::ostream& out)
 {
-  out << "# Auto-generated example for " << m.name << " (WIP)\n";
-  out << "# " << blurb(m) << "\n";
-  out << "import " << m.c_name << " as obj\n";
+  out << "#!/usr/bin/env python3\n";
+  out << "\"\"\"" << m.name << " - " << blurb(m) << "\n\n";
+  out << "Auto-generated usage example.\n\"\"\"\n\n";
+  out << "import " << m.c_name << " as mod\n\n";
+  out << "obj = mod." << m.c_name << "()\n\n";
+  out << "# Set the input controls:\n";
+  bool any = false;
+  for(const auto& c : m.inputs)
+  {
+    if(c.type != "parameter")
+      continue;
+    any = true;
+    std::string v = "0";
+    if(c.value_type == "string")
+      v = "\"\"";
+    else if(c.value_type == "bool")
+      v = "False";
+    else if(c.range && c.range->init)
+      v = trim_num(*c.range->init);
+    else if(c.default_value && c.default_value->is_number())
+      v = trim_num(c.default_value->get<double>());
+    out << "obj." << selector(c.name) << " = " << v;
+    if(!c.description.empty())
+      out << "  # " << c.description;
+    out << "\n";
+  }
+  if(!any)
+    out << "# (this object has no input controls)\n";
 }
 
 int run(const std::string& backend, const std::string& in_path,
-        const std::string& out_path)
+        const std::string& out_path, const std::string& hint)
 {
   std::ifstream in(in_path);
   if(!in)
@@ -735,9 +853,9 @@ int run(const std::string& backend, const std::string& in_path,
   else if(backend == "max" || backend == "maxhelp")
     emit_max(m, out);
   else if(backend == "godot")
-    emit_godot(m, out);
+    emit_godot(m, out, hint);
   else if(backend == "td" || backend == "touchdesigner")
-    emit_td(m, out);
+    emit_td(m, out, hint);
   else if(backend == "python")
     emit_python(m, out);
   else
@@ -751,12 +869,13 @@ int run(const std::string& backend, const std::string& in_path,
 
 int main(int argc, char** argv)
 {
-  if(argc != 4)
+  if(argc != 4 && argc != 5)
   {
     std::cerr
-        << "Usage: generate_patches <backend> <input.json> <output-path>\n"
-           "  backend: pd | max | godot | td | python\n";
+        << "Usage: generate_patches <backend> <input.json> <output-path> [hint]\n"
+           "  backend: pd | max | godot | td | python\n"
+           "  hint:    backend-specific (godot: the registered class name)\n";
     return 1;
   }
-  return run(argv[1], argv[2], argv[3]);
+  return run(argv[1], argv[2], argv[3], argc == 5 ? argv[4] : std::string{});
 }


### PR DESCRIPTION
## What

Infrastructure for shipping a **help / example patch with every object, per backend**. Two sources, in priority order:

1. **Per-object override** — when registering an object, the author points to an explicit hand-authored help/example file per backend; it is copied verbatim to that backend's expected package location.
2. **Auto-generated** — otherwise a generator produces a patch from the object's introspection dump (`dump/<c_name>.json`).

This first PR lands the **plumbing and the generator tool** (phase 0). The rich per-backend emitters land in follow-up phases — see `HELP_PATCH_GENERATION_PLAN.md` for the full design.

## Contents

- **`examples/Demos/GeneratePatches.cpp`** — new JSON-driven tool (`generate_patches <backend> <dump.json> <output>`). Parses the dump schema into a normalized model once, then dispatches to per-backend emitters (`pd`, `max`/`.maxhelp`, `godot`/`.tscn`, `td`, `python`). Phase-0 emitters are minimal but valid (instantiate the object + carry title/description).
- **`cmake/avendish.help.cmake`** — reusable `avnd_generate_help()`: override-if-present else auto-generate, stores the result path as a target property, best-effort, `AVND_DISABLE_AUTOHELP` escape hatch. Mirrors the existing maxref wiring.
- **`cmake/avendish.tools.cmake`** — builds the `generate_patches` target.
- **`cmake/avendish.pd.cmake`** — `avnd_make_pd` gains a `HELP_PATCH` override arg and emits `pd/<c_name>-help.pd`.
- **`cmake/avendish.cmake`** — includes `avendish.help`.
- **`HELP_PATCH_GENERATION_PLAN.md`** — architecture, per-backend design, override mechanism, packaging integration, phasing, and the validated TouchDesigner `.tox` text-synthesis path (via the bundled `toeexpand`/`toecollapse`).

## Verification

- `generate_patches` builds on MSVC and emits valid output for all five backends from a real `AllPortsTypes` dump (`.maxhelp` is valid JSON, `.tscn` valid scene text).
- `avnd_generate_help` exercised in both override (verbatim copy) and auto-gen modes.

## Next

Phase 1: the full Pure Data emitter (header + badge, live interactive demo with a widget wired per control, inlets/outlets/arguments sections, enum/string/color/xy completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)