### PR TITLE
max: fix crash on DSP start with fixed/wider output buses

### DIFF
--- a/include/avnd/binding/max/audio_processor.hpp
+++ b/include/avnd/binding/max/audio_processor.hpp
@@ -299,9 +299,14 @@ audio_processor_metaclass<T>::audio_processor_metaclass()
       return false;
   };
   static constexpr auto outputcount = +[](instance* x, long index) -> long {
-    // TODO check whether the outputs are fixed or dynamic
-    // FIXME compute it better, e.g. use runtime_output_count
-    return x->m_runtime_input_count;
+    // Report the number of output channels Max must allocate. This MUST match
+    // dsp()'s output_chans computation, otherwise perform() receives fewer `outs`
+    // buffers than the object writes -> out-of-bounds. In particular a fixed
+    // output bus (e.g. fixed_audio_bus<..., 2>) always writes its N channels even
+    // when fed a mono signal, so we can never report fewer than output_channels.
+    const long ins
+        = std::max<long>(instance::input_channels, x->m_runtime_input_count);
+    return std::max<long>(instance::output_channels, ins);
   };
 
   // Message processing


### PR DESCRIPTION
## Bug

A Max audio external built from an object with a **fixed output bus** (e.g. `fixed_audio_bus<double, 2>`) **crashes the instant audio (DSP) starts** when fed a mono source.

## Root cause

`audio_processor`'s `multichanneloutputs` handler reported the runtime **input** channel count:

```cpp
static constexpr auto outputcount = +[](instance* x, long index) -> long {
    // FIXME compute it better
    return x->m_runtime_input_count;
};
```

But `dsp()` allocates — and the object writes — `max(output_channels, input_chans)` output channels. With a mono `cycle~` → the effect, Max was told to allocate **1** output channel, while the object's `operator()` unconditionally writes `outputs.audio.channel(1, N)` too → **out-of-bounds write in `perform()`** → hard crash on the first DSP tick.

## Fix

Report the same count `dsp()` uses:

```cpp
const long ins = std::max<long>(instance::input_channels, x->m_runtime_input_count);
return std::max<long>(instance::output_channels, ins);
```

A mono source into a fixed-stereo effect now gets 2 output channels allocated, matching what the object writes.

## Verification

Built the `oscr_Distortion` external (Tutorial/Distortion, `fixed_audio_bus<double, 2>` output) and ran it in **Max 8**: `cycle~ 220` → `oscr_Distortion` → `ezdac~` with DSP auto-started via `loadbang → [; dsp 1(`. Before: crash on DSP start. After: runs cleanly for 30s+, empty Max console, no crash dialog.

Found while GUI-verifying the auto-generated help patches (unrelated PR #126); this is a pre-existing Max-binding bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)