### PR TITLE
python: fix stack overflow importing modules with scalar-arg callbacks

### DIFF
--- a/include/avnd/binding/python/processor.hpp
+++ b/include/avnd/binding/python/processor.hpp
@@ -65,6 +65,9 @@ constexpr auto output_name(avnd::field_reflection<Idx, C>)
   return avnd::get_static_symbol<C>();
 }
 
+template <typename V>
+inline void ensure_value_type_registered(pybind11::module_& m);
+
 template <typename... Args>
 struct register_types;
 template <>
@@ -125,6 +128,20 @@ struct register_types<Arg>
       return 0;
     }();
   }
+};
+
+// Single non-aggregate type (e.g. a callback argument like `float` or an enum).
+// Without this, register_types<float> would fall through to the variadic
+// specialization below (with an empty pack), whose body calls
+// register_types<Arg>{} = register_types<float>{} -> itself -> infinite
+// recursion -> stack overflow when importing a module with a scalar-arg
+// callback. This more-specialized single-type overload breaks that: builtins
+// need no registration, enums are handled by ensure_value_type_registered.
+template <typename Arg>
+  requires(!std::is_aggregate_v<Arg>)
+struct register_types<Arg>
+{
+  void operator()(pybind11::module_& m) { ensure_value_type_registered<Arg>(m); }
 };
 
 template <typename Arg, typename... Args>


### PR DESCRIPTION
## Bug

Importing the Python module for any object with a **callback output whose argument is a scalar** (or any non-aggregate) **crashes the interpreter with a stack overflow**, the instant the module is imported. Affected example objects: `Callback`, `TestCallback`, `CompleteMessageExample`.

## Root cause

Infinite template recursion in `register_types`. For a callback like `halp::basic_callback<void(float)>`, `register_arg_types` calls `register_types<float>`. But there was no single-type specialization for a non-aggregate type:

- `register_types<Arg> requires is_aggregate_v<Arg>` — doesn't match `float`
- `register_types<Arg, Args...>` — **does** match `register_types<float>` with an empty pack

…and that variadic body does:

```cpp
register_types<Arg>{}(m);      // register_types<float>{} -> itself
register_types<Args...>{}(m);  // register_types<>{}
```

So `register_types<float>` instantiates `register_types<float>` → infinite recursion → stack overflow during module init.

## Fix

Add a more-specialized single non-aggregate specialization (selected over the variadic), which breaks the recursion — builtins need no registration, enums go through `ensure_value_type_registered` (forward-declared):

```cpp
template <typename Arg>
  requires(!std::is_aggregate_v<Arg>)
struct register_types<Arg>
{
  void operator()(pybind11::module_& m) { ensure_value_type_registered<Arg>(m); }
};
```

## Verification

`import pyavnd_callback / pyavnd_test_callback / pyavnd_complete_message_example` + construct → all exit 0 (previously crashed on import). Found while sweeping every object across backends (Max/Pd/Godot/Python) for crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)