### PR TITLE
cmake: define stub avnd_make_* when a backend is disabled

### DIFF
--- a/cmake/avendish.godot.cmake
+++ b/cmake/avendish.godot.cmake
@@ -3,6 +3,9 @@
 # -DAVND_ENABLE_GODOT=OFF -- doesn't fetch/build what it won't use (godot-cpp, the
 # VST3 SDK, ...). Matches _avnd_dispatch_backend: only act when explicitly OFF.
 if(DEFINED AVND_ENABLE_GODOT AND NOT AVND_ENABLE_GODOT)
+  # examples.cmake calls avnd_make_godot directly; keep the command defined.
+  function(avnd_make_godot)
+  endfunction()
   return()
 endif()
 

--- a/cmake/avendish.max.cmake
+++ b/cmake/avendish.max.cmake
@@ -3,6 +3,9 @@
 # -DAVND_ENABLE_MAX=OFF -- doesn't fetch/build what it won't use (godot-cpp, the
 # VST3 SDK, ...). Matches _avnd_dispatch_backend: only act when explicitly OFF.
 if(DEFINED AVND_ENABLE_MAX AND NOT AVND_ENABLE_MAX)
+  # examples.cmake calls avnd_make_max directly; keep the command defined.
+  function(avnd_make_max)
+  endfunction()
   return()
 endif()
 

--- a/cmake/avendish.touchdesigner.cmake
+++ b/cmake/avendish.touchdesigner.cmake
@@ -3,6 +3,10 @@
 # -DAVND_ENABLE_TOUCHDESIGNER=OFF -- doesn't fetch/build what it won't use (godot-cpp, the
 # VST3 SDK, ...). Matches _avnd_dispatch_backend: only act when explicitly OFF.
 if(DEFINED AVND_ENABLE_TOUCHDESIGNER AND NOT AVND_ENABLE_TOUCHDESIGNER)
+  # Still define the stub: examples.cmake calls avnd_make_touchdesigner directly,
+  # so a disabled back-end must not leave the command undefined.
+  function(avnd_make_touchdesigner)
+  endfunction()
   return()
 endif()
 


### PR DESCRIPTION
## Bug

`AVND_ENABLE_<BACKEND>=OFF` is meant to let you build a single backend cheaply (the guards were added precisely for that — e.g. an avnd-addon CI lane). But the disable guard `return()`s *before* defining the backend's `avnd_make_*` command, while `examples.cmake` calls several of them directly:

- `avnd_make_touchdesigner` (5×)
- `avnd_make_godot` (4×)
- `avnd_make_max` (2×)

So `cmake -DAVND_ENABLE_TOUCHDESIGNER=OFF …` fails with `Unknown CMake command "avnd_make_touchdesigner"`.

## Fix

Define an empty stub function in the disable branch (matching what each backend's existing no-SDK-found branch already does), so the command stays defined even when the backend is off.

## Found while

Setting up a clang64/MSYS2 **GStreamer-only** local build (`-DAVND_ENABLE_GSTREAMER=ON` + everything else OFF) — which then configures and builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)