### PR TITLE
gstreamer: fix processing crashes on fixed-output-bus + float textures

### DIFF
--- a/include/avnd/binding/gstreamer/audio_filter.hpp
+++ b/include/avnd/binding/gstreamer/audio_filter.hpp
@@ -86,14 +86,22 @@ struct element<T> : property_handler
         this, "Processing %lu frames: %d channels, %d Hz, format=%s, bps=%d", n_frames,
         channels, sample_rate, gst_audio_format_to_string(format), bps);
 
-    // Convert interleaved GStreamer audio to planar format for process_adapter
-    std::vector<float*> input_ptrs(channels);
-    std::vector<float*> output_ptrs(channels);
-    std::vector<std::vector<float>> input_channels(channels);
-    std::vector<std::vector<float>> output_channels(channels);
+    // The object may read/write more channels than the caps advertise -- e.g. a
+    // fixed_audio_bus<..., 2> output unconditionally writes channel 1 even when
+    // fed a mono stream. Size the planar buffers to what the object needs, not
+    // just to `channels`, so process() can never write past the end.
+    const int in_ch = std::max<int>(channels, avnd::input_channels<T>(channels));
+    const int out_ch = std::max<int>(channels, avnd::output_channels<T>(channels));
+    const int buf_ch = std::max(in_ch, out_ch);
 
-    // Allocate and prepare channel arrays
-    for(int ch = 0; ch < channels; ch++)
+    // Convert interleaved GStreamer audio to planar format for process_adapter
+    std::vector<float*> input_ptrs(buf_ch);
+    std::vector<float*> output_ptrs(buf_ch);
+    std::vector<std::vector<float>> input_channels(buf_ch);
+    std::vector<std::vector<float>> output_channels(buf_ch);
+
+    // Allocate and prepare channel arrays (extra channels stay zero-filled)
+    for(int ch = 0; ch < buf_ch; ch++)
     {
       input_channels[ch].resize(n_frames);
       output_channels[ch].resize(n_frames);
@@ -101,7 +109,7 @@ struct element<T> : property_handler
       output_ptrs[ch] = output_channels[ch].data();
     }
 
-    // Convert from interleaved to planar format
+    // Convert from interleaved to planar format (only the caps channels exist)
     float* samples = (float*)in_info.data;
     for(int ch = 0; ch < channels; ch++)
     {
@@ -113,8 +121,8 @@ struct element<T> : property_handler
 
     // Process through process_adapter (handles all Avendish audio APIs)
     processor.process(
-        impl, avnd::span<float*>{input_ptrs.data(), (size_t)channels},
-        avnd::span<float*>{output_ptrs.data(), (size_t)channels}, n_frames);
+        impl, avnd::span<float*>{input_ptrs.data(), (size_t)in_ch},
+        avnd::span<float*>{output_ptrs.data(), (size_t)out_ch}, n_frames);
 
     // Convert back from planar to interleaved format
     float* out_samples = (float*)out_info.data;
@@ -144,13 +152,22 @@ struct element<T> : property_handler
     int sample_rate = GST_AUDIO_INFO_RATE(&audio_info);
     int frames_per_buffer = 1024; // Default, will be updated in transform()
 
+    // Size to what the object needs, not just the caps: a fixed output bus keeps
+    // its channel count regardless of the input's.
+    const int in_ch = std::max<int>(channels, avnd::input_channels<T>(channels));
+    const int out_ch = std::max<int>(channels, avnd::output_channels<T>(channels));
+
     // Initialize process adapter buffers
     avnd::process_setup setup_info{
-        .input_channels = channels,
-        .output_channels = channels,
+        .input_channels = in_ch,
+        .output_channels = out_ch,
         .frames_per_buffer = frames_per_buffer,
         .rate = (double)sample_rate};
     processor.allocate_buffers(setup_info, float{});
+
+    // Set up the effect duplicator's per-channel state and output bus channel
+    // count -- without this the object writes to unallocated output channels.
+    impl.init_channels(in_ch, out_ch);
 
     // Initialize Avendish effect
     avnd::prepare(impl, setup_info);

--- a/include/avnd/binding/gstreamer/texture_filter.hpp
+++ b/include/avnd/binding/gstreamer/texture_filter.hpp
@@ -106,6 +106,17 @@ struct element<T> : property_handler
     {
       avnd::texture_input_introspection<T>::for_all(
           inputs, [&]<typename Field>(Field& field) {
+        // This element advertises 8-bit RGBA caps (4 bytes/pixel). A float
+        // texture (float* bytes, 16 bytes/pixel) would read four times past the
+        // GStreamer buffer -> out-of-bounds. Until the caps become format-aware,
+        // skip such textures (leave bytes null so the effect early-outs) instead
+        // of crashing.
+        using px_t = std::remove_pointer_t<decltype(field.texture.bytes)>;
+        if constexpr(!std::is_same_v<px_t, unsigned char>)
+        {
+          field.texture.bytes = nullptr;
+          return;
+        }
         // CRITICAL: Ensure texture buffer is valid and accessible
         if(!in_info.data || in_info.size < expected_min_size)
         {
@@ -118,8 +129,11 @@ struct element<T> : property_handler
         // Handle stride: if buffer has padding, we need to create a tightly packed copy
         if(stride == width * 4)
         {
-          // No padding, can use buffer directly
-          field.texture.bytes = (unsigned char*)in_info.data;
+          // No padding, can use buffer directly. Cast to the field's own pixel
+          // pointer type: byte textures use `unsigned char*`, float textures
+          // (e.g. RGBA32F) use `float*`.
+          field.texture.bytes
+              = reinterpret_cast<decltype(field.texture.bytes)>(in_info.data);
         }
         else
         {
@@ -139,7 +153,8 @@ struct element<T> : property_handler
             memcpy(dst + y * width * 4, src + y * stride, width * 4);
           }
 
-          field.texture.bytes = stride_conversion_buffer.get();
+          field.texture.bytes = reinterpret_cast<decltype(field.texture.bytes)>(
+              stride_conversion_buffer.get());
           GST_DEBUG_OBJECT(
               this, "Converted strided input (%d) to tightly packed buffer", stride);
         }


### PR DESCRIPTION
Found by **running actual processing** (gst-launch pipelines) through the GStreamer elements, not just inspecting registration — a sweep that went from **4 crashes to 0**.

## 1. Compile (clang): `float*` vs `unsigned char*`
`texture_filter.hpp` cast the mapped buffer to `unsigned char*` and assigned it to `field.texture.bytes`, which is `float*` for float textures → clang error. (MSVC never reaches this — it fails earlier on a GLib macro collision; building via msys2 **clang64** compiles the binding, 92/93 plugins vs 0 on MSVC.) Cast to the field's own pointer type with `decltype`.

## 2. Crash: fixed output bus fed fewer channels
`per_bus_as_ports_fixed`, `test_audio_bus_fixed`, `oscr_Distortion` **segfaulted on the first buffer**. `set_caps` set `output_channels = input channels` and **never called `impl.init_channels()`**, so an object with a `fixed_audio_bus<…, 2>` output fed a mono stream wrote to unallocated output channels. (Same class as the Max `multichanneloutputs` bug, #127.)

Fix: size the planar buffers to `max(caps channels, the object's own in/out counts)` and call `impl.init_channels(in, out)` before `prepare()`.

## 3. Crash: float texture over 8-bit RGBA caps
`test_tex_rgba32f` read 4× past the buffer: the element advertises 8-bit RGBA caps (4 B/px) but a float texture is 16 B/px. Until the caps are made format-aware, skip non-byte textures (leave `bytes` null so the effect early-outs) instead of an OOB read.

## Validation
`audiotestsrc/videotestsrc … ! <element> ! … ! fakesink` across every built plugin:
- **before:** 4 crashes
- **after:** 0 crashes; 22 elements push audio/video through cleanly.

Pairs with #129 (needed to configure a GStreamer-only build). The 68 elements that don't register are per-sample/mono/controls-only shapes with no GStreamer element mapping (graceful, not crashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)