### PR TITLE
touchdesigner: fix crash on audio generators with multiple channel-ports

### DIFF
--- a/include/avnd/binding/touchdesigner/chop/audio_processor.hpp
+++ b/include/avnd/binding/touchdesigner/chop/audio_processor.hpp
@@ -102,8 +102,13 @@ struct audio_processor<T> : public TD::CHOP_CPlusPlusBase
       info->sampleRate = 0;
       return true;
     }
-    else if constexpr(avnd::bus_introspection<T>::output_busses == 1)
+    else if constexpr(avnd::bus_introspection<T>::output_busses >= 1)
     {
+      // TD has a single output bus with all channels concatenated, so objects
+      // with several audio channel-ports (output_busses > 1, e.g. 4 mono
+      // oscillator outputs) are handled here too -- output_channels already
+      // counts every channel across those ports. Without this they fell into
+      // the `else` below, returned false, and crashed TD on cook.
       if(inputs->getNumInputs() == 0)
       {
         if(avnd::monophonic_audio_processor<T>) {
@@ -129,7 +134,6 @@ struct audio_processor<T> : public TD::CHOP_CPlusPlusBase
 
         // Allocate buffers if supported
         avnd::prepare(implementation, setup_info);
-
 
         return true;
       }
@@ -210,11 +214,13 @@ struct audio_processor<T> : public TD::CHOP_CPlusPlusBase
       if(avnd::monophonic_audio_processor<T>)
         return;
 
-      // Prepare input/output spans for processing
+      // Prepare input/output spans for processing. TD hands us one output bus
+      // with every channel concatenated (numChannels), which for objects with
+      // several audio channel-ports is the total across ports -- NOT
+      // get_output_channels(impl, 0), which is only bus 0's count.
       const int num_samples = output->numSamples;
       const int num_in_channels = 0;
       const int num_out_channels = output->numChannels;
-      assert(num_out_channels == channels.get_output_channels(implementation, 0));
 
       float* in_ptrs[8]{0};
       auto out_ptrs = (float**) alloca(sizeof(float*) * num_out_channels + 4);


### PR DESCRIPTION
Found by the automated TD sweep (#131). `avnd_vb_fourses_tilde` (vb.fourses~ — 4 mono oscillator outputs, no input) **crashed TouchDesigner on cook**.

## Cause
Objects with several individual audio channel-ports have `bus_introspection::output_busses == 4`, but the CHOP-audio `getOutputInfo` only handled `== 0` and `== 1`; everything else hit `else { return false; }`. With no valid output info, TD crashed on cook.

TD exposes **one output bus with all channels concatenated** (the code's own FIXME says so), and `output_channels` already counts every channel across the ports — so `output_busses >= 1` should take the same path.

That then surfaced a bogus assert in `execute()`:
```cpp
assert(num_out_channels == channels.get_output_channels(implementation, 0));
```
`get_output_channels(impl, 0)` is **bus 0's** count (1), not the concatenated total (4), so `assert(4 == 1)` aborted the Debug build. (In Release the assert compiles out and the generator silently produced no output.) `num_out_channels` already comes from TD's `numChannels` (the correct total), so the assert is just wrong for multi-channel-port objects — removed.

## Result
`avnd_vb_fourses_tilde`: **crashes TouchDesigner → cooks cleanly, produces output.** TD sweep 61 → 62 ok, **0 crashes**. Same fixed-output-bus class as the Max (#127) and GStreamer (#130) fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)