### PR TITLE
touchdesigner: expose scalar value-port inputs as parameters

### DIFF
--- a/include/avnd/binding/touchdesigner/parameter_setup.hpp
+++ b/include/avnd/binding/touchdesigner/parameter_setup.hpp
@@ -33,11 +33,27 @@ struct parameter_setup
     manager = mgr;
 
     if constexpr(avnd::has_inputs<T>) {
-      // Iterate over all input fields that are parameters
+      // Widget controls (sliders, xy, colour, menus, ...) -> TD parameters.
       avnd::control_input_introspection<T>::for_all(
           avnd::get_inputs(impl),
           [this]<typename Field>(Field& field) {
             setup_parameter<Field>();
+          });
+
+      // Value-ports are parameters WITHOUT a widget (e.g. an int/float control
+      // with just a range, like an audio effect's amount). They are the natural
+      // TD parameters for those objects too, so expose the scalar ones -- else
+      // there is no way to set them (they were silently dropped, so audio
+      // effects had no adjustable controls).
+      avnd::parameter_input_introspection<T>::for_all(
+          avnd::get_inputs(impl),
+          [this]<typename Field>(Field& field) {
+            using vt = std::decay_t<decltype(Field::value)>;
+            if constexpr(
+                avnd::value_port<Field>
+                && (std::is_arithmetic_v<vt> || std::is_enum_v<vt>
+                    || avnd::string_ish<vt>))
+              setup_parameter<Field>();
           });
     }
   }

--- a/include/avnd/binding/touchdesigner/parameter_update.hpp
+++ b/include/avnd/binding/touchdesigner/parameter_update.hpp
@@ -114,6 +114,26 @@ struct parameter_update
         // Call update callback if it exists
         if_possible(field.update(implementation.effect));
       });
+
+      // Scalar value-ports are exposed as TD parameters too (see
+      // parameter_setup) -- read them back from TD the same way.
+      avnd::parameter_input_introspection<T>::for_all(
+          avnd::get_inputs(implementation),
+          [&]<typename Field>(Field& field) {
+        using vt = std::decay_t<decltype(Field::value)>;
+        if constexpr(
+            avnd::value_port<Field>
+            && (std::is_arithmetic_v<vt> || std::is_enum_v<vt>
+                || avnd::string_ish<vt>))
+        {
+          static constexpr auto name = touchdesigner::get_td_name<Field>();
+          if constexpr(avnd::enum_ish_parameter<Field>)
+            this->update_enum(field, name.data(), inputs);
+          else
+            this->update(field, name.data(), inputs);
+          if_possible(field.update(implementation.effect));
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Found by the golden differential (#134): **audio effects had no adjustable controls in TouchDesigner.**

## Cause
An input like an effect's amount — `int value` with a range but **no widget** — is a **value-port** (`avnd::value_port = parameter_port && !control_port`). The TD binding built its parameters from `control_input_introspection` (widget controls only), so value-ports were **silently dropped**. Minimal's `Grunge`, Presets' `Preamp`/`Volume`, the per-sample `Gain`, etc. simply weren't parameters — you couldn't set them, and the effect always ran with the default.

## Fix
`parameter_setup` now also walks `parameter_input_introspection` and creates a TD parameter for every **scalar** value-port (arithmetic / enum / string); the matching `parameter_update` reads them back into the object each cook. Additive and safe:
- widget controls are untouched (`value_port` excludes `control_port`, so no double-append),
- aggregate value-ports (vectors/maps/…) are skipped — TD has no parameter kind for those.

## Result
With the controls settable, `Minimal` / `Presets` / `PerSampleProcessor{,2}` / `ZeroDependencyAudioEffect` went from **MISMATCH to matching the raw-C++ golden oracle** (overall differential match 46 → 50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)