### PR TITLE
touchdesigner: run message objects once per cook + fire impulses only on pulse

### DIFF
--- a/include/avnd/binding/touchdesigner/chop/message_processor.hpp
+++ b/include/avnd/binding/touchdesigner/chop/message_processor.hpp
@@ -328,7 +328,14 @@ struct message_processor<T> : public TD::CHOP_CPlusPlusBase
     info->cookEveryFrameIfAsked = true;
     info->inputMatchIndex = 0;
     info->timeslice = false;
+  }
 
+  // Read inputs and run the object. MUST be called once per cook (from
+  // execute()), NOT from getGeneralInfo -- TD calls getGeneralInfo several times
+  // per cook, so running the effect there advanced stateful objects (counters,
+  // oscillators, RNG) multiple times; stateless ones were merely idempotent.
+  void run_effect(const TD::OP_Inputs* inputs)
+  {
     // Update parameter values from TouchDesigner
     update_controls(inputs);
 
@@ -380,7 +387,6 @@ struct message_processor<T> : public TD::CHOP_CPlusPlusBase
       int frames = 0;
     } t{.frames = (int) ti->deltaFrames};
 
-    // Copy outputs in their respective channels
     invoke_effect(implementation, t);
   }
 
@@ -461,6 +467,9 @@ struct message_processor<T> : public TD::CHOP_CPlusPlusBase
 
   void execute(TD::CHOP_Output* output, const TD::OP_Inputs* inputs, void* reserved) override
   {
+    // Run the object exactly once per cook (see run_effect).
+    run_effect(inputs);
+
     if(output->numSamples <= 0)
       return;
 

--- a/include/avnd/binding/touchdesigner/parameter_update.hpp
+++ b/include/avnd/binding/touchdesigner/parameter_update.hpp
@@ -304,7 +304,11 @@ struct parameter_update
   template <typename Field>
   void update(Field& field, const char* name, const TD::OP_Inputs* inputs)
   {
-    pulse(field, name);
+    // Generic fallback (e.g. impulse_button -> TD pulse parameter). An impulse
+    // must engage ONLY when its pulse is actually clicked -- that happens via
+    // the onPulse callback (message_processor -> parameter_update::pulse()).
+    // The per-cook update must NOT engage it, otherwise the impulse fires on
+    // every single cook (a counter driven by it increments forever).
   }
 
   // NOTE: file_port / soundfile_port / midifile_port are handled by


### PR DESCRIPTION
Two related CHOP_MESSAGE binding bugs, found by the golden differential (#134) on `avnd_test_impulse` (a bang → counter: TD read `Count=3`, the raw-C++ oracle `Count=0`).

## Bug 1 — the object ran multiple times per cook
`message_processor::getGeneralInfo` — a **metadata** callback TD invokes several times per cook — called `invoke_effect`, i.e. ran the object's `operator()`. Proven by the op's own `total_cooks` info channel: **`total_cooks = 1`** (one `execute`) yet `operator()` ran **3×**. This mis-advances **every stateful object** (counters, oscillators, RNG); stateless ones were merely idempotent, so it hid. Moved the input-read + run into `run_effect()`, called **once** from `execute()`; `getGeneralInfo` is now metadata-only. (`audio_processor` was already correct — it runs in `execute()`.)

## Bug 2 — impulses fired on every cook
The generic per-cook `update()` fallback called `pulse(field, name)`, and `pulse()` for an optional-valued port (`impulse_button`) does `field.value = {std::in_place}` — **engaging it every cook**. So a bang fired on every frame instead of only when clicked. Impulses must engage solely via the `onPulse` callback (already wired at `message_processor → parameter_update::pulse`); the per-cook `update` must not. Emptied the generic `update` fallback.

## Result
`avnd_test_impulse` `Count` **3 → 0** (matches the oracle); differential match **50 → 51**. Beyond the test: stateful message objects no longer advance N× per cook, and bang/impulse buttons no longer trigger continuously in normal TD use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)