### PR TITLE
touchdesigner: make value-port inputs optional (cook standalone from parameter)

### DIFF
--- a/include/avnd/binding/touchdesigner/chop/message_processor.hpp
+++ b/include/avnd/binding/touchdesigner/chop/message_processor.hpp
@@ -347,8 +347,11 @@ struct message_processor<T> : public TD::CHOP_CPlusPlusBase
           avnd::get_inputs(implementation),
           [&]<typename Field, std::size_t P, std::size_t I>(Field& field, avnd::predicate_index<P> pred_idx, avnd::field_index<I>) {
 
+        // Value-port inputs are optional (they double as parameters), so the
+        // connector may be unconnected -> getInputCHOP returns null. Guard it;
+        // when absent the parameter value set by update_controls is used.
         auto chop_in = inputs->getInputCHOP(P);
-        if(chop_in->numChannels > 0)
+        if(chop_in && chop_in->numChannels > 0)
         {
           if(chop_in->numSamples > 0)
           {

--- a/include/avnd/binding/touchdesigner/configure.hpp
+++ b/include/avnd/binding/touchdesigner/configure.hpp
@@ -139,9 +139,15 @@ inline void configure_opInfo(TD::OP_CustomOPInfo& op, std::string_view nm, std::
   }
   else if(optype == "CHOP_MESSAGE")
   {
-    op.minInputs = avnd::value_port_input_introspection<type>::size
+    // Value-port inputs are OPTIONAL: each also surfaces as a parameter
+    // (parameter_setup), so the object cooks standalone from the parameter and a
+    // connected CHOP overrides it (run_effect reads the parameter, then the
+    // input CHOP only when one is connected). Matches native TD generators
+    // (Constant/Pattern/...) which cook from parameters with minInputs == 0.
+    // Tensor inputs have no parameter fallback, so they stay mandatory.
+    op.minInputs = avnd::tensor_port_input_introspection<type>::size;
+    op.maxInputs = avnd::value_port_input_introspection<type>::size
                  + avnd::tensor_port_input_introspection<type>::size;
-    op.maxInputs = op.minInputs;
   }
   else if(optype == "TOP")
   {
@@ -150,9 +156,10 @@ inline void configure_opInfo(TD::OP_CustomOPInfo& op, std::string_view nm, std::
   }
   else if(optype == "DAT")
   {
-    op.minInputs = avnd::value_port_input_introspection<type>::size
+    // Value-port inputs optional (parameter fallback); tensor inputs mandatory.
+    op.minInputs = avnd::tensor_port_input_introspection<type>::size;
+    op.maxInputs = avnd::value_port_input_introspection<type>::size
                  + avnd::tensor_port_input_introspection<type>::size;
-    op.maxInputs = op.minInputs;
   }
   else if(optype == "SOP")
   {


### PR DESCRIPTION
Follow-up to the value-port parameter work merged in the previous PR. Branched off current `main`.

## Problem
Value-port inputs also surface as parameters, but the binding still declared them as **required** inputs (`minInputs == value-port count`, the `// FIXME` in `configure.hpp`). So an object couldn't cook unless a CHOP was wired to every value input — TD reported **"Not enough sources specified"**, and the parameter was effectively useless for standalone use.

## Why optional is the TD-idiomatic choice
Native TD keeps *inputs* (data being processed) and *parameters* (how to process) separate; the same value is not both a **required** input and a parameter. Generators (Constant/Pattern/LFO) cook from their parameters with `minInputs == 0`; an optional input overrides the parameter when connected (Speed/Env CHOP). An avendish `val_float` is conceptually a Constant CHOP.

## Change
- **`configure.hpp`** (CHOP_MESSAGE, DAT): `minInputs` now counts only tensor inputs (which have no parameter fallback); `maxInputs` still allows the value-port inputs. A value-port input becomes optional — cook from the parameter, override with a connected CHOP. `run_effect` already reads the parameter first, then the input only when present, so override-when-connected already works.
- **`message_processor::run_effect`**: null-check `getInputCHOP(P)`. With optional inputs the connector can be unconnected (`getInputCHOP` → null); the old code dereferenced it unconditionally and crashed. The tensor loop already guarded this — the value-port loop didn't.

## Verification (golden differential)
Value-IO objects (`val_float/bool/int/string`, `test_bypass`, `test_smooth`, `TrivialFilter`, …) go from "Not enough sources" to cooking standalone with correct output (`val_float` In=0.5 → Out=0.5). **TD match 45 → 54, no new crashes.**

Note: `avnd_essentia_entropy` still crashes TD, but that is pre-existing and unrelated to this change (an Essentia-library object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)