### PR TITLE
clap: export the entry point as clap_entry, not clap_plugin_entry

### DIFF
--- a/include/avnd/binding/clap/prototype.cpp.in
+++ b/include/avnd/binding/clap/prototype.cpp.in
@@ -8,7 +8,8 @@
 using plug_type = decltype(avnd::configure<avnd_clap::config, @AVND_MAIN_CLASS@>())::type;
 using effect_type = avnd_clap::SimpleAudioEffect<plug_type>;
 
-AVND_EXPORTED_SYMBOL extern const struct clap_plugin_entry clap_plugin_entry = {
+// clap_entry is the symbol hosts look up (see clap/entry.h).
+AVND_EXPORTED_SYMBOL extern const struct clap_plugin_entry clap_entry = {
    CLAP_VERSION,
    +[] (const char* path) -> bool { /* init */ return true; },
    +[] () { /* deinit */ },


### PR DESCRIPTION
Rename the exported CLAP entry point from `clap_plugin_entry` to `clap_entry`, matching the `extern "C"` declaration in `clap/entry.h` — that is the symbol hosts `dlsym`/`GetProcAddress`.

Now a single concern: the unrelated soft-UI wiring that was previously bundled here has been moved to #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)