### PR TITLE
clap: fix input-event processing for MIDI-less plug-ins + out_N channel count

### DIFF
--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -268,7 +268,7 @@ struct SimpleAudioEffect : clap_plugin
     // Process the audio
     {
       int in_N = avnd::input_channels<T>(2);
-      int out_N = avnd::input_channels<T>(2);
+      int out_N = avnd::output_channels<T>(2);
 
       if constexpr(avnd::float_processor<T>)
       {

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -15,6 +15,8 @@
 #include <avnd/wrappers/widgets.hpp>
 #include <clap/all.h>
 
+#include <algorithm>
+
 namespace avnd_clap
 {
 template <typename T>
@@ -272,15 +274,21 @@ struct SimpleAudioEffect : clap_plugin
 
       if constexpr(avnd::float_processor<T>)
       {
-        auto inputs = (float**)alloca(sizeof(float*) * in_N);
-        auto outputs = (float**)alloca(sizeof(float*) * out_N);
+        auto inputs = (float**)alloca(sizeof(float*) * std::max(in_N, 1));
+        auto outputs = (float**)alloca(sizeof(float*) * std::max(out_N, 1));
+        // Null the slots so the zero-filled-channels invariant substitutes
+        // silent buffers rather than the effect dereferencing garbage.
+        std::fill_n(inputs, in_N, nullptr);
+        std::fill_n(outputs, out_N, nullptr);
 
         process_impl<&clap_audio_buffer::data32>(process, inputs, in_N, outputs, out_N);
       }
       else if constexpr(avnd::double_processor<T>)
       {
-        auto inputs = (double**)alloca(sizeof(double*) * in_N);
-        auto outputs = (double**)alloca(sizeof(double*) * out_N);
+        auto inputs = (double**)alloca(sizeof(double*) * std::max(in_N, 1));
+        auto outputs = (double**)alloca(sizeof(double*) * std::max(out_N, 1));
+        std::fill_n(inputs, in_N, nullptr);
+        std::fill_n(outputs, out_N, nullptr);
 
         process_impl<&clap_audio_buffer::data64>(process, inputs, in_N, outputs, out_N);
       }

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -333,60 +333,67 @@ struct SimpleAudioEffect : clap_plugin
 
   void process_in_events(const clap_process& p)
   {
-    if constexpr(midi_in_info::size > 0)
+    // Parameter and transport events apply to every plug-in; only the MIDI
+    // cases depend on having MIDI inputs.
+    auto N = p.in_events->size(p.in_events);
+
+    for(uint32_t i = 0; i < N; i++)
     {
-      auto N = p.in_events->size(p.in_events);
+      const clap_event_header_t* ev = p.in_events->get(p.in_events, i);
 
-      for(uint32_t i = 0; i < N; i++)
+      switch(ev->type)
       {
-        const clap_event_header_t* ev = p.in_events->get(p.in_events, i);
-
-        switch(ev->type)
-        {
-          case CLAP_EVENT_NOTE_ON:
-          case CLAP_EVENT_NOTE_OFF: {
+        case CLAP_EVENT_NOTE_ON:
+        case CLAP_EVENT_NOTE_OFF: {
+          if constexpr(midi_in_info::size > 0)
+          {
             midi_in_info::for_nth_mapped(
                 controls_inputs(), ((clap_event_note_t*)ev)->port_index,
                 [&]<typename C>(C& in_port) {
               midi.add_message(in_port, *(clap_event_note_t*)ev);
             });
-            break;
           }
-          case CLAP_EVENT_MIDI: {
+          break;
+        }
+        case CLAP_EVENT_MIDI: {
+          if constexpr(midi_in_info::size > 0)
+          {
             midi_in_info::for_nth_mapped(
                 controls_inputs(), ((clap_event_midi_t*)ev)->port_index,
                 [&]<typename C>(C& in_port) {
               midi.add_message(in_port, *(clap_event_midi_t*)ev);
             });
-            break;
           }
-          case CLAP_EVENT_MIDI_SYSEX: {
+          break;
+        }
+        case CLAP_EVENT_MIDI_SYSEX: {
+          if constexpr(midi_in_info::size > 0)
+          {
             midi_in_info::for_nth_mapped(
                 controls_inputs(), ((clap_event_midi_sysex_t*)ev)->port_index,
                 [&]<typename C>(C& in_port) {
               midi.add_message(in_port, *(clap_event_midi_sysex_t*)ev);
             });
-            break;
-          }
-
-          case CLAP_EVENT_PARAM_VALUE: {
-            process_param(*((clap_event_param_value_t*)ev));
-            break;
           }
           break;
-          case CLAP_EVENT_PARAM_MOD:
-            break;
-          case CLAP_EVENT_TRANSPORT: {
-            process_transport(*((clap_event_transport_t*)ev));
-            break;
-          }
-          case CLAP_EVENT_NOTE_CHOKE:
-          case CLAP_EVENT_NOTE_EXPRESSION:
-          case CLAP_EVENT_NOTE_END:
-          default:
-            // TODO
-            break;
         }
+
+        case CLAP_EVENT_PARAM_VALUE: {
+          process_param(*((clap_event_param_value_t*)ev));
+          break;
+        }
+        case CLAP_EVENT_PARAM_MOD:
+          break;
+        case CLAP_EVENT_TRANSPORT: {
+          process_transport(*((clap_event_transport_t*)ev));
+          break;
+        }
+        case CLAP_EVENT_NOTE_CHOKE:
+        case CLAP_EVENT_NOTE_EXPRESSION:
+        case CLAP_EVENT_NOTE_END:
+        default:
+          // TODO
+          break;
       }
     }
   }


### PR DESCRIPTION
Two bugs in `SimpleAudioEffect::process` found while adding the CLAP editor support on the `avendish-ui` branch:

1. **Host automation was silently ignored for plug-ins without MIDI inputs.** The entire input-event loop in `process_in_events()` was inside `if constexpr(midi_in_info::size > 0)`, so `CLAP_EVENT_PARAM_VALUE` and `CLAP_EVENT_TRANSPORT` were only handled when the plug-in happened to declare a MIDI input. The loop now runs unconditionally and only the MIDI cases are gated on `midi_in_info::size > 0`. (Also removes a stray duplicated `break;`.)

2. **`out_N` was computed with `input_channels`** instead of `output_channels` — a copy-paste slip that sized the output pointer array with the input channel count, wrong for asymmetric layouts (mono-in/stereo-out and the like).

Verified by building every example `.clap` target with clang-cl (covers both template branches: MIDI-less plug-ins now instantiate the always-on event loop, MIDI plug-ins still compile the gated cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zm2k4dsLp2jMa47zyLcSZ