### PR TITLE
wrappers: always hand the effect zero-filled channels (never null)

### DIFF
--- a/include/avnd/wrappers/process/base.hpp
+++ b/include/avnd/wrappers/process/base.hpp
@@ -17,7 +17,16 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-// #define AVND_ENABLE_SAFE_BUFFER_STORAGE 1
+
+// The effect must always receive valid, zero-filled channel buffers. When a host
+// supplies fewer channels than the object declares (e.g. an unconnected input),
+// the missing channels must point at silent scratch buffers -- otherwise the
+// effect dereferences a null channel pointer and crashes. This is a core
+// invariant, so it is on by default; define AVND_ENABLE_SAFE_BUFFER_STORAGE=0
+// before including to opt out.
+#ifndef AVND_ENABLE_SAFE_BUFFER_STORAGE
+#define AVND_ENABLE_SAFE_BUFFER_STORAGE 1
+#endif
 namespace avnd
 {
 


### PR DESCRIPTION
Extracted from the `avendish-ui` branch so it can land independently (it is unrelated to the UI work it was riding on).

The process adapters (`process/` and `process_bus/`, per-channel and poly) already had storage to point missing channels at silent scratch buffers, but it was gated behind a commented-out `AVND_ENABLE_SAFE_BUFFER_STORAGE`. By default, a host supplying fewer channels than the object declares left `bus.channel = nullptr` — any effect that dereferences its channel then crashes. An effect must always receive valid, zero-filled channel buffers.

This enables the safe buffer storage by default; opt out with `-DAVND_ENABLE_SAFE_BUFFER_STORAGE=0`. `process_bus/base.hpp` includes `process/base.hpp`, so one definition covers every backend.

Verified: full build (examples across enabled backends) + the 100-test suite passing with clang-cl on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zm2k4dsLp2jMa47zyLcSZ