### PR TITLE
controls: make the port-level map_control_to_01 overload reachable

### DIFF
--- a/include/avnd/wrappers/controls.hpp
+++ b/include/avnd/wrappers/controls.hpp
@@ -283,8 +283,12 @@ static constexpr auto map_control_to_01(const auto& value) = delete;
 //   static_assert(std::is_void_v<T>, "Error: unhandled control type");
 // }
 
+// Note: the value-level overloads above cannot deduce T, so the constraint
+// must pass it explicitly -- with the unqualified form this overload was
+// unsatisfiable and every caller's `requires { map_control_to_01(ctl); }`
+// silently evaluated to false.
 template <avnd::parameter_port T>
-  requires requires(T t) { map_control_to_01(t.value); }
+  requires requires(T t) { map_control_to_01<T>(t.value); }
 static constexpr auto map_control_to_01(const T& ctl)
 {
   return map_control_to_01<T>(ctl.value);


### PR DESCRIPTION
The port-level convenience overload

```cpp
template <avnd::parameter_port T>
  requires requires(T t) { map_control_to_01(t.value); }
static constexpr auto map_control_to_01(const T& ctl)
```

constrained itself with an unqualified `map_control_to_01(t.value)` — but `T` is non-deducible in every value-level overload, so that expression can never resolve and the constraint is unsatisfiable. Consequences:

- `avnd::map_control_to_01(ctl)` never participated in overload resolution, and every caller guarding with `requires { map_control_to_01(ctl); }` silently got `false`.
- Concretely, `vintage::Controls::read()` never initialized the atomic parameter mirror: VST2 hosts read 0 as the initial value of every parameter.

Fix: pass `T` explicitly in the constraint, matching what the body already does. Verified with a minimal reachability check (`static_assert(requires(halp::knob_f32<...> c) { avnd::map_control_to_01(c); })` fails before, passes after) plus the full build and 100-test suite on main. Found via the VST2 editor host test on the `avendish-ui` branch, where `getParameter` returned 0 for a control initialized to 0.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zm2k4dsLp2jMa47zyLcSZ