### PR TITLE
concepts: make ui.hpp self-contained (missing <utility>)

### DIFF
--- a/include/avnd/concepts/ui.hpp
+++ b/include/avnd/concepts/ui.hpp
@@ -2,6 +2,8 @@
 
 /* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
 
+#include <utility>
+
 namespace avnd
 {
 


### PR DESCRIPTION
`avnd/concepts/ui.hpp` uses `std::declval` but does not include `<utility>`, so it only compiles when another header happened to pull it in first. Surfaced by a new include order on the `avendish-ui` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zm2k4dsLp2jMa47zyLcSZ