### PR TITLE
concepts: fix range detection for nested range types on MSVC/clang-cl

### DIFF
--- a/include/avnd/concepts/parameter.hpp
+++ b/include/avnd/concepts/parameter.hpp
@@ -23,16 +23,16 @@ namespace avnd
 
 #if defined(_MSC_VER)
 
-#define AVND_REQUIREMENT_ON_MEMBER(Field, Member, Requirement)   \
-  (                                                              \
-      requires { Field::Member().Requirement; }                  \
-      || requires { std::declval<Field::Member>().Requirement; } \
+#define AVND_REQUIREMENT_ON_MEMBER(Field, Member, Requirement)            \
+  (                                                                       \
+      requires { Field::Member().Requirement; }                           \
+      || requires { std::declval<typename Field::Member>().Requirement; } \
       || requires { Field::Member.Requirement; })
 
 #define AVND_CONCEPT_CHECK_ON_MEMBER(Concept, Field, Member, Requirement) \
   (Concept<decltype(Field::Member().Requirement)>                         \
    || Concept<decltype(Field::Member.Requirement)>                        \
-   || Concept<decltype(std::declval<Field::Member>().Requirement)>)
+   || Concept<decltype(std::declval<typename Field::Member>().Requirement)>)
 #else
 
 #define AVND_REQUIREMENT_ON_MEMBER(Field, Member, Requirement) \


### PR DESCRIPTION
The `_MSC_VER` variant of `AVND_REQUIREMENT_ON_MEMBER` used `std::declval<Field::Member>()` without `typename`, so nested range structs (`struct range { const T min = ...; }` — the shape every halp slider/knob uses) never satisfied `parameter_with_minmax_range` on Windows builds. The non-MSVC branch already handles this case via `(typename Field::Member){}`.

Consequence: `map_control_to_01`/`from_01` silently fell through to the identity mapping on MSVC/clang-cl — e.g. a stock `hslider_i32` (range 0..127) reported `defaultNormalizedValue = 64` to VST3 hosts, and normalized parameter I/O was wrong for every non-[0,1] control. Caught by running the Steinberg VST3 validator over all example plug-ins (60+ affected); after the fix the validator's parameter tests pass.

Fix: use `std::declval<typename Field::Member>()` in both macros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zm2k4dsLp2jMa47zyLcSZ