### PR TITLE
clap: conformance fixes found by clap-validator

### DIFF
--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -475,10 +475,11 @@ struct SimpleAudioEffect : clap_plugin
   {
     static constexpr bool midi_ins = avnd::midi_input_introspection<T>::size > 0;
     static constexpr bool midi_outs = avnd::midi_output_introspection<T>::size > 0;
-    static constexpr bool audio_ins
-        = avnd::audio_channel_input_introspection<T>::size > 0;
+    // Bus counts, not channel-port counts: bus-typed audio I/O
+    // (dynamic_audio_bus etc.) must classify too.
+    static constexpr bool audio_ins = avnd_clap::audio_bus_info<T>::input_count() > 0;
     static constexpr bool audio_outs
-        = avnd::audio_channel_output_introspection<T>::size > 0;
+        = avnd_clap::audio_bus_info<T>::output_count() > 0;
     static constexpr bool instrument = midi_ins && audio_outs;
     static constexpr bool audio_fx = audio_ins && audio_outs;
     static constexpr bool analyzer = audio_ins && !audio_outs;
@@ -493,14 +494,16 @@ struct SimpleAudioEffect : clap_plugin
           audio_fx ? CLAP_PLUGIN_FEATURE_AUDIO_EFFECT : 0, 0};
     else if constexpr(audio_fx)
       return std::array<const char*, 2>{CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, 0};
-    else if constexpr(analyzer)
-      return std::array<const char*, 2>{CLAP_PLUGIN_FEATURE_NOTE_EFFECT, 0};
-    else if constexpr(note_fx)
-      return std::array<const char*, 2>{CLAP_PLUGIN_FEATURE_NOTE_DETECTOR, 0};
     else if constexpr(note_detector)
+      return std::array<const char*, 2>{CLAP_PLUGIN_FEATURE_NOTE_DETECTOR, 0};
+    else if constexpr(analyzer)
       return std::array<const char*, 2>{CLAP_PLUGIN_FEATURE_ANALYZER, 0};
+    else if constexpr(note_fx)
+      return std::array<const char*, 2>{CLAP_PLUGIN_FEATURE_NOTE_EFFECT, 0};
     else
-      return std::array<const char*, 1>{0};
+      // Parameter-only utility objects: hosts require one of the main
+      // categories; audio-effect is the least wrong.
+      return std::array<const char*, 2>{CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, 0};
   }
   static constexpr auto features = get_features();
   static constexpr clap_plugin_descriptor descriptor{

--- a/include/avnd/binding/clap/prototype.cpp.in
+++ b/include/avnd/binding/clap/prototype.cpp.in
@@ -16,7 +16,12 @@ AVND_EXPORTED_SYMBOL extern const struct clap_plugin_entry clap_plugin_entry = {
       static constexpr const clap_plugin_factory factory {
         .get_plugin_count = +[] (const struct clap_plugin_factory *factory) -> uint32_t { /* count */ return 1; }
       , .get_plugin_descriptor =  +[] (const struct clap_plugin_factory *factory, uint32_t) -> const clap_plugin_descriptor* { return &effect_type::descriptor; }
-      , .create_plugin = +[] (const struct clap_plugin_factory *factory, const clap_host_t *host, const char *plugin_id) -> const clap_plugin_t* { return new effect_type{host}; }
+      , .create_plugin = +[] (const struct clap_plugin_factory *factory, const clap_host_t *host, const char *plugin_id) -> const clap_plugin_t* {
+          // Hosts probe with arbitrary IDs; only answer to ours.
+          if(!plugin_id || strcmp(plugin_id, effect_type::descriptor.id) != 0)
+            return nullptr;
+          return new effect_type{host};
+        }
       };
       if(!strcmp(factory_id,CLAP_PLUGIN_FACTORY_ID))
         return &factory;


### PR DESCRIPTION
Running [clap-validator](https://github.com/free-audio/clap-validator) over every example plug-in flagged two universal failures:

1. **`create_plugin` ignored the requested plugin ID** — hosts probe factories with arbitrary IDs and expect `nullptr` for unknown ones; we instantiated unconditionally.
2. **Feature categories were empty or wrong**: audio I/O was classified with channel-port introspection only, so bus-typed plug-ins (`dynamic_audio_bus`, ...) reported no main CLAP category at all; additionally the analyzer / note-effect / note-detector labels were rotated by one (each returned the next one's constant). Parameter-only utility objects now fall back to `audio-effect` so hosts get a required main category.

After this (plus #141 and the MSVC range-concept fix), 53 of 85 example `.clap`s pass clap-validator fully; the remainder fail processing-crash tests tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zm2k4dsLp2jMa47zyLcSZ