### PR TITLE
packaging: ship the generated help patch in Max/Pd single-object packages

### DIFF
--- a/cmake/avendish.max.cmake
+++ b/cmake/avendish.max.cmake
@@ -345,6 +345,21 @@ function(avnd_create_max_package)
       )
     endif()
 
+    # Max looks for the help patch in <package>/help/<name>.maxhelp.
+    # Best-effort: it may be absent on some toolchains, so don't fail packaging.
+    get_target_property(_maxhelp ${_external} AVND_MAX_HELP)
+    if(_maxhelp)
+      if(TARGET "${_external}_help")
+        add_dependencies("${_external}" "${_external}_help")
+      endif()
+      get_property(_pkgdir GLOBAL PROPERTY AVND_PACKAGING_DIR)
+      add_custom_command(TARGET ${_external} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+          "-DSRC=${CMAKE_BINARY_DIR}/${_maxhelp}" "-DDST=${_pkg}/help"
+          -P "${_pkgdir}/avendish.packaging.copy_optional.cmake"
+        VERBATIM)
+    endif()
+
 
     # Copy the external (fairly platform-specific)
     if(WIN32)

--- a/cmake/avendish.pd.cmake
+++ b/cmake/avendish.pd.cmake
@@ -190,6 +190,21 @@ function(avnd_create_pd_package)
     add_custom_command(TARGET ${_external} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy "${_external_bin}" "${_pkg}/"
     )
+
+    # Pd opens <c_name>-help.pd from the external's own folder.
+    # Best-effort: it may be absent on some toolchains, so don't fail packaging.
+    get_target_property(_pd_help ${_external} AVND_PD_HELP)
+    if(_pd_help)
+      if(TARGET "${_external}_help")
+        add_dependencies("${_external}" "${_external}_help")
+      endif()
+      get_property(_pkgdir GLOBAL PROPERTY AVND_PACKAGING_DIR)
+      add_custom_command(TARGET ${_external} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+          "-DSRC=${CMAKE_BINARY_DIR}/${_pd_help}" "-DDST=${_pkg}"
+          -P "${_pkgdir}/avendish.packaging.copy_optional.cmake"
+        VERBATIM)
+    endif()
   endforeach()
 
   # Copy the support files


### PR DESCRIPTION
Split out of the former channel-safety mega-PR (#143).

Copy the interactive help patch into each single-object package so the host finds it:
- Max searches `<package>/help/<name>.maxhelp`
- Pd opens `<c_name>-help.pd` from the external's own folder

Both are best-effort — the help patch may be absent on some toolchains and must not fail packaging. Consumes the `AVND_MAX_HELP` / `AVND_PD_HELP` target properties and the `copy_optional.cmake` helper already in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)