### PR TITLE
clap: wire the soft-UI implementation into the plug-in entry point

### DIFF
--- a/include/avnd/binding/clap/prototype.cpp.in
+++ b/include/avnd/binding/clap/prototype.cpp.in
@@ -4,6 +4,11 @@
 #include <avnd/binding/clap/audio_effect.hpp>
 #include <avnd/binding/clap/configure.hpp>
 
+#if defined(AVND_CLAP_UI)
+// Emit the Nuklear + canvas_ity implementations exactly once per plug-in.
+#include <avnd/binding/ui/soft/implementation.hpp>
+#endif
+
 // clang-format off
 using plug_type = decltype(avnd::configure<avnd_clap::config, @AVND_MAIN_CLASS@>())::type;
 using effect_type = avnd_clap::SimpleAudioEffect<plug_type>;


### PR DESCRIPTION
**Draft — part of the custom-UI effort, not yet enable-able.**

Split out of the clap entry-symbol fix (#140), which had bundled this unrelated change. When `AVND_CLAP_UI` is defined, `prototype.cpp.in` emits the Nuklear + canvas_ity soft-UI implementation exactly once per plug-in.

Kept as a draft because nothing defines `AVND_CLAP_UI` yet — it belongs with the broader custom-UI work (see `CUSTOM_UI_PLAN.md`). Parked here so the change isn't lost and stays a single concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)