### PR TITLE
Backend conformance & build fixes (CLAP/VST2/VST3) — fixes #153, part of #154

### DIFF
--- a/cmake/avendish.clap.cmake
+++ b/cmake/avendish.clap.cmake
@@ -8,6 +8,24 @@ endif()
 
 find_path(CLAP_HEADER NAMES clap/clap.h)
 if(NOT CLAP_HEADER)
+  # The CLAP "SDK" is a set of plain C headers: fetch them when absent.
+  include(FetchContent)
+  FetchContent_Declare(
+    avnd_clap_headers
+    GIT_REPOSITORY "https://github.com/free-audio/clap"
+    GIT_TAG 1.2.6
+    GIT_PROGRESS true
+  )
+  FetchContent_GetProperties(avnd_clap_headers)
+  if(NOT avnd_clap_headers_POPULATED)
+    FetchContent_Populate(avnd_clap_headers)
+  endif()
+  if(EXISTS "${avnd_clap_headers_SOURCE_DIR}/include/clap/clap.h")
+    set(CLAP_HEADER "${avnd_clap_headers_SOURCE_DIR}/include" CACHE PATH "clap headers" FORCE)
+  endif()
+endif()
+
+if(NOT CLAP_HEADER)
   message(STATUS "Clap not found, skipping bindings...")
 
   function(avnd_make_clap)

--- a/cmake/avendish.dependencies.cmake
+++ b/cmake/avendish.dependencies.cmake
@@ -1,6 +1,9 @@
 include(FetchContent)
 
 if(NOT TARGET fmt::fmt AND NOT TARGET fmt::fmt_header_only)
+  # fmt >= 12 auto-enables its C++-modules target when CMake supports it and
+  # then hard-requires a module-scanning toolchain; we never want that here.
+  set(FMT_MODULE OFF CACHE BOOL "Build fmt as a C++ module")
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY "https://github.com/fmtlib/fmt"

--- a/cmake/avendish.vst3.cmake
+++ b/cmake/avendish.vst3.cmake
@@ -7,6 +7,32 @@ if(DEFINED AVND_ENABLE_VST3 AND NOT AVND_ENABLE_VST3)
 endif()
 
 set(VST3_SDK_ROOT "" CACHE PATH "VST3 SDK path")
+option(AVND_FETCH_VST3_SDK "Fetch the VST3 SDK when VST3_SDK_ROOT is not set" OFF)
+
+if(NOT VST3_SDK_ROOT AND AVND_FETCH_VST3_SDK)
+  include(FetchContent)
+  FetchContent_Declare(
+    avnd_vst3sdk
+    GIT_REPOSITORY "https://github.com/steinbergmedia/vst3sdk"
+    GIT_TAG v3.7.14_build_55
+    GIT_SUBMODULES base cmake pluginterfaces public.sdk
+    GIT_PROGRESS true
+  )
+  FetchContent_GetProperties(avnd_vst3sdk)
+  if(NOT avnd_vst3sdk_POPULATED)
+    FetchContent_Populate(avnd_vst3sdk)
+  endif()
+  if(EXISTS "${avnd_vst3sdk_SOURCE_DIR}/pluginterfaces/base/funknown.h")
+    set(VST3_SDK_ROOT "${avnd_vst3sdk_SOURCE_DIR}" CACHE PATH "VST3 SDK path" FORCE)
+    # Plug-in library only: no samples, hosting tools, validator or vstgui
+    set(SMTG_ENABLE_VST3_PLUGIN_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(SMTG_ENABLE_VST3_HOSTING_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(SMTG_ENABLE_VSTGUI_SUPPORT OFF CACHE BOOL "" FORCE)
+    set(SMTG_CREATE_PLUGIN_LINK OFF CACHE BOOL "" FORCE)
+    set(SMTG_RUN_VST_VALIDATOR OFF CACHE BOOL "" FORCE)
+  endif()
+endif()
+
 if(NOT VST3_SDK_ROOT)
   function(avnd_make_vst3)
   endfunction()
@@ -52,6 +78,14 @@ if(MSVC AND (AVND_ENABLE_MAX
 endif()
 
 add_subdirectory("${VST3_SDK_ROOT}" "${CMAKE_BINARY_DIR}/vst3_sdk")
+
+# The SDK's `base` target uses pluginterfaces symbols (FUID, FUnknown, ...)
+# but never declares the dependency; with a single-pass linker (GNU ld) base
+# then ends up after pluginterfaces on the link line and the plug-ins ship
+# with undefined Steinberg::FUID::* symbols. Declare it for them.
+if(TARGET base AND TARGET pluginterfaces)
+  target_link_libraries(base PUBLIC pluginterfaces)
+endif()
 
 function(avnd_make_vst3)
   cmake_parse_arguments(AVND "" "TARGET;MAIN_FILE;MAIN_CLASS;C_NAME" "" ${ARGN})

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -12,6 +12,7 @@
 #include <avnd/wrappers/controls_double.hpp>
 #include <avnd/wrappers/controls_storage.hpp>
 #include <avnd/wrappers/metadatas.hpp>
+#include <avnd/wrappers/prepare.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 #include <avnd/wrappers/widgets.hpp>
 #include <clap/all.h>
@@ -196,40 +197,9 @@ struct SimpleAudioEffect : clap_plugin
       avnd::init_controls(effect);
     }
 
-    wire_effect_callbacks();
-  }
-
-  // Host-callback members on the effect must never be left as empty
-  // std::functions: calling one terminates the process under
-  // -fno-exceptions (bad_function_call cannot unwind).
-  void wire_effect_callbacks()
-  {
-    // Workers offload a job to the host; CLAP has no generic offloading
-    // hook wired here yet, so run the job inline (same result, no
-    // background thread).
-    if constexpr(avnd::has_worker<T>)
-    {
-      for(auto& impl : effect.effects())
-      {
-        using worker_t = std::decay_t<decltype(impl.worker)>;
-        impl.worker.request = [](auto&&... args) {
-          worker_t::work(std::forward<decltype(args)>(args)...);
-        };
-      }
-    }
-
-    // Runtime channel-count requests (variable_audio_bus): CLAP only
-    // renegotiates port layouts across a restart; accept and ignore until
-    // that is implemented rather than crash on an empty function.
-    for(auto state : effect.full_state())
-    {
-      auto wire = [](auto& port) {
-        if constexpr(requires { port.request_channels = std::function<void(int)>{}; })
-          port.request_channels = [](int) {};
-      };
-      avnd::for_each_field_ref(state.inputs, wire);
-      avnd::for_each_field_ref(state.outputs, wire);
-    }
+    // Safe no-op handlers for worker.request / request_channels members:
+    // an empty std::function call terminates under -fno-exceptions.
+    avnd::wire_fallback_callbacks(effect);
   }
 
   void start()

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -10,6 +10,7 @@
 #include <avnd/wrappers/control_display.hpp>
 #include <avnd/wrappers/controls.hpp>
 #include <avnd/wrappers/controls_double.hpp>
+#include <avnd/wrappers/controls_storage.hpp>
 #include <avnd/wrappers/metadatas.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 #include <avnd/wrappers/widgets.hpp>
@@ -126,6 +127,9 @@ struct SimpleAudioEffect : clap_plugin
 
   AVND_NO_UNIQUE_ADDRESS avnd_clap::audio_bus_info<T> audio_busses;
   AVND_NO_UNIQUE_ADDRESS avnd::process_adapter<T> processor;
+
+  // Per-buffer storage backing sample-accurate control ports
+  AVND_NO_UNIQUE_ADDRESS avnd::control_storage<T> control_buffers;
   AVND_NO_UNIQUE_ADDRESS midi_processor<T> midi;
 
   float sample_rate{44100.};
@@ -147,6 +151,7 @@ struct SimpleAudioEffect : clap_plugin
       auto& p = *self(plugin);
       p.sample_rate = sample_rate;
       p.buffer_size = max_frames_count;
+      p.ensure_scratch(max_frames_count);
 
       p.start();
       return true;
@@ -190,6 +195,41 @@ struct SimpleAudioEffect : clap_plugin
     {
       avnd::init_controls(effect);
     }
+
+    wire_effect_callbacks();
+  }
+
+  // Host-callback members on the effect must never be left as empty
+  // std::functions: calling one terminates the process under
+  // -fno-exceptions (bad_function_call cannot unwind).
+  void wire_effect_callbacks()
+  {
+    // Workers offload a job to the host; CLAP has no generic offloading
+    // hook wired here yet, so run the job inline (same result, no
+    // background thread).
+    if constexpr(avnd::has_worker<T>)
+    {
+      for(auto& impl : effect.effects())
+      {
+        using worker_t = std::decay_t<decltype(impl.worker)>;
+        impl.worker.request = [](auto&&... args) {
+          worker_t::work(std::forward<decltype(args)>(args)...);
+        };
+      }
+    }
+
+    // Runtime channel-count requests (variable_audio_bus): CLAP only
+    // renegotiates port layouts across a restart; accept and ignore until
+    // that is implemented rather than crash on an empty function.
+    for(auto state : effect.full_state())
+    {
+      auto wire = [](auto& port) {
+        if constexpr(requires { port.request_channels = std::function<void(int)>{}; })
+          port.request_channels = [](int) {};
+      };
+      avnd::for_each_field_ref(state.inputs, wire);
+      avnd::for_each_field_ref(state.outputs, wire);
+    }
   }
 
   void start()
@@ -201,8 +241,16 @@ struct SimpleAudioEffect : clap_plugin
         .frames_per_buffer = buffer_size,
         .rate = sample_rate};
 
+    // Hosts choose float or double per process() call (data32 / data64):
+    // conversion storage must exist for both source sample types.
+    processor.allocate_buffers(setup_info, float{});
     processor.allocate_buffers(setup_info, double{});
     effect.init_channels(setup_info.input_channels, setup_info.output_channels);
+
+    // Sample-accurate control ports need their per-buffer storage reserved
+    // before process() (else the effect reads unallocated `values` arrays).
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.reserve_space(effect, buffer_size);
 
     // Setup buffers for storing MIDI messages
     if constexpr(midi_in_info::size > 0)
@@ -251,15 +299,52 @@ struct SimpleAudioEffect : clap_plugin
     }
 
     using samples_t = std::decay_t<decltype(inputs[0][0])>;
+
+    // Hosts may hand buses whose channel rows are null (clap-validator
+    // does): point those at binding-owned scratch so no adapter shape ever
+    // dereferences null — silence in, discarded writes out.
+    ensure_scratch(process.frames_count);
+    for(int i = 0; i < in_N; i++)
+      if(!inputs[i])
+        inputs[i] = zero_buffer<samples_t>();
+    for(int i = 0; i < out_N; i++)
+      if(!outputs[i])
+        outputs[i] = trash_buffer<samples_t>();
+
     processor.process(
         effect, avnd::span<samples_t*>{inputs, std::size_t(in_N)},
         avnd::span<samples_t*>{outputs, std::size_t(out_N)}, process.frames_count);
   }
 
+  // Scratch rows substituted for null host channel pointers. Sized in
+  // activate(); the process-time call only allocates if a non-conformant
+  // host processes more frames than it activated for (or never activated).
+  void ensure_scratch(uint32_t frames)
+  {
+    if(m_zero64.size() < frames)
+    {
+      m_zero64.assign(frames, 0.);
+      m_trash64.resize(frames);
+    }
+  }
+  template <typename Sample>
+  Sample* zero_buffer() noexcept
+  {
+    // A double row of N zeros is also a valid float row of 2N zeros.
+    return reinterpret_cast<Sample*>(m_zero64.data());
+  }
+  template <typename Sample>
+  Sample* trash_buffer() noexcept
+  {
+    return reinterpret_cast<Sample*>(m_trash64.data());
+  }
+  std::vector<double> m_zero64, m_trash64;
+
   void process(const clap_process& process)
   {
-    // Clear the control out ports
-    // FIXME
+    // Clear the sample-accurate control out ports
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.clear_outputs(this->effect);
 
     // Clear the midi out ports
     midi.clear_outputs(this->effect);
@@ -272,33 +357,52 @@ struct SimpleAudioEffect : clap_plugin
       int in_N = avnd::input_channels<T>(2);
       int out_N = avnd::output_channels<T>(2);
 
-      if constexpr(avnd::float_processor<T>)
+      // SUPPORTS_64BITS is a per-process() negotiation: the host decides
+      // each call which of data32 / data64 it filled. Read what is actually
+      // there — the adapters convert between float and double effects and
+      // buffers as needed.
+      const bool host_64 = [&] {
+        if(process.audio_inputs_count + process.audio_outputs_count == 0)
+          return avnd::double_processor<T>;
+        for(uint32_t b = 0; b < process.audio_inputs_count; b++)
+          if(process.audio_inputs[b].channel_count > 0
+             && !process.audio_inputs[b].data64)
+            return false;
+        for(uint32_t b = 0; b < process.audio_outputs_count; b++)
+          if(process.audio_outputs[b].channel_count > 0
+             && !process.audio_outputs[b].data64)
+            return false;
+        return true;
+      }();
+
+      if(host_64)
       {
-        auto inputs = (float**)alloca(sizeof(float*) * std::max(in_N, 1));
-        auto outputs = (float**)alloca(sizeof(float*) * std::max(out_N, 1));
+        auto inputs = (double**)alloca(sizeof(double*) * std::max(in_N, 1));
+        auto outputs = (double**)alloca(sizeof(double*) * std::max(out_N, 1));
         // Null the slots so the zero-filled-channels invariant substitutes
         // silent buffers rather than the effect dereferencing garbage.
         std::fill_n(inputs, in_N, nullptr);
         std::fill_n(outputs, out_N, nullptr);
 
-        process_impl<&clap_audio_buffer::data32>(process, inputs, in_N, outputs, out_N);
+        process_impl<&clap_audio_buffer::data64>(process, inputs, in_N, outputs, out_N);
       }
-      else if constexpr(avnd::double_processor<T>)
+      else
       {
-        auto inputs = (double**)alloca(sizeof(double*) * std::max(in_N, 1));
-        auto outputs = (double**)alloca(sizeof(double*) * std::max(out_N, 1));
+        auto inputs = (float**)alloca(sizeof(float*) * std::max(in_N, 1));
+        auto outputs = (float**)alloca(sizeof(float*) * std::max(out_N, 1));
         std::fill_n(inputs, in_N, nullptr);
         std::fill_n(outputs, out_N, nullptr);
 
-        process_impl<&clap_audio_buffer::data64>(process, inputs, in_N, outputs, out_N);
+        process_impl<&clap_audio_buffer::data32>(process, inputs, in_N, outputs, out_N);
       }
     }
 
     // Process the output events
     process_out_events(process);
 
-    // Clear the control in ports
-    // FIXME
+    // Clear the sample-accurate control in ports
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.clear_inputs(this->effect);
 
     // Clear the midi in ports
     midi.clear_inputs(this->effect);
@@ -431,6 +535,14 @@ struct SimpleAudioEffect : clap_plugin
         {
           info->min_value = 0;
           info->max_value = avnd::get_enum_choices_count<C>() - 1;
+          info->flags |= CLAP_PARAM_IS_STEPPED;
+        }
+        else if constexpr(requires { std::size(range.values); })
+        {
+          // Values-list controls (combo boxes...): the value is an index
+          // into range.values; there is no range.min / range.max.
+          info->min_value = 0;
+          info->max_value = double(std::size(range.values)) - 1.;
           info->flags |= CLAP_PARAM_IS_STEPPED;
         }
         else

--- a/include/avnd/binding/clap/bus_info.hpp
+++ b/include/avnd/binding/clap/bus_info.hpp
@@ -36,6 +36,11 @@ struct event_bus_info
           [&]<std::size_t I, typename C>(const avnd::field_reflection<I, C>& port) {
         copy_string(info.name, C::name());
           });
+      // process_in_events consumes both note events and raw MIDI; the
+      // ports are MIDI-message-based, so prefer that dialect. (A zero
+      // preferred_dialect is invalid and makes hosts reject the config.)
+      info.supported_dialects = CLAP_NOTE_DIALECT_MIDI | CLAP_NOTE_DIALECT_CLAP;
+      info.preferred_dialect = CLAP_NOTE_DIALECT_MIDI;
       return true;
     }
     else
@@ -56,6 +61,8 @@ struct event_bus_info
           [&]<std::size_t I, typename C>(const avnd::field_reflection<I, C>& port) {
         copy_string(info.name, C::name());
           });
+      info.supported_dialects = CLAP_NOTE_DIALECT_MIDI | CLAP_NOTE_DIALECT_CLAP;
+      info.preferred_dialect = CLAP_NOTE_DIALECT_MIDI;
       return true;
     }
     else
@@ -286,10 +293,15 @@ struct audio_bus_info<T>
             = avnd::poly_array_sample_port<double, C>
                   ? (CLAP_AUDIO_PORT_SUPPORTS_64BITS | CLAP_AUDIO_PORT_PREFERS_64BITS)
                   : 0;
+        // Each port reports its own channel count, not the plug-in total
+        // (a stereo main + stereo sidechain is two 2-channel ports, not
+        // two 4-channel ones). Dynamic buses default to stereo.
+        const int channels = avnd::channels_in_bus<C>();
+        info.channel_count = channels > 0 ? channels : 2;
+        info.port_type = info.channel_count == 1   ? CLAP_PORT_MONO
+                         : info.channel_count == 2 ? CLAP_PORT_STEREO
+                                                   : nullptr;
           });
-
-      info.channel_count = default_input_channel_count();
-      info.port_type = CLAP_PORT_STEREO;
       info.in_place_pair = CLAP_INVALID_ID; // FIXME
 
       return true;
@@ -311,10 +323,12 @@ struct audio_bus_info<T>
             = avnd::poly_array_sample_port<double, C>
                   ? (CLAP_AUDIO_PORT_SUPPORTS_64BITS | CLAP_AUDIO_PORT_PREFERS_64BITS)
                   : 0;
+        const int channels = avnd::channels_in_bus<C>();
+        info.channel_count = channels > 0 ? channels : 2;
+        info.port_type = info.channel_count == 1   ? CLAP_PORT_MONO
+                         : info.channel_count == 2 ? CLAP_PORT_STEREO
+                                                   : nullptr;
           });
-
-      info.channel_count = default_output_channel_count();
-      info.port_type = CLAP_PORT_STEREO;
       info.in_place_pair = CLAP_INVALID_ID; // FIXME
 
       return true;
@@ -393,8 +407,11 @@ struct audio_bus_info<T>
 template <avnd::channel_port_processor T>
 struct audio_bus_info<T>
 {
-  using input_refl = avnd::audio_bus_input_introspection<T>;
-  using output_refl = avnd::audio_bus_output_introspection<T>;
+  // Channel ports (mono `.channel` members), not bus ports: the bus
+  // introspection is empty for these, hiding the plug-in's real audio
+  // shape from hosts (issue #154).
+  using input_refl = avnd::audio_channel_input_introspection<T>;
+  using output_refl = avnd::audio_channel_output_introspection<T>;
   static constexpr int input_count() noexcept { return input_refl::size; }
   static constexpr int output_count() noexcept { return output_refl::size; }
   static constexpr int default_input_channel_count() noexcept { return input_count(); }
@@ -408,7 +425,11 @@ struct audio_bus_info<T>
       input_refl::for_nth_mapped(
           index,
           [&]<std::size_t I, typename C>(const avnd::field_reflection<I, C>& port) {
-        copy_string(info.name, C::name());
+        // name() may be a static_string NTTP rather than string_view-like
+        if constexpr(requires { copy_string(info.name, C::name()); })
+          copy_string(info.name, C::name());
+        else
+          copy_string(info.name, std::string_view{C::name().value});
         info.flags
             = avnd::mono_array_sample_port<double, C>
                   ? (CLAP_AUDIO_PORT_SUPPORTS_64BITS | CLAP_AUDIO_PORT_PREFERS_64BITS)
@@ -433,7 +454,10 @@ struct audio_bus_info<T>
       output_refl::for_nth_mapped(
           index,
           [&]<std::size_t I, typename C>(const avnd::field_reflection<I, C>& port) {
-        copy_string(info.name, C::name());
+        if constexpr(requires { copy_string(info.name, C::name()); })
+          copy_string(info.name, C::name());
+        else
+          copy_string(info.name, std::string_view{C::name().value});
         info.flags
             = avnd::mono_array_sample_port<double, C>
                   ? (CLAP_AUDIO_PORT_SUPPORTS_64BITS | CLAP_AUDIO_PORT_PREFERS_64BITS)

--- a/include/avnd/binding/vintage/audio_effect.hpp
+++ b/include/avnd/binding/vintage/audio_effect.hpp
@@ -12,6 +12,7 @@
 #include <avnd/common/export.hpp>
 #include <avnd/introspection/channels.hpp>
 #include <avnd/wrappers/controls.hpp>
+#include <avnd/wrappers/controls_storage.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 
 namespace vintage
@@ -43,6 +44,9 @@ struct SimpleAudioEffect : vintage::Effect
   AVND_NO_UNIQUE_ADDRESS programs_setup programs;
 
   AVND_NO_UNIQUE_ADDRESS midi_processor<T> midi;
+
+  // Per-buffer storage backing sample-accurate control ports
+  AVND_NO_UNIQUE_ADDRESS avnd::control_storage<T> control_buffers;
 
   float sample_rate{44100.};
   int buffer_size{512};
@@ -129,6 +133,11 @@ struct SimpleAudioEffect : vintage::Effect
     if constexpr(avnd::double_processor<T>)
       processor.allocate_buffers(setup_info, double{});
 
+    // Sample-accurate control ports need their per-buffer storage reserved
+    // before process() (else the effect reads unallocated `values` arrays).
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.reserve_space(effect, buffer_size);
+
     // Setup buffers for storing MIDI messages
     if constexpr(midi_input_introspection<T>::size > 0)
     {
@@ -166,6 +175,8 @@ struct SimpleAudioEffect : vintage::Effect
 
     // Clear our midi outputs
     midi.clear_outputs(effect);
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.clear_outputs(effect);
 
     // Before processing starts, we copy all our atomics back into the struct
     controls.write(effect);
@@ -178,6 +189,8 @@ struct SimpleAudioEffect : vintage::Effect
 
     // Clear our midi inputs
     midi.clear_inputs(effect);
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.clear_inputs(effect);
   }
 
   void event_input(const vintage::Events* evs)

--- a/include/avnd/binding/vintage/audio_effect.hpp
+++ b/include/avnd/binding/vintage/audio_effect.hpp
@@ -13,6 +13,7 @@
 #include <avnd/introspection/channels.hpp>
 #include <avnd/wrappers/controls.hpp>
 #include <avnd/wrappers/controls_storage.hpp>
+#include <avnd/wrappers/prepare.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 
 namespace vintage
@@ -100,6 +101,10 @@ struct SimpleAudioEffect : vintage::Effect
     buffer_size = request(HostOpcodes::GetBlockSize, 0, 0, nullptr, 0.f);
 
     /// Read the initial state of the controls
+    // Safe no-op handlers for worker.request / request_channels members:
+    // an empty std::function call terminates under -fno-exceptions.
+    avnd::wire_fallback_callbacks(effect);
+
     if constexpr(avnd::has_inputs<T>)
     {
       // First the default value

--- a/include/avnd/binding/vst3/bus_info.hpp
+++ b/include/avnd/binding/vst3/bus_info.hpp
@@ -157,47 +157,86 @@ default_speaker_arrangement(int channels, Steinberg::Vst::SpeakerArrangement& ar
 // thus either the number of channels is set explicitely, or we default to 2 as
 // that is the expectation for VSTs.
 
+// Fallback: no specialized bus concept matched. The core wrappers may
+// still see audio channels the concepts above don't cover (array-style
+// value ports carrying a .channel, analyzers without audio outputs...):
+// declare one main bus per direction that actually has channels, so
+// hosts/validators see the plug-in's real audio shape instead of
+// "no buses at all". Effects with no audio in either direction keep
+// declaring nothing (parameter-only utility objects).
 template <typename T>
 struct audio_bus_info
 {
-  static constexpr int inputCount() noexcept { return 0; }
-  static constexpr int outputCount() noexcept { return 0; }
-  static constexpr int defaultInputChannelCount() noexcept { return 0; }
-  static constexpr int defaultOutputChannelCount() noexcept { return 0; }
+  static constexpr int inputCount() noexcept
+  {
+    return avnd::input_channels<T>(0) > 0 ? 1 : 0;
+  }
+  static constexpr int outputCount() noexcept
+  {
+    return avnd::output_channels<T>(0) > 0 ? 1 : 0;
+  }
+  static constexpr int defaultInputChannelCount() noexcept
+  {
+    return avnd::input_channels<T>(0);
+  }
+  static constexpr int defaultOutputChannelCount() noexcept
+  {
+    return avnd::output_channels<T>(0);
+  }
 
   static Steinberg::tresult
   inputInfo(Steinberg::int32 index, Steinberg::Vst::BusInfo& info)
   {
+    if(index == 0 && inputCount() > 0)
+    {
+      info.channelCount = defaultInputChannelCount();
+      setStr(info.name, u16_str "In");
+      info.busType = Steinberg::Vst::BusTypes::kMain;
+      return Steinberg::kResultTrue;
+    }
     return Steinberg::kInvalidArgument;
   }
 
   static Steinberg::tresult
   outputInfo(Steinberg::int32 index, Steinberg::Vst::BusInfo& info)
   {
+    if(index == 0 && outputCount() > 0)
+    {
+      info.channelCount = defaultOutputChannelCount();
+      setStr(info.name, u16_str "Out");
+      info.busType = Steinberg::Vst::BusTypes::kMain;
+      return Steinberg::kResultTrue;
+    }
     return Steinberg::kInvalidArgument;
   }
 
   static Steinberg::tresult
   inputArrangement(Steinberg::int32 index, Steinberg::Vst::SpeakerArrangement& arr)
   {
+    if(index == 0 && inputCount() > 0)
+      return default_speaker_arrangement(defaultInputChannelCount(), arr);
     return Steinberg::kInvalidArgument;
   }
 
   static Steinberg::tresult
   outputArrangement(Steinberg::int32 index, Steinberg::Vst::SpeakerArrangement& arr)
   {
+    if(index == 0 && outputCount() > 0)
+      return default_speaker_arrangement(defaultOutputChannelCount(), arr);
     return Steinberg::kInvalidArgument;
   }
 
   static Steinberg::tresult activateInput(Steinberg::int32 index, Steinberg::TBool state)
   {
-    return Steinberg::kInvalidArgument;
+    return (index == 0 && inputCount() > 0) ? Steinberg::kResultTrue
+                                            : Steinberg::kInvalidArgument;
   }
 
   static Steinberg::tresult
   activateOutput(Steinberg::int32 index, Steinberg::TBool state)
   {
-    return Steinberg::kInvalidArgument;
+    return (index == 0 && outputCount() > 0) ? Steinberg::kResultTrue
+                                             : Steinberg::kInvalidArgument;
   }
 
   Steinberg::tresult setBusArrangements(
@@ -206,7 +245,7 @@ struct audio_bus_info
       Steinberg::int32 numOuts)
   {
     using namespace Steinberg;
-    if(numIns == 0 && numOuts == 0)
+    if(numIns == inputCount() && numOuts == outputCount())
       return kResultTrue;
     return kResultFalse;
   }
@@ -751,8 +790,11 @@ struct audio_bus_info<T>
 template <avnd::channel_port_processor T>
 struct audio_bus_info<T>
 {
-  using input_refl = avnd::audio_bus_input_introspection<T>;
-  using output_refl = avnd::audio_bus_output_introspection<T>;
+  // Channel ports (mono `.channel` members), not bus ports: the bus
+  // introspection is empty for these — that made analyzers such as
+  // essentia Entropy report zero buses (issue #154).
+  using input_refl = avnd::audio_channel_input_introspection<T>;
+  using output_refl = avnd::audio_channel_output_introspection<T>;
   static constexpr int inputCount() noexcept { return input_refl::size; }
   static constexpr int outputCount() noexcept { return output_refl::size; }
   static constexpr int defaultInputChannelCount() noexcept { return inputCount(); }

--- a/include/avnd/binding/vst3/component.hpp
+++ b/include/avnd/binding/vst3/component.hpp
@@ -10,6 +10,7 @@
 #include <avnd/introspection/midi.hpp>
 #include <avnd/introspection/output.hpp>
 #include <avnd/wrappers/controls.hpp>
+#include <avnd/wrappers/controls_storage.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 
 namespace stv3
@@ -75,6 +76,9 @@ struct Component final
   AVND_NO_UNIQUE_ADDRESS avnd::process_adapter<T> processor;
 
   AVND_NO_UNIQUE_ADDRESS avnd::midi_storage<T> midi;
+
+  // Per-buffer storage backing sample-accurate control ports
+  AVND_NO_UNIQUE_ADDRESS avnd::control_storage<T> control_buffers;
 
   AVND_NO_UNIQUE_ADDRESS stv3::audio_bus_info<T> audio_busses;
 
@@ -301,6 +305,11 @@ struct Component final
     // We always do so for float, as the plug-in API requires the existence of this
     processor.allocate_buffers(setup_info, float{});
     processor.allocate_buffers(setup_info, double{});
+
+    // Sample-accurate control ports need their per-buffer storage reserved
+    // before process() (else the effect reads unallocated `values` arrays).
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.reserve_space(effect, newSetup.maxSamplesPerBlock);
 
     effect.init_channels(
         audio_busses.runtime_input_channel_count,
@@ -529,6 +538,8 @@ struct Component final
 
     // Clear outputs
     this->midi.clear_outputs(effect);
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.clear_outputs(effect);
 
     processControls(data);
     processEvents(data);
@@ -541,6 +552,8 @@ struct Component final
 
     // Clear inputs
     this->midi.clear_inputs(effect);
+    if constexpr(sizeof(control_buffers) > 1)
+      control_buffers.clear_inputs(effect);
 
     return kResultOk;
   }

--- a/include/avnd/binding/vst3/component.hpp
+++ b/include/avnd/binding/vst3/component.hpp
@@ -11,6 +11,7 @@
 #include <avnd/introspection/output.hpp>
 #include <avnd/wrappers/controls.hpp>
 #include <avnd/wrappers/controls_storage.hpp>
+#include <avnd/wrappers/prepare.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 
 namespace stv3
@@ -106,6 +107,10 @@ struct Component final
 
     // First the default value
     avnd::init_controls(effect);
+
+    // Safe no-op handlers for worker.request / request_channels members:
+    // an empty std::function call terminates under -fno-exceptions.
+    avnd::wire_fallback_callbacks(effect);
   }
 
   virtual ~Component() { }

--- a/include/avnd/wrappers/prepare.hpp
+++ b/include/avnd/wrappers/prepare.hpp
@@ -2,9 +2,13 @@
 
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include <avnd/common/for_nth.hpp>
 #include <avnd/common/function_reflection.hpp>
 #include <avnd/concepts/audio_processor.hpp>
+#include <avnd/concepts/worker.hpp>
 #include <avnd/wrappers/effect_container.hpp>
+
+#include <functional>
 
 namespace avnd
 {
@@ -28,6 +32,47 @@ struct process_setup
 
   double model_to_samples{1.};
 };
+
+// Host-callback members on the effect (worker.request, request_channels...)
+// must never be left as empty std::functions: calling one terminates the
+// process under -fno-exceptions. Bindings without a richer implementation
+// call this to install safe fallbacks; bindings that support a concept
+// natively wire their own handler afterwards.
+template <typename T>
+void wire_fallback_callbacks(avnd::effect_container<T>& implementation)
+{
+  // Workers offload a job to the host: run it inline (same result, no
+  // background thread).
+  if constexpr(avnd::has_worker<T>)
+  {
+    for(auto& impl : implementation.effects())
+    {
+      using worker_t = std::decay_t<decltype(impl.worker)>;
+      impl.worker.request = [](auto&&... args) {
+        worker_t::work(std::forward<decltype(args)>(args)...);
+      };
+    }
+  }
+
+  // Runtime channel-count requests (variable_audio_bus): most plug-in APIs
+  // only renegotiate layouts across a restart; accept and ignore.
+  if constexpr(avnd::has_inputs<T> || avnd::has_outputs<T>)
+  {
+    for(auto state : implementation.full_state())
+    {
+      auto wire = [](auto& port) {
+        if constexpr(requires {
+                       port.request_channels = std::function<void(int)>{};
+                     })
+          port.request_channels = [](int) {};
+      };
+      if constexpr(avnd::has_inputs<T>)
+        avnd::for_each_field_ref(state.inputs, wire);
+      if constexpr(avnd::has_outputs<T>)
+        avnd::for_each_field_ref(state.outputs, wire);
+    }
+  }
+}
 
 template <typename T>
 void prepare(avnd::effect_container<T>& implementation, process_setup setup)

--- a/include/avnd/wrappers/process/base.hpp
+++ b/include/avnd/wrappers/process/base.hpp
@@ -17,7 +17,16 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-// #define AVND_ENABLE_SAFE_BUFFER_STORAGE 1
+
+// The effect must always receive valid, zero-filled channel buffers. When a host
+// supplies fewer channels than the object declares (e.g. an unconnected input),
+// the missing channels must point at silent scratch buffers -- otherwise the
+// effect dereferences a null channel pointer and crashes. This is a core
+// invariant, so it is on by default; define AVND_ENABLE_SAFE_BUFFER_STORAGE=0
+// before including to opt out.
+#ifndef AVND_ENABLE_SAFE_BUFFER_STORAGE
+#define AVND_ENABLE_SAFE_BUFFER_STORAGE 1
+#endif
 namespace avnd
 {
 


### PR DESCRIPTION
Backend fixes extracted from the custom-UI branch — nothing here touches UI; every change is a host-conformance or build fix for the existing CLAP/VST2/VST3 bindings.

## Fixes
- **Zero-filled channels**: the effect is never handed null channel pointers; short host buffers get binding-owned silent scratch (`wrappers/process/base.hpp`, plus null rows inside host buses pointed at zero/trash scratch sized at activate).
- **#153/#154 conformance sweep** (debugged against clap-validator + the Steinberg validator; 53/85 → 84/85 fully-passing clap-validator runs):
  - per-`process()` 32/64-bit sample format negotiation (both conversion storages allocated);
  - note ports declare valid dialects; per-port channel counts; values-list controls report stepped 0..N-1 ranges;
  - channel-port effects (mono `.channel` members) report their buses from the channel introspection (#154);
  - sample-accurate control ports get per-buffer storage reserved at activate and cleared around process().
- **Host-callback fallbacks** (`avnd::wire_fallback_callbacks`): `worker.request` / `request_channels` members are never left as empty `std::function`s — calling one terminates under `-fno-exceptions`.
- **cmake**: `FMT_MODULE=OFF` default (fmt ≥ 12 would require a module-scanning toolchain); CLAP headers fetched when absent; `AVND_FETCH_VST3_SDK=ON` fetches the SDK (v3.7.14_build_55); the fetched SDK's `base` library gets its missing `pluginterfaces` link dependency declared — without it every plug-in ships with undefined `Steinberg::FUID::*` under GNU ld.

## Validation
- Linux (clang 19): clean build, 100/100 tests; clap-validator and Steinberg validator spot-checks pass.
- The full sweep on the tip of the stack: 84/85 clap-validator (the 85th is a clap-validator bug: `note_ports.rs` queries output ports with `is_input=true`), zero VST3 validator crashes.

Part 1/3 of splitting the custom-UI work; #161 (UI concepts + Tier C + message bus) and #162 (reference software UI) stack on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)