### PR TITLE
cmake: stub the addon object library when it is header-only

### DIFF
--- a/cmake/AvendishAddon.cmake
+++ b/cmake/AvendishAddon.cmake
@@ -72,7 +72,27 @@ macro(avnd_addon_object)
     endif()
   else()
     if(NOT TARGET ${AA_C_NAME})
-      add_library(${AA_C_NAME} STATIC ${AA_SOURCES})
+      # A header-only object (SOURCES lists no translation unit) would produce an
+      # empty STATIC library: GNU ar tolerates that, but macOS ar and MSVC lib
+      # reject it ("no archive members specified"). Give it the same generated
+      # empty stub the base target uses, so header-only addons link everywhere.
+      set(_avnd_obj_sources ${AA_SOURCES})
+      set(_avnd_obj_has_tu 0)
+      foreach(_avnd_src ${AA_SOURCES})
+        if(_avnd_src MATCHES "\\.(c|C|cc|cpp|cxx|c\\+\\+|m|mm|M)$")
+          set(_avnd_obj_has_tu 1)
+          break()
+        endif()
+      endforeach()
+      if(NOT _avnd_obj_has_tu)
+        set(_avnd_obj_stub "${CMAKE_CURRENT_BINARY_DIR}/${AA_C_NAME}_avnd_obj_stub.cpp")
+        if(NOT EXISTS "${_avnd_obj_stub}")
+          file(WRITE "${_avnd_obj_stub}"
+            "// Avendish standalone addon object (header-only; intentionally empty TU).\n")
+        endif()
+        list(APPEND _avnd_obj_sources "${_avnd_obj_stub}")
+      endif()
+      add_library(${AA_C_NAME} STATIC ${_avnd_obj_sources})
     endif()
     if(TARGET ${AA_BASE} AND NOT "${AA_BASE}" STREQUAL "${AA_C_NAME}")
       target_link_libraries(${AA_C_NAME} PUBLIC ${AA_BASE})


### PR DESCRIPTION
## Problem

`avnd_addon_object` builds the object as a STATIC library directly from `SOURCES`.
A **header-only** object (no `.cpp`/`.mm`/… TU) yields an **empty archive**: GNU `ar`
tolerates it, but macOS `ar` and MSVC `lib` reject it with *"no archive members
specified"*, breaking the build for any single-header addon (e.g. a header-only
TouchDesigner POP).

## Fix

The base target already guards this with a generated empty stub TU; apply the
same to the object library when `SOURCES` contains no translation unit.

## Validation

Built a header-only `avnd_addon_object` against this branch: the object archive
`tiny.a` now contains `tiny_avnd_obj_stub.cpp.o` (was empty before). This is
exactly the failure hit by `carto-tcp-avendish` on macOS/Windows CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4KK2Rays9dTj8J2AJcFZ
