### PR TITLE
halp: fix std::span narrowing in cpu_buffer_input::cast() on 32-bit (wasm)

### DIFF
--- a/include/halp/buffer.hpp
+++ b/include/halp/buffer.hpp
@@ -65,13 +65,15 @@ struct cpu_buffer_input
   auto cast()
   {
     return std::span<T>{
-        reinterpret_cast<T*>(buffer.raw_data), buffer.byte_size / sizeof(T)};
+        reinterpret_cast<T*>(buffer.raw_data),
+        static_cast<std::size_t>(buffer.byte_size / sizeof(T))};
   }
   template <typename T>
   auto cast() const noexcept
   {
     return std::span<const T>{
-        reinterpret_cast<const T*>(buffer.raw_data), buffer.byte_size / sizeof(T)};
+        reinterpret_cast<const T*>(buffer.raw_data),
+        static_cast<std::size_t>(buffer.byte_size / sizeof(T))};
   }
 
   halp::raw_buffer buffer{};


### PR DESCRIPTION
## Problem

`raw_buffer::byte_size` is `int64_t`, so `byte_size / sizeof(T)` stays 64-bit and
narrows to `std::span`'s `size_type` in the braced initializer of
`cpu_buffer_input::cast()`. With 64-bit `size_t` the conversion is silent, but where
`size_t` is 32-bit (**wasm/emscripten**) it fails under `-Wc++11-narrowing` —
breaking e.g. `score-addon-cv`'s wasm CI lane.

## Fix

Cast the element count to `std::size_t` explicitly (both `cast()` overloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4KK2Rays9dTj8J2AJcFZ
