### PR TITLE
cmake: require Boost >= 1.90 (Boost.PFR get_name)

### DIFF
--- a/cmake/avendish.cmake
+++ b/cmake/avendish.cmake
@@ -56,7 +56,7 @@ function(_avnd_dispatch_backend backend)
   cmake_language(CALL "avnd_make_${backend}" ${ARGN})
 endfunction()
 
-find_package(Boost 1.87 QUIET REQUIRED)
+find_package(Boost 1.90 QUIET REQUIRED)
 find_package(Threads QUIET)
 find_package(fmt QUIET)
 


### PR DESCRIPTION
### Problem

The Godot back-end (`binding/godot/node.hpp:70`) calls `boost::pfr::get_name<...>()`. That API was added to Boost.PFR in **1.88** and is missing from earlier Boost. With the current `find_package(Boost 1.87 …)`, building the Godot binding fails:

```
binding/godot/node.hpp:70:24: error:
  'get_name' is not a member of 'boost::pfr'
```

(GCC's `did you mean 'avnd::get_name'?` hint is a red herring — unrelated function.)

### Fix

Bump the minimum required Boost in `cmake/avendish.cmake` from `1.87` to `1.90`, per @jcelerier's request, so the Boost.PFR name-reflection API is guaranteed present.

### Verification

Reproduced downstream in `sat-mtl/sherpa-plugins` on Ubuntu 24.04. Building against Boost 1.87/1.83 fails as above; forcing **Boost 1.91** makes the previously-failing `sherpa_tts_NODE_godot` target compile and link cleanly (`build/godot/sherpa_tts.so`). The non-Godot targets were unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)