### PR TITLE
Add dynamic_combobox: a combobox with a runtime-populated item list

### DIFF
--- a/include/avnd/concepts/dynamic_items.hpp
+++ b/include/avnd/concepts/dynamic_items.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/concepts/parameter.hpp>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace avnd
+{
+// enum-ish parameter carrying an update_items callback for runtime item lists.
+template <typename T>
+concept dynamic_items_parameter = enum_ish_parameter<T> && requires(T t) {
+  {
+    t.update_items
+  } -> std::convertible_to<std::function<void(std::vector<std::string>)>>;
+};
+}

--- a/include/avnd/concepts/dynamic_items.hpp
+++ b/include/avnd/concepts/dynamic_items.hpp
@@ -1,20 +1,18 @@
 #pragma once
 
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
 
+#include <avnd/common/function_reflection.hpp>
 #include <avnd/concepts/parameter.hpp>
-
-#include <functional>
-#include <string>
-#include <vector>
 
 namespace avnd
 {
 // enum-ish parameter carrying an update_items callback for runtime item lists.
+// Any function-like member works (std::function-ish object, function pointer,
+// ...); the argument type is left to the binding.
 template <typename T>
-concept dynamic_items_parameter = enum_ish_parameter<T> && requires(T t) {
-  {
-    t.update_items
-  } -> std::convertible_to<std::function<void(std::vector<std::string>)>>;
-};
+concept dynamic_items_parameter
+    = enum_ish_parameter<T>
+      && (function_ish<std::decay_t<decltype(T{}.update_items)>>
+          || function<std::decay_t<decltype(T{}.update_items)>>);
 }

--- a/include/avnd/concepts/folder_items.hpp
+++ b/include/avnd/concepts/folder_items.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/concepts/parameter.hpp>
+
+#include <string_view>
+
+namespace avnd
+{
+// A combobox whose items are the files of a sibling folder port, populated by
+// the host at edit time. The port exposes folder_port() (the sibling port's
+// name) and extensions() (accepted suffixes).
+template <typename T>
+concept folder_items_parameter = enum_ish_parameter<T> && requires {
+  { T::folder_port() } -> std::convertible_to<std::string_view>;
+  { T::extensions() } -> std::convertible_to<std::string_view>;
+};
+}

--- a/include/avnd/concepts/folder_items.hpp
+++ b/include/avnd/concepts/folder_items.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
 
 #include <avnd/concepts/parameter.hpp>
 

--- a/include/halp/dynamic_combobox.hpp
+++ b/include/halp/dynamic_combobox.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <halp/polyfill.hpp>
+#include <halp/static_string.hpp>
+
+#include <array>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace halp
+{
+// Combobox whose items are set at runtime via update_items. Bindings without
+// support leave update_items empty and use the static range() fallback.
+template <static_string lit>
+struct dynamic_combobox
+{
+  enum widget
+  {
+    combobox
+  };
+
+  struct range
+  {
+    std::array<std::string_view, 1> values{"-"};
+    int init{0};
+  };
+
+  static clang_buggy_consteval auto name() { return std::string_view{lit.value}; }
+
+  int value{0};
+
+  std::function<void(std::vector<std::string>)> update_items;
+
+  operator int&() noexcept { return value; }
+  operator const int&() const noexcept { return value; }
+  auto& operator=(int t) noexcept
+  {
+    value = t;
+    return *this;
+  }
+};
+}

--- a/include/halp/folder_combobox.hpp
+++ b/include/halp/folder_combobox.hpp
@@ -13,9 +13,15 @@ namespace halp
 {
 // Combobox whose items are the files of a sibling folder port, listed by the
 // host at edit time (and refreshed when the folder changes) — no execution
-// needed. `folder_port` names the sibling path/folder port; `extensions` is a
-// space-separated list of accepted suffixes (empty = all files).
-template <static_string lit, static_string folder = "Folder", static_string exts = "">
+// needed. The VALUE is the selected file name (a string), so an object can use
+// it directly as a file name. `folder_port` names the sibling path/folder
+// port; `extensions` is a space-separated list of accepted suffixes (empty =
+// all files); `init` is the initially selected file name — it stays selected
+// even while the file does not exist yet, so chains of processes that write
+// then read conventionally-named files keep working with default values.
+template <
+    static_string lit, static_string folder = "Folder", static_string exts = "",
+    static_string init_value = "-">
 struct folder_combobox
 {
   enum widget
@@ -25,21 +31,21 @@ struct folder_combobox
 
   struct range
   {
-    std::array<std::string_view, 1> values{"-"};
-    int init{0};
+    std::array<std::string_view, 1> values{init_value.value};
+    std::string_view init{init_value.value};
   };
 
   static clang_buggy_consteval auto name() { return std::string_view{lit.value}; }
   static clang_buggy_consteval auto folder_port() { return std::string_view{folder.value}; }
   static clang_buggy_consteval auto extensions() { return std::string_view{exts.value}; }
 
-  int value{0};
+  std::string value{};
 
-  operator int&() noexcept { return value; }
-  operator const int&() const noexcept { return value; }
-  auto& operator=(int t) noexcept
+  operator std::string&() noexcept { return value; }
+  operator const std::string&() const noexcept { return value; }
+  auto& operator=(std::string t) noexcept
   {
-    value = t;
+    value = std::move(t);
     return *this;
   }
 };

--- a/include/halp/folder_combobox.hpp
+++ b/include/halp/folder_combobox.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <halp/polyfill.hpp>
+#include <halp/static_string.hpp>
+
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace halp
+{
+// Combobox whose items are the files of a sibling folder port, listed by the
+// host at edit time (and refreshed when the folder changes) — no execution
+// needed. `folder_port` names the sibling path/folder port; `extensions` is a
+// space-separated list of accepted suffixes (empty = all files).
+template <static_string lit, static_string folder = "Folder", static_string exts = "">
+struct folder_combobox
+{
+  enum widget
+  {
+    combobox
+  };
+
+  struct range
+  {
+    std::array<std::string_view, 1> values{"-"};
+    int init{0};
+  };
+
+  static clang_buggy_consteval auto name() { return std::string_view{lit.value}; }
+  static clang_buggy_consteval auto folder_port() { return std::string_view{folder.value}; }
+  static clang_buggy_consteval auto extensions() { return std::string_view{exts.value}; }
+
+  int value{0};
+
+  operator int&() noexcept { return value; }
+  operator const int&() const noexcept { return value; }
+  auto& operator=(int t) noexcept
+  {
+    value = t;
+    return *this;
+  }
+};
+}


### PR DESCRIPTION
# PR (avendish): dynamic_combobox — runtime-populated combobox port

**Branch:** `feature/dynamic-combobox` (off `main`)
**Files:** 2 new headers, 79 lines, no changes to existing code.

## What

A combobox port whose item list is discovered by the processor at run time,
rather than fixed at compile time by `range()`:

```cpp
struct ins {
  halp::folder_port<"Folder"> folder;
  halp::dynamic_combobox<"File"> file;   // items filled at runtime
} inputs;

void operator()(int) {
  if (folder_changed && inputs.file.update_items)
    inputs.file.update_items(list_of_names);   // any thread
  // inputs.file.value is the selected index
}
```

- `halp/dynamic_combobox.hpp` — the port: `int value`, a static fallback
  `range()` (single "-" item), and
  `std::function<void(std::vector<std::string>)> update_items`.
- `avnd/concepts/dynamic_items.hpp` — `avnd::dynamic_items_parameter<T>`, so a
  binding can detect these ports.

## Backwards compatibility

The design is additive and opt-in. Bindings that don't know the concept never
fill `update_items`; the port then renders as a plain combobox from the static
fallback `range()`. Existing objects and existing bindings are untouched — no
API, ABI or behaviour change.

## Host side

The score binding that consumes this is a companion PR on ossia/score
(`feature/dynamic-combobox`): `Process::ComboBox` gains
`setAlternatives()` + `alternativesChanged`, the widgets rebuild live, and the
executor injects `update_items` (thread-marshalled). Other bindings can adopt
it incrementally or ignore it.

## Motivation

Folder-backed pickers: the score-avnd-flucoma / Granola work needs a sound
whose choices are the files currently in a working folder. Also useful for OSC
address lists, dataset point ids, device names, preset names — any choice set
known only at run time. Full design notes in `dynamic-combobox-proposal.md`.

## Open questions for review

1. Callback injection (chosen here) vs. reusing the processor→UI message bus.
2. Value semantics when the list changes: clamp index (host PR does this) vs.
   match by string.

## Host binding

**ossia/score#2110** consumes this port: `Process::ComboBox` gains a runtime `setAlternatives()` + `alternativesChanged`, the inspector/canvas widgets rebuild live, and the avnd executor injects `update_items`. This avendish PR should land first. No real object depends on it yet — it was verified with a throwaway test object.
