### PR TITLE
Host state, transport ticks, and update() dispatch (CLAP + VST3)

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -49,6 +49,7 @@
   - [Logging](./advanced/logging.md)
   - [FFT](./advanced/fft.md)
 - [Presets](./advanced/presets.md)
+- [Host state](./advanced/state.md)
 - [Sample-accurate processing](./advanced/sample_accurate.md)
   - [Example](./advanced/sample_accurate.example.md)
 - [Channel mimicking](./advanced/channel_mimicking.md)

--- a/book/src/advanced/state.md
+++ b/book/src/advanced/state.md
@@ -1,0 +1,48 @@
+# Host state (session persistence)
+
+Processors sometimes carry state that is not expressible as parameter ports:
+pattern data, captured audio, generated content... By exposing a pair of
+member functions, that state is persisted in the DAW session by the plug-in
+bindings (currently CLAP and VST3), alongside the usual parameter values:
+
+```cpp
+struct MyProcessor
+{
+  ...
+
+  std::vector<uint8_t> save_state();
+  bool load_state(const uint8_t* data, size_t n);
+};
+```
+
+Several spellings are accepted (see `<avnd/concepts/state.hpp>`):
+
+- `save_state()` may return any contiguous byte container
+  (`std::vector<uint8_t>`, `std::string`, `std::vector<std::byte>`, ...);
+- alternatively, a writer callback form allows streaming without allocation:
+
+```cpp
+void save_state(avnd::state_writer auto& write)
+{
+  write(header_bytes, sizeof(header_bytes));
+  write(pattern.data(), pattern.size());
+}
+```
+
+- `load_state` may take `(const uint8_t*, size_t)`, `(const char*, size_t)`,
+  `(const std::byte*, size_t)` or a `std::span<const uint8_t>`; returning
+  `bool` allows rejecting an invalid blob (`void` also works and means
+  loading cannot fail).
+
+Important notes:
+
+- The blob is **owned by the processor**: version it, validate it (it comes
+  back from arbitrary session files), and return `false` on anything
+  suspicious **without partially applying it**. The binding then keeps the
+  current state and reports the failure to the host.
+- Parameters are restored first, then `load_state` runs: a processor that
+  reconfigures itself from the blob wins where the two overlap.
+- Save and load run on the host's state-handling thread (main/UI thread in
+  practice), like parameter restoration.
+
+A complete example: `examples/Raw/CustomState.hpp`.

--- a/book/src/writing_processors/ports.update.md
+++ b/book/src/writing_processors/ports.update.md
@@ -1,6 +1,6 @@
 # Port update callback
 
-> Supported bindings: ossia
+> Supported bindings: ossia, clap, vst3
 
 It is possible to get a callback whenever the value of a (value) input port gets updated, to perform complex actions.
 `update` will always be called before the current tick starts.

--- a/cmake/FindBoost.cmake
+++ b/cmake/FindBoost.cmake
@@ -2,8 +2,10 @@
 #
 # Avendish only needs Boost headers (Boost::boost / Boost::headers). Strategy:
 #  1. defer to Boost's own BoostConfig.cmake when it is installed;
-#  2. otherwise, satisfy the request from a plain header tree given via
-#     BOOST_ROOT / Boost_INCLUDE_DIR.
+#  2. otherwise, satisfy the request from a plain header tree, accepting both
+#     the source layout (<root>/boost/version.hpp) and the installed one
+#     (<root>/include/boost/version.hpp), and falling back to the default
+#     search paths.
 
 # 1. Prefer config mode if available.
 find_package(Boost ${Boost_FIND_VERSION} CONFIG QUIET)
@@ -13,22 +15,36 @@ endif()
 
 # 2. Header-only fallback.
 if(NOT Boost_INCLUDE_DIR)
-  if(BOOST_ROOT)
-    set(Boost_INCLUDE_DIR "${BOOST_ROOT}")
-  elseif(DEFINED ENV{BOOST_ROOT})
-    set(Boost_INCLUDE_DIR "$ENV{BOOST_ROOT}")
-  endif()
+  set(_avnd_boost_hints "")
+  foreach(_avnd_boost_root
+          "${BOOST_ROOT}" "$ENV{BOOST_ROOT}"
+          "${Boost_ROOT}" "$ENV{Boost_ROOT}"
+          "${BOOSTROOT}" "$ENV{BOOSTROOT}")
+    if(_avnd_boost_root)
+      list(APPEND _avnd_boost_hints "${_avnd_boost_root}")
+    endif()
+  endforeach()
+
+  # PATH_SUFFIXES covers installed trees (<root>/include/boost/version.hpp);
+  # the bare hint covers unpacked source trees (<root>/boost/version.hpp).
+  find_path(Boost_INCLUDE_DIR
+    NAMES boost/version.hpp
+    HINTS ${_avnd_boost_hints}
+    PATH_SUFFIXES include)
+  unset(_avnd_boost_hints)
+  unset(_avnd_boost_root)
 endif()
 
 if(Boost_INCLUDE_DIR AND EXISTS "${Boost_INCLUDE_DIR}/boost/version.hpp")
-  file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_ver_line
+  file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _avnd_boost_ver_line
        REGEX "#define BOOST_LIB_VERSION ")
-  string(REGEX MATCH "\"([0-9]+)_([0-9]+)\"" _ "${_boost_ver_line}")
+  string(REGEX MATCH "\"([0-9]+)_([0-9]+)" _ "${_avnd_boost_ver_line}")
   set(Boost_VERSION_MAJOR "${CMAKE_MATCH_1}")
   set(Boost_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(Boost_VERSION_PATCH 0)
   set(Boost_VERSION_STRING "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.0")
   set(Boost_VERSION "${Boost_VERSION_STRING}")
-  set(Boost_FOUND TRUE)
+  unset(_avnd_boost_ver_line)
 
   if(NOT TARGET Boost::boost)
     add_library(Boost::boost INTERFACE IMPORTED GLOBAL)
@@ -40,11 +56,12 @@ if(Boost_INCLUDE_DIR AND EXISTS "${Boost_INCLUDE_DIR}/boost/version.hpp")
     set_target_properties(Boost::headers PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIR}")
   endif()
-else()
-  set(Boost_FOUND FALSE)
-  if(Boost_FIND_REQUIRED)
-    message(FATAL_ERROR
-      "FindBoost shim: Boost not found. Install Boost with CMake config "
-      "files, or pass -DBOOST_ROOT=<path to a Boost header tree>.")
-  endif()
 endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Boost
+  REQUIRED_VARS Boost_INCLUDE_DIR
+  VERSION_VAR Boost_VERSION_STRING
+  FAIL_MESSAGE
+    "Boost headers not found. Install Boost with CMake config files, or pass \
+-DBOOST_ROOT=<path to a Boost tree>.")

--- a/cmake/FindBoost.cmake
+++ b/cmake/FindBoost.cmake
@@ -1,0 +1,50 @@
+# Minimal FindBoost for CMake >= 4 (which removed the bundled module).
+#
+# Avendish only needs Boost headers (Boost::boost / Boost::headers). Strategy:
+#  1. defer to Boost's own BoostConfig.cmake when it is installed;
+#  2. otherwise, satisfy the request from a plain header tree given via
+#     BOOST_ROOT / Boost_INCLUDE_DIR.
+
+# 1. Prefer config mode if available.
+find_package(Boost ${Boost_FIND_VERSION} CONFIG QUIET)
+if(Boost_FOUND)
+  return()
+endif()
+
+# 2. Header-only fallback.
+if(NOT Boost_INCLUDE_DIR)
+  if(BOOST_ROOT)
+    set(Boost_INCLUDE_DIR "${BOOST_ROOT}")
+  elseif(DEFINED ENV{BOOST_ROOT})
+    set(Boost_INCLUDE_DIR "$ENV{BOOST_ROOT}")
+  endif()
+endif()
+
+if(Boost_INCLUDE_DIR AND EXISTS "${Boost_INCLUDE_DIR}/boost/version.hpp")
+  file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_ver_line
+       REGEX "#define BOOST_LIB_VERSION ")
+  string(REGEX MATCH "\"([0-9]+)_([0-9]+)\"" _ "${_boost_ver_line}")
+  set(Boost_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  set(Boost_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(Boost_VERSION_STRING "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.0")
+  set(Boost_VERSION "${Boost_VERSION_STRING}")
+  set(Boost_FOUND TRUE)
+
+  if(NOT TARGET Boost::boost)
+    add_library(Boost::boost INTERFACE IMPORTED GLOBAL)
+    set_target_properties(Boost::boost PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIR}")
+  endif()
+  if(NOT TARGET Boost::headers)
+    add_library(Boost::headers INTERFACE IMPORTED GLOBAL)
+    set_target_properties(Boost::headers PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIR}")
+  endif()
+else()
+  set(Boost_FOUND FALSE)
+  if(Boost_FIND_REQUIRED)
+    message(FATAL_ERROR
+      "FindBoost shim: Boost not found. Install Boost with CMake config "
+      "files, or pass -DBOOST_ROOT=<path to a Boost header tree>.")
+  endif()
+endif()

--- a/cmake/avendish.examples.cmake
+++ b/cmake/avendish.examples.cmake
@@ -41,6 +41,13 @@ avnd_make_all(
 )
 
 avnd_make_all(
+  TARGET MixedParams
+  MAIN_FILE examples/Raw/MixedParams.hpp
+  MAIN_CLASS examples::MixedParams
+  C_NAME avnd_mixed_params
+)
+
+avnd_make_all(
   TARGET PerSampleProcessor
   MAIN_FILE examples/Raw/PerSampleProcessor.hpp
   MAIN_CLASS examples::PerSampleProcessor

--- a/cmake/avendish.examples.cmake
+++ b/cmake/avendish.examples.cmake
@@ -34,6 +34,13 @@ avnd_make_all(
 )
 
 avnd_make_all(
+  TARGET CustomState
+  MAIN_FILE examples/Raw/CustomState.hpp
+  MAIN_CLASS examples::CustomState
+  C_NAME avnd_custom_state
+)
+
+avnd_make_all(
   TARGET PerSampleProcessor
   MAIN_FILE examples/Raw/PerSampleProcessor.hpp
   MAIN_CLASS examples::PerSampleProcessor

--- a/cmake/avendish.tests.cmake
+++ b/cmake/avendish.tests.cmake
@@ -59,6 +59,11 @@ if(BUILD_TESTING)
 
     avnd_add_catch_test(test_state_clap tests/objects/state_clap.cpp)
     target_include_directories(test_state_clap PRIVATE "${CLAP_HEADER}")
+
+    # Transport-to-tick conversion (uses the clap headers for the clap
+    # converter; the vst3 converter is tested through a structural mirror).
+    avnd_add_catch_test(test_transport tests/test_transport.cpp)
+    target_include_directories(test_transport PRIVATE "${CLAP_HEADER}")
   endif()
 endif()
 

--- a/cmake/avendish.tests.cmake
+++ b/cmake/avendish.tests.cmake
@@ -64,6 +64,10 @@ if(BUILD_TESTING)
     # converter; the vst3 converter is tested through a structural mirror).
     avnd_add_catch_test(test_transport tests/test_transport.cpp)
     target_include_directories(test_transport PRIVATE "${CLAP_HEADER}")
+
+    # update() dispatch on host parameter changes.
+    avnd_add_catch_test(test_update_controls tests/objects/update_controls.cpp)
+    target_include_directories(test_update_controls PRIVATE "${CLAP_HEADER}")
   endif()
 endif()
 

--- a/cmake/avendish.tests.cmake
+++ b/cmake/avendish.tests.cmake
@@ -49,10 +49,16 @@ if(BUILD_TESTING)
   avnd_add_catch_test(test_gain tests/objects/gain.cpp)
   avnd_add_catch_test(test_patternal tests/objects/patternal.cpp)
 
-  # clap_plugin_params::flush event application.
+  # Custom-state feature
+  avnd_add_static_test(test_state tests/test_state.cpp)
+
   if(AVND_ENABLE_CLAP AND CLAP_HEADER)
+    # clap_plugin_params::flush event application.
     avnd_add_catch_test(test_params_flush tests/objects/params_flush.cpp)
     target_include_directories(test_params_flush PRIVATE "${CLAP_HEADER}")
+
+    avnd_add_catch_test(test_state_clap tests/objects/state_clap.cpp)
+    target_include_directories(test_state_clap PRIVATE "${CLAP_HEADER}")
   endif()
 endif()
 

--- a/examples/Raw/CustomState.hpp
+++ b/examples/Raw/CustomState.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace examples
+{
+/**
+ * Example of the custom host-state (session persistence) feature:
+ * see <avnd/concepts/state.hpp> and the "Host state" chapter of the manual.
+ *
+ * A processor may carry state beyond its parameter ports -- pattern data,
+ * captured buffers, generated content... By exposing save_state / load_state,
+ * that state is persisted in the DAW session by the plug-in bindings
+ * (currently CLAP and VST3), appended to the usual parameter persistence.
+ *
+ * The blob is entirely owned by the processor: version it, validate it,
+ * and reject anything suspicious by returning false (the bindings then
+ * keep the current state and report failure to the host).
+ */
+struct CustomState
+{
+  static constexpr auto name() { return "CustomState"; }
+  static constexpr auto c_name() { return "avnd_custom_state"; }
+  static constexpr auto uuid() { return "3183d03e-2f43-4c4b-9a1e-6f5f2a3d9f4b"; }
+
+  struct
+  {
+    struct
+    {
+      static constexpr auto name() { return "Level"; }
+      struct range
+      {
+        double min = 0., max = 1., init = 0.5;
+      };
+      double value = 0.5;
+    } level;
+  } inputs;
+
+  struct
+  {
+  } outputs;
+
+  // Some state that is not expressible as parameters: here, a little
+  // event pattern the user could edit through a custom UI.
+  std::vector<uint8_t> pattern = {1, 0, 0, 1};
+
+  static constexpr uint32_t state_magic = 0x50415431; // 'PAT1'
+
+  std::vector<uint8_t> save_state()
+  {
+    std::vector<uint8_t> blob(8 + pattern.size());
+    const uint32_t size = uint32_t(pattern.size());
+    std::memcpy(blob.data(), &state_magic, 4);
+    std::memcpy(blob.data() + 4, &size, 4);
+    std::memcpy(blob.data() + 8, pattern.data(), pattern.size());
+    return blob;
+  }
+
+  bool load_state(const uint8_t* data, size_t n)
+  {
+    if(n < 8)
+      return false;
+    uint32_t magic{}, size{};
+    std::memcpy(&magic, data, 4);
+    std::memcpy(&size, data + 4, 4);
+    if(magic != state_magic || n != 8 + size_t(size) || size > 4096)
+      return false;
+    pattern.assign(data + 8, data + 8 + size);
+    return true;
+  }
+
+  double operator()(double in)
+  {
+    // (The pattern would do something interesting here.)
+    return in * inputs.level.value;
+  }
+};
+}

--- a/examples/Raw/MixedParams.hpp
+++ b/examples/Raw/MixedParams.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+namespace examples
+{
+/**
+ * A processor whose parameters come AFTER an audio port, so their raw field
+ * indices differ from their dense ordinals: exercises the id space of the
+ * parameter and state paths in the bindings.
+ */
+struct MixedParams
+{
+  static constexpr auto name() { return "MixedParams"; }
+  static constexpr auto c_name() { return "avnd_mixed_params"; }
+  static constexpr auto uuid() { return "16d3f7c2-8b7e-4a52-b64f-2c1a90aa7e55"; }
+
+  struct
+  {
+    struct
+    {
+      static constexpr auto name() { return "In"; }
+      const double** samples{};
+      int channels{};
+    } audio;
+
+    struct
+    {
+      static constexpr auto name() { return "Mix"; }
+      struct range
+      {
+        double min = 0., max = 1., init = 1.;
+      };
+      double value = 1.;
+    } mix;
+
+    struct
+    {
+      static constexpr auto name() { return "Freq"; }
+      struct range
+      {
+        double min = 20., max = 20000., init = 440.;
+      };
+      double value = 440.;
+    } freq;
+
+    struct
+    {
+      static constexpr auto name() { return "Mode"; }
+      struct range
+      {
+        int min = 0, max = 3, init = 0;
+      };
+      int value = 0;
+    } mode;
+  } inputs;
+
+  struct
+  {
+    struct
+    {
+      static constexpr auto name() { return "Out"; }
+      double** samples{};
+      int channels{};
+    } audio;
+  } outputs;
+
+  void operator()(int frames)
+  {
+    for(int c = 0; c < outputs.audio.channels; c++)
+      for(int i = 0; i < frames; i++)
+        outputs.audio.samples[c][i]
+            = (c < inputs.audio.channels ? inputs.audio.samples[c][i] : 0.)
+              * inputs.mix.value;
+  }
+};
+}

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -457,7 +457,7 @@ struct SimpleAudioEffect : clap_plugin
   //   param_count x f64 normalized values (port order)
   //   u64 blob_size  [blob bytes]
   static constexpr uint32_t state_magic = 0x41564353; // 'AVCS'
-  static constexpr uint32_t state_version = 1;
+  static constexpr uint32_t state_version = 2;
   static constexpr uint64_t state_max_blob = 1024 * 1024 * 1024; // sanity
 
   static bool
@@ -500,9 +500,14 @@ struct SimpleAudioEffect : clap_plugin
     bool ok = true;
     if constexpr(parameter_count > 0)
     {
+      // (raw id, plain value) pairs: the same id and value space as the
+      // params extension, robust to parameter reordering across versions.
+      std::size_t ordinal = 0;
       param_in_info::for_all(controls_inputs(), [&]<typename C>(C& field) {
+        const uint32_t id = uint32_t(param_in_info::index_map[ordinal++]);
         double v{};
-        if_possible(v = avnd::map_control_to_01<C>(field.value));
+        if_possible(v = avnd::map_control_to_double(field));
+        ok &= write_all(os, &id, sizeof(id));
         ok &= write_all(os, &v, sizeof(v));
       });
       if(!ok)
@@ -547,22 +552,27 @@ struct SimpleAudioEffect : clap_plugin
     if(stored_params > 65536)
       return false;
 
-    // Parameters first (tier 0): apply the common ordinal prefix.
-    std::vector<double> values(stored_params);
-    if(stored_params > 0 && !read_exact(is, values.data(), stored_params * 8))
-      return false;
-    for(auto state : this->effect.full_state())
+    // Parameters first (tier 0): (raw id, plain value) pairs; unknown ids
+    // are skipped (parameter removed in a newer version). A state restore
+    // is an opaque bulk assignment, not a host gesture: update() callbacks
+    // are NOT dispatched here -- a derive-style handler (one that rewrites
+    // other ports) would otherwise clobber freshly restored values in
+    // save-order-dependent ways. Processors that derive internal state
+    // from their ports reconcile in their custom-state load.
+    for(uint32_t k = 0; k < stored_params; k++)
     {
-      std::size_t i = 0;
-      param_in_info::for_all(state.inputs, [&]<typename C>(C& field) {
-        if(i < values.size())
-        {
-          if constexpr(requires { avnd::map_control_from_01<C>(values[i]); })
-            field.value = avnd::map_control_from_01<C>(values[i]);
-        }
-        i++;
-      });
-      avnd::update_controls(state);
+      uint32_t id{};
+      double v{};
+      if(!read_exact(is, &id, sizeof(id)) || !read_exact(is, &v, sizeof(v)))
+        return false;
+      for(auto state : this->effect.full_state())
+        param_in_info::for_nth_raw(
+            state.inputs, int(id), [&]<typename C>(C& field) {
+              if constexpr(requires {
+                             field.value = avnd::map_control_from_double<C>(v);
+                           })
+                field.value = avnd::map_control_from_double<C>(v);
+            });
     }
 
     // Then the custom blob (tier 1): it wins where the two overlap.

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -227,11 +227,9 @@ struct SimpleAudioEffect : clap_plugin
     // an empty std::function call terminates under -fno-exceptions.
     avnd::wire_fallback_callbacks(effect);
 
-    // Polyphonic containers keep their instances in a vector populated by
-    // init_channels at activation -- but hosts drive the state and parameter
-    // entry points on deactivated plug-ins (state loads, main-thread flush),
-    // and every full_state() consumer silently does nothing on an empty
-    // container. Guarantee one live instance from construction.
+    // full_state() iterates the instance vector, which init_channels only
+    // fills at activation; hosts drive state and parameters (loads,
+    // main-thread flush) while deactivated, so keep one instance always live.
     effect.init_channels(1, 1);
   }
 
@@ -599,14 +597,11 @@ struct SimpleAudioEffect : clap_plugin
 
   void process_param(const clap_event_param_value& p)
   {
-    // Parameter ids are the RAW field indices (as advertised by
-    // get_param_info) and values are PLAIN, in the [min_value, max_value]
-    // range of the param info -- matching get_value. Apply to every
-    // (per-channel) instance; guard the whole assignment, as the conversion
-    // is also well-formed for controls whose value cannot be assigned from
-    // it, such as the optional payload of an impulse button.
-    // Ports with an update() callback get it invoked with the new value in
-    // place, like in init_controls.
+    // Ids are raw field indices and values are plain [min, max], matching
+    // get_param_info / get_value. The assignment is guarded rather than the
+    // conversion: the conversion is well-formed even where its result is not
+    // assignable (an impulse button's optional payload). update() runs per
+    // change, as in init_controls.
     for(auto state : this->effect.full_state())
       param_in_info::for_nth_raw(
           state.inputs, p.param_id, [&]<typename C>(C& field) {

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -562,6 +562,7 @@ struct SimpleAudioEffect : clap_plugin
         }
         i++;
       });
+      avnd::update_controls(state);
     }
 
     // Then the custom blob (tier 1): it wins where the two overlap.
@@ -594,6 +595,8 @@ struct SimpleAudioEffect : clap_plugin
     // (per-channel) instance; guard the whole assignment, as the conversion
     // is also well-formed for controls whose value cannot be assigned from
     // it, such as the optional payload of an impulse button.
+    // Ports with an update() callback get it invoked with the new value in
+    // place, like in init_controls.
     for(auto state : this->effect.full_state())
       param_in_info::for_nth_raw(
           state.inputs, p.param_id, [&]<typename C>(C& field) {
@@ -601,6 +604,7 @@ struct SimpleAudioEffect : clap_plugin
                            field.value = avnd::map_control_from_double<C>(p.value);
                          })
               field.value = avnd::map_control_from_double<C>(p.value);
+            if_possible(field.update(state.effect));
           });
   }
 

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -5,6 +5,7 @@
 #include <avnd/binding/clap/bus_info.hpp>
 #include <avnd/binding/clap/helpers.hpp>
 #include <avnd/common/export.hpp>
+#include <avnd/concepts/state.hpp>
 #include <avnd/introspection/channels.hpp>
 #include <avnd/introspection/midi.hpp>
 #include <avnd/wrappers/control_display.hpp>
@@ -14,10 +15,12 @@
 #include <avnd/wrappers/metadatas.hpp>
 #include <avnd/wrappers/prepare.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
+#include <avnd/wrappers/state.hpp>
 #include <avnd/wrappers/widgets.hpp>
 #include <clap/all.h>
 
 #include <algorithm>
+#include <vector>
 
 namespace avnd_clap
 {
@@ -133,6 +136,8 @@ struct SimpleAudioEffect : clap_plugin
   AVND_NO_UNIQUE_ADDRESS avnd::control_storage<T> control_buffers;
   AVND_NO_UNIQUE_ADDRESS midi_processor<T> midi;
 
+  clap_plugin_state state_ext{};
+
   float sample_rate{44100.};
   int buffer_size{512};
 
@@ -185,8 +190,22 @@ struct SimpleAudioEffect : clap_plugin
         return &p.audio_ports;
       if(id_sv == "clap.note-ports")
         return &p.note_ports;
+      if(id_sv == CLAP_EXT_STATE)
+        return &p.state_ext;
 
       return nullptr;
+    };
+
+    // Session persistence: parameter values + the object's opaque custom
+    // state when it models avnd::has_custom_state (container format
+    // described below).
+    state_ext.save
+        = [](const clap_plugin* plugin, const clap_ostream* stream) -> bool {
+      return self(plugin)->save_state_impl(stream);
+    };
+    state_ext.load
+        = [](const clap_plugin* plugin, const clap_istream* stream) -> bool {
+      return self(plugin)->load_state_impl(stream);
     };
 
     clap_plugin::on_main_thread = [](const struct clap_plugin* plugin) {};
@@ -401,6 +420,143 @@ struct SimpleAudioEffect : clap_plugin
       static typename avnd::inputs_type<T>::type empty{};
       return (empty);
     }
+  }
+
+  /*****************/
+  /**** STATE ******/
+  /*****************/
+  // Container format (native little-endian):
+  //   u32 'AVCS'  u32 version=1  u32 param_count  u32 reserved
+  //   param_count x f64 normalized values (port order)
+  //   u64 blob_size  [blob bytes]
+  static constexpr uint32_t state_magic = 0x41564353; // 'AVCS'
+  static constexpr uint32_t state_version = 1;
+  static constexpr uint64_t state_max_blob = 1024 * 1024 * 1024; // sanity
+
+  static bool
+  write_all(const clap_ostream* os, const void* data, uint64_t size) noexcept
+  {
+    auto p = static_cast<const uint8_t*>(data);
+    while(size > 0)
+    {
+      const int64_t n = os->write(os, p, size);
+      if(n <= 0)
+        return false;
+      p += n;
+      size -= uint64_t(n);
+    }
+    return true;
+  }
+
+  static bool
+  read_exact(const clap_istream* is, void* data, uint64_t size) noexcept
+  {
+    auto p = static_cast<uint8_t*>(data);
+    while(size > 0)
+    {
+      const int64_t n = is->read(is, p, size);
+      if(n <= 0)
+        return false;
+      p += n;
+      size -= uint64_t(n);
+    }
+    return true;
+  }
+
+  bool save_state_impl(const clap_ostream* os)
+  {
+    const uint32_t header[4]
+        = {state_magic, state_version, uint32_t(parameter_count), 0};
+    if(!write_all(os, header, sizeof(header)))
+      return false;
+
+    bool ok = true;
+    if constexpr(parameter_count > 0)
+    {
+      param_in_info::for_all(controls_inputs(), [&]<typename C>(C& field) {
+        double v{};
+        if_possible(v = avnd::map_control_to_01<C>(field.value));
+        ok &= write_all(os, &v, sizeof(v));
+      });
+      if(!ok)
+        return false;
+    }
+
+    uint64_t blob_size = 0;
+    if constexpr(avnd::has_custom_state<T>)
+    {
+      // Save from the first instance (polyphonic instances share state).
+      std::vector<uint8_t> blob;
+      for(auto state : this->effect.full_state())
+      {
+        avnd::save_state(state.effect, [&](const void* d, std::size_t n) {
+          auto b = static_cast<const uint8_t*>(d);
+          blob.insert(blob.end(), b, b + n);
+        });
+        break;
+      }
+      blob_size = blob.size();
+      if(!write_all(os, &blob_size, sizeof(blob_size)))
+        return false;
+      if(blob_size > 0 && !write_all(os, blob.data(), blob_size))
+        return false;
+    }
+    else
+    {
+      if(!write_all(os, &blob_size, sizeof(blob_size)))
+        return false;
+    }
+    return true;
+  }
+
+  bool load_state_impl(const clap_istream* is)
+  {
+    uint32_t header[4]{};
+    if(!read_exact(is, header, sizeof(header)))
+      return false;
+    if(header[0] != state_magic || header[1] != state_version)
+      return false;
+    const uint32_t stored_params = header[2];
+    if(stored_params > 65536)
+      return false;
+
+    // Parameters first (tier 0): apply the common ordinal prefix.
+    std::vector<double> values(stored_params);
+    if(stored_params > 0 && !read_exact(is, values.data(), stored_params * 8))
+      return false;
+    for(auto state : this->effect.full_state())
+    {
+      std::size_t i = 0;
+      param_in_info::for_all(state.inputs, [&]<typename C>(C& field) {
+        if(i < values.size())
+        {
+          if constexpr(requires { avnd::map_control_from_01<C>(values[i]); })
+            field.value = avnd::map_control_from_01<C>(values[i]);
+        }
+        i++;
+      });
+    }
+
+    // Then the custom blob (tier 1): it wins where the two overlap.
+    uint64_t blob_size = 0;
+    if(!read_exact(is, &blob_size, sizeof(blob_size)))
+      return false;
+    if(blob_size > state_max_blob)
+      return false;
+    if constexpr(avnd::has_custom_state<T>)
+    {
+      if(blob_size > 0)
+      {
+        std::vector<uint8_t> blob(blob_size);
+        if(!read_exact(is, blob.data(), blob_size))
+          return false;
+        bool ok = true;
+        for(auto state : this->effect.full_state())
+          ok &= avnd::load_state(state.effect, blob.data(), blob.size());
+        return ok;
+      }
+    }
+    return true;
   }
 
   void process_param(const clap_event_param_value& p)

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -4,6 +4,7 @@
 
 #include <avnd/binding/clap/bus_info.hpp>
 #include <avnd/binding/clap/helpers.hpp>
+#include <avnd/binding/clap/transport.hpp>
 #include <avnd/common/export.hpp>
 #include <avnd/concepts/state.hpp>
 #include <avnd/introspection/channels.hpp>
@@ -137,6 +138,12 @@ struct SimpleAudioEffect : clap_plugin
   AVND_NO_UNIQUE_ADDRESS midi_processor<T> midi;
 
   clap_plugin_state state_ext{};
+
+  // Latest transport information: clap_process::transport at block start,
+  // then any CLAP_EVENT_TRANSPORT in-events. When no transport was ever
+  // provided, processors receive the frames-only tick as before.
+  clap_event_transport_t transport_state{};
+  bool transport_known{false};
 
   float sample_rate{44100.};
   int buffer_size{512};
@@ -307,9 +314,22 @@ struct SimpleAudioEffect : clap_plugin
       if(!outputs[i])
         outputs[i] = trash_buffer<samples_t>();
 
-    processor.process(
-        effect, avnd::span<samples_t*>{inputs, std::size_t(in_N)},
-        avnd::span<samples_t*>{outputs, std::size_t(out_N)}, process.frames_count);
+    if(transport_known)
+    {
+      processor.process(
+          effect, avnd::span<samples_t*>{inputs, std::size_t(in_N)},
+          avnd::span<samples_t*>{outputs, std::size_t(out_N)},
+          tick_from_transport(
+              transport_state, process.frames_count, sample_rate,
+              process.steady_time));
+    }
+    else
+    {
+      processor.process(
+          effect, avnd::span<samples_t*>{inputs, std::size_t(in_N)},
+          avnd::span<samples_t*>{outputs, std::size_t(out_N)},
+          process.frames_count);
+    }
   }
 
   // Scratch rows substituted for null host channel pointers. Sized in
@@ -344,6 +364,13 @@ struct SimpleAudioEffect : clap_plugin
 
     // Clear the midi out ports
     midi.clear_outputs(this->effect);
+
+    // Block-start transport; CLAP_EVENT_TRANSPORT in-events refine it below.
+    if(process.transport)
+    {
+      transport_state = *process.transport;
+      transport_known = true;
+    }
 
     // Process the input events
     process_in_events(process);
@@ -579,7 +606,8 @@ struct SimpleAudioEffect : clap_plugin
 
   void process_transport(const clap_event_transport& transport)
   {
-    // TODO
+    transport_state = transport;
+    transport_known = true;
   }
 
   void process_in_events(const clap_process& p)

--- a/include/avnd/binding/clap/transport.hpp
+++ b/include/avnd/binding/clap/transport.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/wrappers/transport_tick.hpp>
+#include <clap/all.h>
+
+#include <cmath>
+
+namespace avnd_clap
+{
+/**
+ * Translate a clap_event_transport into an avnd::transport_tick for one
+ * block of `frames` frames at `sample_rate`.
+ *
+ * Semantics:
+ *  - clap_beattime / clap_sectime are 32.31 fixed point; conversion is a
+ *    plain division by CLAP_BEATTIME_FACTOR / CLAP_SECTIME_FACTOR (exact in
+ *    double for any position below ~2^21 beats / seconds). Beats are
+ *    quarter notes.
+ *  - Fields whose flag is absent fall back to: tempo 120, signature 4/4,
+ *    positions 0.
+ *  - end_position_in_quarters = start + frames * tempo / (60 * rate),
+ *    i.e. tempo is taken as constant over the block (tempo_inc is applied
+ *    by hosts through per-block transport updates).
+ *  - The seconds timeline is preferred for the seconds/frames/flicks
+ *    positions; without it they are derived from the beats timeline at
+ *    constant tempo; without either they stay at steady_time (if provided).
+ */
+inline avnd::transport_tick tick_from_transport(
+    const clap_event_transport_t& tr, uint32_t frames, double sample_rate,
+    int64_t steady_time = -1) noexcept
+{
+  avnd::transport_tick t;
+  t.frames = int32_t(frames);
+
+  if(tr.flags & CLAP_TRANSPORT_HAS_TEMPO)
+    t.tempo = tr.tempo;
+  if(tr.flags & CLAP_TRANSPORT_HAS_TIME_SIGNATURE)
+  {
+    t.signature.num = tr.tsig_num;
+    t.signature.denom = tr.tsig_denom;
+  }
+  t.playing = (tr.flags & CLAP_TRANSPORT_IS_PLAYING) != 0;
+  t.speed = t.playing ? 1. : 0.;
+
+  const double rate = sample_rate > 0 ? sample_rate : 44100.;
+  const double block_quarters = double(frames) * t.tempo / (60. * rate);
+
+  if(tr.flags & CLAP_TRANSPORT_HAS_BEATS_TIMELINE)
+  {
+    t.start_position_in_quarters
+        = double(tr.song_pos_beats) / CLAP_BEATTIME_FACTOR;
+    t.end_position_in_quarters = t.start_position_in_quarters + block_quarters;
+
+    const double bar_start = double(tr.bar_start) / CLAP_BEATTIME_FACTOR;
+    const double quarters_per_bar
+        = t.signature.denom > 0
+              ? double(t.signature.num) * 4. / double(t.signature.denom)
+              : 4.;
+    t.bar_at_start = bar_start;
+    t.bar_at_end = avnd::last_bar_before(
+        t.end_position_in_quarters, bar_start, quarters_per_bar);
+  }
+  else
+  {
+    t.end_position_in_quarters = block_quarters;
+  }
+
+  double seconds = 0.;
+  bool has_seconds = false;
+  if(tr.flags & CLAP_TRANSPORT_HAS_SECONDS_TIMELINE)
+  {
+    seconds = double(tr.song_pos_seconds) / CLAP_SECTIME_FACTOR;
+    has_seconds = true;
+  }
+  else if(tr.flags & CLAP_TRANSPORT_HAS_BEATS_TIMELINE)
+  {
+    // Constant-tempo approximation of the seconds position.
+    seconds = t.start_position_in_quarters * 60. / t.tempo;
+    has_seconds = true;
+  }
+
+  if(has_seconds)
+  {
+    t.position_in_seconds = seconds;
+    t.position_in_frames = int64_t(std::llround(seconds * rate));
+    t.start_in_flicks = int64_t(std::llround(seconds * avnd::flicks_per_second));
+    t.end_in_flicks = int64_t(std::llround(
+        (seconds + double(frames) / rate) * avnd::flicks_per_second));
+  }
+  else if(steady_time >= 0)
+  {
+    t.position_in_frames = steady_time;
+    t.position_in_seconds = double(steady_time) / rate;
+  }
+
+  return t;
+}
+}

--- a/include/avnd/binding/vst3/component.hpp
+++ b/include/avnd/binding/vst3/component.hpp
@@ -5,6 +5,7 @@
 #include <avnd/binding/vst3/bus_info.hpp>
 #include <avnd/binding/vst3/component_base.hpp>
 #include <avnd/binding/vst3/helpers.hpp>
+#include <avnd/binding/vst3/param_apply.hpp>
 #include <avnd/binding/vst3/refcount.hpp>
 #include <avnd/binding/vst3/transport.hpp>
 #include <avnd/concepts/state.hpp>
@@ -372,14 +373,7 @@ struct Component final
     int id = queue.getParameterId();
     if(queue.getPoint(numPoints - 1, sampleOffset, value) == Steinberg::kResultTrue)
     {
-      // Apply the host parameter change to every (per-channel) instance so all
-      // voices of a polyphonic effect track automation, not just instance 0.
-      for(auto state : this->effect.full_state())
-        avnd::parameter_input_introspection<T>::for_nth_raw(
-            state.inputs, id, [&]<typename C>(C& ctl) {
-              if constexpr(requires { avnd::map_control_from_01<C>(value); })
-                assign_if_assignable(ctl.value, avnd::map_control_from_01<C>(value));
-            });
+      stv3::apply_control(this->effect, id, value);
     };
   }
 
@@ -615,6 +609,14 @@ struct Component final
       bool ok = inputs_info_t::for_all_unless(this->controls_inputs(), read_one);
       if(!ok)
         return Steinberg::kResultFalse;
+
+      // Restored values are host-driven changes: dispatch update() on the
+      // instance the values landed in.
+      for(auto st : this->effect.full_state())
+      {
+        avnd::update_controls(st);
+        break;
+      }
     }
 
     if constexpr(avnd::has_custom_state<T>)

--- a/include/avnd/binding/vst3/component.hpp
+++ b/include/avnd/binding/vst3/component.hpp
@@ -6,6 +6,7 @@
 #include <avnd/binding/vst3/component_base.hpp>
 #include <avnd/binding/vst3/helpers.hpp>
 #include <avnd/binding/vst3/refcount.hpp>
+#include <avnd/binding/vst3/transport.hpp>
 #include <avnd/concepts/state.hpp>
 #include <avnd/introspection/input.hpp>
 #include <avnd/introspection/midi.hpp>
@@ -513,24 +514,31 @@ struct Component final
     auto out = stv3::getChannelBuffersPointer(processSetup, data.outputs[0]);
 
     data.outputs[0].silenceFlags = 0;
+
+    // With a ProcessContext, hand the processor a transport-filled tick;
+    // otherwise keep the frames-only invocation.
+    auto invoke = [&]<typename Sample>() {
+      auto ins = avnd::span<Sample*>{
+          (Sample**)in, std::size_t(data.inputs[0].numChannels)};
+      auto outs = avnd::span<Sample*>{
+          (Sample**)out, std::size_t(data.outputs[0].numChannels)};
+      if(data.processContext)
+      {
+        processor.process(
+            effect, ins, outs,
+            stv3::tick_from_context(
+                *data.processContext, data.numSamples, processSetup.sampleRate));
+      }
+      else
+      {
+        processor.process(effect, ins, outs, data.numSamples);
+      }
+    };
+
     if(data.symbolicSampleSize == kSample32)
-    {
-      processor.process(
-          effect,
-          avnd::span<Sample32*>{(Sample32**)in, std::size_t(data.inputs[0].numChannels)},
-          avnd::span<Sample32*>{
-              (Sample32**)out, std::size_t(data.outputs[0].numChannels)},
-          data.numSamples);
-    }
+      invoke.template operator()<Sample32>();
     else
-    {
-      processor.process(
-          effect,
-          avnd::span<Sample64*>{(Sample64**)in, std::size_t(data.inputs[0].numChannels)},
-          avnd::span<Sample64*>{
-              (Sample64**)out, std::size_t(data.outputs[0].numChannels)},
-          data.numSamples);
-    }
+      invoke.template operator()<Sample64>();
   }
 
   void processOutputs(ProcessData& data)

--- a/include/avnd/binding/vst3/component.hpp
+++ b/include/avnd/binding/vst3/component.hpp
@@ -598,7 +598,10 @@ struct Component final
         double param = 0.f;
         if(streamer.readDouble(param) == false)
           return false;
-        // map_control_from_01 is deleted for non-scalar controls.
+        // map_control_from_01 is deleted for non-scalar controls. A state
+        // restore is an opaque bulk assignment, not a host gesture: update()
+        // is not dispatched here (derive-style handlers would clobber other
+        // freshly restored values in save-order-dependent ways).
         if constexpr(requires { avnd::map_control_from_01<C>(param); })
           assign_if_assignable(field.value, avnd::map_control_from_01<C>(param));
         return true;
@@ -610,13 +613,6 @@ struct Component final
       if(!ok)
         return Steinberg::kResultFalse;
 
-      // Restored values are host-driven changes: dispatch update() on the
-      // instance the values landed in.
-      for(auto st : this->effect.full_state())
-      {
-        avnd::update_controls(st);
-        break;
-      }
     }
 
     if constexpr(avnd::has_custom_state<T>)

--- a/include/avnd/binding/vst3/component.hpp
+++ b/include/avnd/binding/vst3/component.hpp
@@ -6,6 +6,7 @@
 #include <avnd/binding/vst3/component_base.hpp>
 #include <avnd/binding/vst3/helpers.hpp>
 #include <avnd/binding/vst3/refcount.hpp>
+#include <avnd/concepts/state.hpp>
 #include <avnd/introspection/input.hpp>
 #include <avnd/introspection/midi.hpp>
 #include <avnd/introspection/output.hpp>
@@ -13,6 +14,9 @@
 #include <avnd/wrappers/controls_storage.hpp>
 #include <avnd/wrappers/prepare.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
+#include <avnd/wrappers/state.hpp>
+
+#include <vector>
 
 namespace stv3
 {
@@ -567,6 +571,15 @@ struct Component final
   /**** SAVING ****/
   /****************/
 
+  // Custom-state trailer, appended after the parameter doubles so existing
+  // session data stays byte-compatible:
+  //   u32 'AVCS'  u32 version=1  u64 blob_size  [blob bytes]
+  // The controller's setComponentState reads only the doubles and never
+  // sees the trailer; old sessions simply end at EOF before it.
+  static constexpr Steinberg::uint32 state_trailer_magic = 0x41564353; // AVCS
+  static constexpr Steinberg::uint32 state_trailer_version = 1;
+  static constexpr Steinberg::uint64 state_max_blob = 1024 * 1024 * 1024;
+
   tresult setState(IBStream* state) override
   {
     using namespace Steinberg;
@@ -592,13 +605,36 @@ struct Component final
       // One representative control set => exactly inputs_info_t::size doubles,
       // matching getState and the controller's setComponentState.
       bool ok = inputs_info_t::for_all_unless(this->controls_inputs(), read_one);
+      if(!ok)
+        return Steinberg::kResultFalse;
+    }
 
-      return ok ? Steinberg::kResultOk : Steinberg::kResultFalse;
-    }
-    else
+    if constexpr(avnd::has_custom_state<T>)
     {
-      return Steinberg::kResultOk;
+      // Optional trailer: absent in pre-feature sessions (EOF here is fine).
+      uint32 magic{};
+      if(streamer.readInt32u(magic) == false)
+        return Steinberg::kResultOk;
+      if(magic != state_trailer_magic)
+        return Steinberg::kResultOk; // unknown data: leave defaults, don't fail
+      uint32 version{};
+      if(streamer.readInt32u(version) == false || version != state_trailer_version)
+        return Steinberg::kResultOk;
+      uint64 blob_size{};
+      if(streamer.readInt64u(blob_size) == false || blob_size > state_max_blob)
+        return Steinberg::kResultFalse;
+      if(blob_size > 0)
+      {
+        std::vector<uint8_t> blob(blob_size);
+        if(streamer.readRaw(blob.data(), int32(blob_size)) != int32(blob_size))
+          return Steinberg::kResultFalse;
+        bool ok = true;
+        for(auto st : this->effect.full_state())
+          ok &= avnd::load_state(st.effect, blob.data(), blob.size());
+        return ok ? Steinberg::kResultOk : Steinberg::kResultFalse;
+      }
     }
+    return Steinberg::kResultOk;
   }
 
   tresult getState(IBStream* state) override
@@ -617,13 +653,33 @@ struct Component final
       };
 
       bool ok = inputs_info_t::for_all_unless(this->controls_inputs(), write_one);
+      if(!ok)
+        return Steinberg::kResultFalse;
+    }
 
-      return ok ? Steinberg::kResultOk : Steinberg::kResultFalse;
-    }
-    else
+    if constexpr(avnd::has_custom_state<T>)
     {
-      return Steinberg::kResultOk;
+      // Save from the first instance (polyphonic instances share state).
+      std::vector<uint8_t> blob;
+      for(auto st : this->effect.full_state())
+      {
+        avnd::save_state(st.effect, [&](const void* d, std::size_t n) {
+          auto b = static_cast<const uint8_t*>(d);
+          blob.insert(blob.end(), b, b + n);
+        });
+        break;
+      }
+      if(streamer.writeInt32u(state_trailer_magic) == false)
+        return Steinberg::kResultFalse;
+      if(streamer.writeInt32u(state_trailer_version) == false)
+        return Steinberg::kResultFalse;
+      if(streamer.writeInt64u(uint64(blob.size())) == false)
+        return Steinberg::kResultFalse;
+      if(!blob.empty())
+        if(streamer.writeRaw(blob.data(), int32(blob.size())) == false)
+          return Steinberg::kResultFalse;
     }
+    return Steinberg::kResultOk;
   }
 
   /****************/

--- a/include/avnd/binding/vst3/param_apply.hpp
+++ b/include/avnd/binding/vst3/param_apply.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/introspection/input.hpp>
+#include <avnd/wrappers/controls.hpp>
+#include <avnd/wrappers/controls_double.hpp>
+#include <avnd/wrappers/effect_container.hpp>
+
+namespace stv3
+{
+/**
+ * Apply one host parameter change (raw field index, normalized [0, 1] value)
+ * to every effect instance, invoking the port's update() callback with the
+ * new value in place, like init_controls does.
+ *
+ * Kept free of SDK types so it is testable on its own.
+ */
+template <typename T>
+inline void
+apply_control(avnd::effect_container<T>& effect, int id, double value) noexcept
+{
+  // Apply the host parameter change to every (per-channel) instance so all
+  // voices of a polyphonic effect track automation, not just instance 0.
+  for(auto state : effect.full_state())
+    avnd::parameter_input_introspection<T>::for_nth_raw(
+        state.inputs, id, [&]<typename C>(C& ctl) {
+          if constexpr(requires { avnd::map_control_from_01<C>(value); })
+            assign_if_assignable(ctl.value, avnd::map_control_from_01<C>(value));
+          if_possible(ctl.update(state.effect));
+        });
+}
+}

--- a/include/avnd/binding/vst3/transport.hpp
+++ b/include/avnd/binding/vst3/transport.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/wrappers/transport_tick.hpp>
+
+#include <cmath>
+#include <cstdint>
+
+namespace stv3
+{
+/**
+ * Translate a ProcessContext into an avnd::transport_tick for one block.
+ *
+ * Templated on the context type so the conversion is testable without the
+ * SDK headers: any type with ProcessContext's fields and StatesAndFlags
+ * constants works.
+ *
+ * Semantics:
+ *  - validity flags are honored per field: tempo (kTempoValid, else 120),
+ *    signature (kTimeSigValid, else 4/4), musical position
+ *    (kProjectTimeMusicValid, else derived from projectTimeSamples at the
+ *    current tempo), bar position (kBarPositionValid, else the last bar
+ *    boundary before the start assuming bars aligned at 0);
+ *  - projectTimeSamples needs no flag (always provided per the spec) and
+ *    yields the seconds/frames/flicks positions;
+ *  - position_in_nanoseconds comes from systemTime when kSystemTimeValid;
+ *  - end_position_in_quarters = start + frames * tempo / (60 * rate).
+ */
+template <typename ProcessContext>
+inline avnd::transport_tick
+tick_from_context(const ProcessContext& ctx, int32_t frames, double fallback_rate) noexcept
+{
+  avnd::transport_tick t;
+  t.frames = frames;
+
+  if(ctx.state & ProcessContext::kTempoValid)
+    t.tempo = ctx.tempo;
+  if(ctx.state & ProcessContext::kTimeSigValid)
+  {
+    t.signature.num = uint16_t(ctx.timeSigNumerator);
+    t.signature.denom = uint16_t(ctx.timeSigDenominator);
+  }
+  t.playing = (ctx.state & ProcessContext::kPlaying) != 0;
+  t.speed = t.playing ? 1. : 0.;
+
+  const double rate = ctx.sampleRate > 0 ? ctx.sampleRate : fallback_rate;
+  const double seconds = rate > 0 ? double(ctx.projectTimeSamples) / rate : 0.;
+
+  t.position_in_frames = ctx.projectTimeSamples;
+  t.position_in_seconds = seconds;
+  t.start_in_flicks = int64_t(std::llround(seconds * avnd::flicks_per_second));
+  t.end_in_flicks = int64_t(std::llround(
+      (seconds + (rate > 0 ? double(frames) / rate : 0.))
+      * avnd::flicks_per_second));
+
+  if(ctx.state & ProcessContext::kSystemTimeValid)
+    t.position_in_nanoseconds = double(ctx.systemTime);
+
+  if(ctx.state & ProcessContext::kProjectTimeMusicValid)
+    t.start_position_in_quarters = ctx.projectTimeMusic;
+  else
+    t.start_position_in_quarters = seconds * t.tempo / 60.;
+
+  t.end_position_in_quarters = t.start_position_in_quarters
+                               + (rate > 0 ? double(frames) * t.tempo / (60. * rate) : 0.);
+
+  const double quarters_per_bar
+      = t.signature.denom > 0
+            ? double(t.signature.num) * 4. / double(t.signature.denom)
+            : 4.;
+  if(ctx.state & ProcessContext::kBarPositionValid)
+    t.bar_at_start = ctx.barPositionMusic;
+  else
+    t.bar_at_start
+        = avnd::last_bar_before(t.start_position_in_quarters, 0., quarters_per_bar);
+  t.bar_at_end = avnd::last_bar_before(
+      t.end_position_in_quarters, t.bar_at_start, quarters_per_bar);
+
+  return t;
+}
+}

--- a/include/avnd/concepts/state.hpp
+++ b/include/avnd/concepts/state.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
+
+#include <avnd/common/concepts_polyfill.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace avnd
+{
+/**
+ * Host state (session persistence) support: processors may expose an opaque,
+ * processor-versioned byte blob that plug-in bindings persist in DAW
+ * sessions alongside parameter values.
+ *
+ * Accepted spellings:
+ *
+ *   // Save, container-return form: any contiguous byte container
+ *   std::vector<uint8_t> save_state();
+ *
+ *   // Save, writer form (zero-allocation streaming)
+ *   void save_state(avnd::state_writer auto& write); // write(ptr, size)
+ *
+ *   // Load: pointer + size (byte-like pointee), or a span-ish of bytes.
+ *   // Returning bool: false = blob rejected, no partial application.
+ *   bool load_state(const uint8_t* data, std::size_t n);
+ *   bool load_state(std::span<const uint8_t> bytes);
+ *
+ * The blob comes back from arbitrary session files: processors must
+ * validate it (magic/version/checksum) and fail cleanly.
+ */
+
+// A byte-like element: char, unsigned char, std::byte...
+template <typename T>
+concept byte_like = (sizeof(T) == 1) && !std::is_same_v<std::remove_cv_t<T>, bool>;
+
+// A contiguous container of bytes, e.g. std::vector<uint8_t>, std::string.
+template <typename T>
+concept byte_container = requires(const T& t) {
+                           { t.data() } -> std::convertible_to<const void*>;
+                           { t.size() } -> std::convertible_to<std::size_t>;
+                         } && byte_like<std::remove_pointer_t<decltype(std::declval<const T&>().data())>>;
+
+// The sink passed to the writer form of save_state.
+template <typename T>
+concept state_writer
+    = requires(T t, const void* p, std::size_t n) { t(p, n); };
+
+// Minimal writer used for detection of the writer form.
+struct dummy_state_writer
+{
+  void operator()(const void*, std::size_t) const noexcept { }
+};
+
+// ---- save spellings -------------------------------------------------------
+template <typename T>
+concept has_save_state_container = requires(T t) {
+                                     { t.save_state() } -> byte_container;
+                                   };
+
+template <typename T>
+concept has_save_state_writer
+    = requires(T t, dummy_state_writer w) { t.save_state(w); };
+
+template <typename T>
+concept has_save_state = has_save_state_container<T> || has_save_state_writer<T>;
+
+// ---- load spellings -------------------------------------------------------
+template <typename T>
+concept has_load_state_ptr
+    = requires(T t, const std::uint8_t* d, std::size_t n) { t.load_state(d, n); }
+      || requires(T t, const char* d, std::size_t n) { t.load_state(d, n); }
+      || requires(T t, const std::byte* d, std::size_t n) { t.load_state(d, n); };
+
+// Span-ish overload: anything constructible from (const uint8_t*, size_t)
+// that the object accepts, e.g. std::span<const uint8_t>.
+template <typename T>
+concept has_load_state_span = requires(T t, const std::uint8_t* d, std::size_t n) {
+                                t.load_state({d, n});
+                              };
+
+template <typename T>
+concept has_load_state = has_load_state_ptr<T> || has_load_state_span<T>;
+
+// ---- the feature ----------------------------------------------------------
+template <typename T>
+concept has_custom_state = has_save_state<T> && has_load_state<T>;
+
+}

--- a/include/avnd/wrappers/controls.hpp
+++ b/include/avnd/wrappers/controls.hpp
@@ -50,6 +50,17 @@ static constexpr void init_controls(F& state)
   }
 }
 
+// Dispatch the update() callback of every input port without touching the
+// values: used after bulk value restores (state loads), so ports observe
+// their new values just like after individual host parameter changes.
+template <typename F>
+static constexpr void update_controls(F& state)
+{
+  avnd::for_each_field_ref(state.inputs, [&]<typename T>(T& ctl) {
+    if_possible(ctl.update(state.effect));
+  });
+}
+
 /**
  * @brief Used to set the initial value for controls when
  * the plug-in is first loaded.

--- a/include/avnd/wrappers/process_execution.hpp
+++ b/include/avnd/wrappers/process_execution.hpp
@@ -86,6 +86,7 @@ auto current_tick(avnd::effect_container<T>& implementation, const Tick& tick_da
     if_possible(t.relative_position = tick_data.relative_position());
     if_possible(t.parent_duration = tick_data.parent_duration());
     if_possible(t.speed = tick_data.speed());
+    if_possible(t.playing = tick_data.playing());
     if_possible(t.tempo = tick_data.tempo());
     if constexpr(
         requires { t.signature; } && requires { tick_data.signature(); })
@@ -130,6 +131,7 @@ auto current_tick(avnd::effect_container<T>& implementation, const Tick& tick_da
     if_possible(t.relative_position = tick_data.relative_position);
     if_possible(t.parent_duration = tick_data.parent_duration);
     if_possible(t.speed = tick_data.speed);
+    if_possible(t.playing = tick_data.playing);
     if_possible(t.tempo = tick_data.tempo);
     if constexpr(
         requires { t.signature; } && requires { tick_data.signature; })

--- a/include/avnd/wrappers/state.hpp
+++ b/include/avnd/wrappers/state.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
+
+#include <avnd/concepts/state.hpp>
+
+#include <cstring>
+
+namespace avnd
+{
+/**
+ * Normalized access to the custom-state spellings (see concepts/state.hpp).
+ * Bindings call these; the accepted user spellings never leak further.
+ */
+
+// Stream the object's custom state into sink(const void*, std::size_t).
+// The sink may be called multiple times; bytes are concatenated.
+template <typename T, typename F>
+  requires has_save_state<T> && state_writer<F>
+void save_state(T& obj, F&& sink)
+{
+  if constexpr(has_save_state_writer<T>)
+  {
+    obj.save_state(sink);
+  }
+  else
+  {
+    static_assert(has_save_state_container<T>);
+    auto&& bytes = obj.save_state();
+    if(bytes.size() > 0)
+      sink(bytes.data(), bytes.size());
+  }
+}
+
+// Load a blob into the object. Returns false if the object rejected it
+// (void-returning load spellings cannot fail and thus always succeed).
+template <has_load_state T>
+bool load_state(T& obj, const std::uint8_t* data, std::size_t n)
+{
+  const auto call = [&](auto&&... args) -> bool {
+    if constexpr(requires {
+                   { obj.load_state(args...) } -> std::convertible_to<bool>;
+                 })
+      return static_cast<bool>(obj.load_state(args...));
+    else
+    {
+      obj.load_state(args...);
+      return true;
+    }
+  };
+
+  if constexpr(requires { obj.load_state(data, n); })
+    return call(data, n);
+  else if constexpr(requires { obj.load_state((const char*)data, n); })
+    return call((const char*)data, n);
+  else if constexpr(requires { obj.load_state((const std::byte*)data, n); })
+    return call((const std::byte*)data, n);
+  else
+  {
+    static_assert(has_load_state_span<T>);
+    if constexpr(requires {
+                   { obj.load_state({data, n}) } -> std::convertible_to<bool>;
+                 })
+      return static_cast<bool>(obj.load_state({data, n}));
+    else
+    {
+      obj.load_state({data, n});
+      return true;
+    }
+  }
+}
+
+}

--- a/include/avnd/wrappers/transport_tick.hpp
+++ b/include/avnd/wrappers/transport_tick.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <cstdint>
+
+namespace avnd
+{
+/**
+ * Host-independent transport snapshot for one processing block.
+ *
+ * Plug-in bindings translate their native transport structures into this
+ * type and hand it to the process adapters; current_tick() then maps every
+ * member the processor's own tick type declares (tempo, signature, musical
+ * positions...) and ignores the rest.
+ *
+ * Units:
+ *  - musical positions are in quarter notes;
+ *  - flicks: 1 s == 705'600'000 flicks;
+ *  - speed is 1 when the transport runs, 0 when stopped.
+ */
+struct transport_tick
+{
+  int32_t frames{};
+
+  double tempo{120.};
+  struct
+  {
+    uint16_t num{4};
+    uint16_t denom{4};
+  } signature;
+
+  bool playing{};
+  double speed{};
+
+  int64_t position_in_frames{};
+  double position_in_seconds{};
+  double position_in_nanoseconds{};
+
+  double start_position_in_quarters{};
+  double end_position_in_quarters{};
+
+  // Last bar boundary at (<=) the start, resp. the end, of the block.
+  double bar_at_start{};
+  double bar_at_end{};
+
+  int64_t start_in_flicks{};
+  int64_t end_in_flicks{};
+};
+
+inline constexpr double flicks_per_second = 705'600'000.;
+
+// Last bar boundary <= pos, given a bar starting at bar_ref (all in quarters).
+inline constexpr double
+last_bar_before(double pos, double bar_ref, double quarters_per_bar) noexcept
+{
+  if(quarters_per_bar <= 0.)
+    return bar_ref;
+  const double bars = (pos - bar_ref) / quarters_per_bar;
+  const auto whole = (int64_t)bars;
+  const double base = bar_ref + double(whole - (bars < whole)) * quarters_per_bar;
+  return base;
+}
+}

--- a/tests/objects/state_clap.cpp
+++ b/tests/objects/state_clap.cpp
@@ -207,3 +207,110 @@ TEST_CASE("clap state: tier-0 only (no custom state)", "[state]")
   REQUIRE(fx->state_ext.load(fx.get(), &mem.in));
   REQUIRE(fx->effect.effect.inputs.amount.value == Catch::Approx(0.9f));
 }
+
+// ---------------------------------------------------------------------------
+// Mixed-port shape: an audio port BEFORE the parameters, so raw field
+// indices differ from dense parameter ordinals; includes an enum-ish param
+// whose update() derives another port (must not clobber restored values).
+namespace
+{
+struct MixedFx
+{
+  static consteval auto name() { return "MixedFx"; }
+  static consteval auto c_name() { return "mixed_fx"; }
+  static consteval auto uuid() { return "aa1541cf-3f2b-4b8e-9f0d-77f5f7f0c9e2"; }
+
+  struct
+  {
+    struct
+    {
+      static consteval auto name() { return "In"; }
+      const float** samples{};
+      int channels{};
+    } audio;
+
+    struct
+    {
+      static consteval auto name() { return "Mix"; }
+      struct range
+      {
+        float min = 0.f, max = 1.f, init = 1.f;
+      };
+      float value = 1.f;
+    } mix;
+
+    struct
+    {
+      static consteval auto name() { return "Freq"; }
+      struct range
+      {
+        float min = 20.f, max = 20000.f, init = 440.f;
+      };
+      float value = 440.f;
+    } freq;
+
+    struct
+    {
+      static consteval auto name() { return "Mode"; }
+      struct range
+      {
+        int min = 0, max = 3, init = 0;
+      };
+      int value = 0;
+      // Derive-style handler: on change, repaint Mix (like a preset would).
+      void update(struct MixedFx& self)
+      {
+        self.inputs.mix.value = 1.f;
+        self.mode_updates++;
+      }
+    } mode;
+  } inputs;
+  struct
+  {
+  } outputs;
+
+  int mode_updates = 0;
+  void operator()(int) { }
+};
+}
+
+TEST_CASE("clap state: mixed-port shape round-trips by id, not ordinal",
+          "[state]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<MixedFx>>(&fake_host);
+  auto* params = fx->get_params();
+
+  // Raw ids as advertised.
+  clap_param_info_t i0{}, i1{}, i2{};
+  REQUIRE(params->get_info(fx.get(), 0, &i0)); // Mix
+  REQUIRE(params->get_info(fx.get(), 1, &i1)); // Freq
+  REQUIRE(params->get_info(fx.get(), 2, &i2)); // Mode
+  REQUIRE(i0.id != 0); // audio + midi come first: raw != ordinal
+
+  auto& obj = fx->effect.effect;
+  obj.inputs.mix.value = 0.109f;
+  obj.inputs.freq.value = 1234.f;
+  obj.inputs.mode.value = 2;
+
+  memory_streams mem;
+  REQUIRE(fx->state_ext.save(fx.get(), &mem.out));
+
+  // Fresh instance: restore and verify every param through the vtable.
+  auto fx2 = std::make_unique<avnd_clap::SimpleAudioEffect<MixedFx>>(&fake_host);
+  auto& obj2 = fx2->effect.effect;
+  const int updates_before = obj2.mode_updates;
+  REQUIRE(fx2->state_ext.load(fx2.get(), &mem.in));
+
+  double v = 0.;
+  REQUIRE(params->get_value(fx2.get(), i0.id, &v));
+  REQUIRE(v == Catch::Approx(0.109).margin(1e-4));
+  REQUIRE(params->get_value(fx2.get(), i1.id, &v));
+  REQUIRE(v == Catch::Approx(1234.));
+  REQUIRE(params->get_value(fx2.get(), i2.id, &v));
+  REQUIRE(v == Catch::Approx(2.));
+
+  // A restore is a bulk assignment: no update() dispatch, so the Mode
+  // handler must NOT have run and cannot clobber the restored Mix.
+  REQUIRE(obj2.mode_updates == updates_before);
+  REQUIRE(obj2.inputs.mix.value == Catch::Approx(0.109f).margin(1e-4));
+}

--- a/tests/objects/state_clap.cpp
+++ b/tests/objects/state_clap.cpp
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
+
+// Runtime round-trip of the custom-state feature through the real CLAP
+// binding: params + opaque blob, saved into an in-memory clap_ostream and
+// loaded back through a clap_istream.
+
+#include <avnd/binding/clap/audio_effect.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <cstring>
+#include <vector>
+
+namespace
+{
+// A processor with one parameter and a little versioned custom-state blob.
+struct StatefulFx
+{
+  static consteval auto name() { return "StatefulFx"; }
+  static consteval auto c_name() { return "stateful_fx"; }
+  static consteval auto uuid() { return "5a0175c4-46ff-4b3c-8f5f-6b60acbdc9f0"; }
+
+  struct
+  {
+    struct
+    {
+      static consteval auto name() { return "Gain"; }
+      struct range
+      {
+        float min = 0.f, max = 1.f, init = 0.25f;
+      };
+      float value = 0.25f;
+    } gain;
+  } inputs;
+
+  struct
+  {
+  } outputs;
+
+  // Custom state: a little versioned blob owning `secret`.
+  int secret = 42;
+
+  std::vector<uint8_t> save_state()
+  {
+    std::vector<uint8_t> v(8);
+    const uint32_t magic = 0x5EC2E7;
+    std::memcpy(v.data(), &magic, 4);
+    std::memcpy(v.data() + 4, &secret, 4);
+    return v;
+  }
+
+  bool load_state(const uint8_t* data, size_t n)
+  {
+    if(n != 8)
+      return false;
+    uint32_t magic{};
+    std::memcpy(&magic, data, 4);
+    if(magic != 0x5EC2E7)
+      return false;
+    std::memcpy(&secret, data + 4, 4);
+    return true;
+  }
+
+  void operator()(int frames) { }
+};
+static_assert(avnd::has_custom_state<StatefulFx>);
+
+// A processor without custom state: only tier-0 params.
+struct PlainFx
+{
+  static consteval auto name() { return "PlainFx"; }
+  static consteval auto c_name() { return "plain_fx"; }
+  static consteval auto uuid() { return "e6b6f4de-9d3e-4e35-9d5f-3f2b7bd9b2af"; }
+
+  struct
+  {
+    struct
+    {
+      static consteval auto name() { return "Amount"; }
+      struct range
+      {
+        float min = 0.f, max = 1.f, init = 0.5f;
+      };
+      float value = 0.5f;
+    } amount;
+  } inputs;
+
+  struct
+  {
+  } outputs;
+
+  void operator()(int frames) { }
+};
+static_assert(!avnd::has_custom_state<PlainFx>);
+
+// In-memory clap streams.
+struct memory_streams
+{
+  std::vector<uint8_t> bytes;
+  size_t read_pos = 0;
+  // Force tiny transfers to exercise the partial-IO loops.
+  int64_t max_chunk = 3;
+
+  clap_ostream out{
+      .ctx = this,
+      .write = [](const clap_ostream* stream, const void* buffer,
+                  uint64_t size) -> int64_t {
+        auto& self = *static_cast<memory_streams*>(stream->ctx);
+        const auto n = std::min<uint64_t>(size, self.max_chunk);
+        auto b = static_cast<const uint8_t*>(buffer);
+        self.bytes.insert(self.bytes.end(), b, b + n);
+        return int64_t(n);
+      }};
+
+  clap_istream in{
+      .ctx = this,
+      .read = [](const clap_istream* stream, void* buffer,
+                 uint64_t size) -> int64_t {
+        auto& self = *static_cast<memory_streams*>(stream->ctx);
+        const auto avail = self.bytes.size() - self.read_pos;
+        const auto n = std::min<uint64_t>(
+            {size, avail, uint64_t(self.max_chunk)});
+        std::memcpy(buffer, self.bytes.data() + self.read_pos, n);
+        self.read_pos += n;
+        return int64_t(n);
+      }};
+};
+
+const clap_host fake_host{
+    .clap_version = CLAP_VERSION,
+    .host_data = nullptr,
+    .name = "test-host",
+    .vendor = "avnd",
+    .url = "",
+    .version = "1.0",
+    .get_extension = [](const clap_host*, const char*) -> const void* {
+      return nullptr;
+    },
+    .request_restart = [](const clap_host*) {},
+    .request_process = [](const clap_host*) {},
+    .request_callback = [](const clap_host*) {},
+};
+}
+
+TEST_CASE("clap state: extension is advertised", "[state]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<StatefulFx>>(&fake_host);
+  auto ext = fx->get_extension(fx.get(), CLAP_EXT_STATE);
+  REQUIRE(ext != nullptr);
+  REQUIRE(ext == &fx->state_ext);
+}
+
+TEST_CASE("clap state: params + custom blob round-trip", "[state]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<StatefulFx>>(&fake_host);
+
+  // Mutate both tiers.
+  fx->effect.effect.inputs.gain.value = 0.75f;
+  fx->effect.effect.secret = 1234;
+
+  memory_streams mem;
+  REQUIRE(fx->state_ext.save(fx.get(), &mem.out));
+  REQUIRE(mem.bytes.size() > 0);
+
+  // Wreck the live state, then load the snapshot back.
+  fx->effect.effect.inputs.gain.value = 0.f;
+  fx->effect.effect.secret = -1;
+  REQUIRE(fx->state_ext.load(fx.get(), &mem.in));
+
+  REQUIRE(fx->effect.effect.inputs.gain.value == Catch::Approx(0.75f));
+  REQUIRE(fx->effect.effect.secret == 1234);
+}
+
+TEST_CASE("clap state: rejected blob leaves object playable", "[state]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<StatefulFx>>(&fake_host);
+  fx->effect.effect.secret = 77;
+
+  memory_streams mem;
+  REQUIRE(fx->state_ext.save(fx.get(), &mem.out));
+
+  // Corrupt the custom blob's magic (it sits at the end of the container).
+  mem.bytes[mem.bytes.size() - 8] ^= 0xFF;
+  REQUIRE(!fx->state_ext.load(fx.get(), &mem.in));
+
+  // Truncated container.
+  memory_streams trunc;
+  trunc.bytes.assign(mem.bytes.begin(), mem.bytes.begin() + 5);
+  REQUIRE(!fx->state_ext.load(fx.get(), &trunc.in));
+
+  // Bad magic.
+  memory_streams bad;
+  bad.bytes = mem.bytes;
+  bad.bytes[0] = 0x00;
+  REQUIRE(!fx->state_ext.load(fx.get(), &bad.in));
+}
+
+TEST_CASE("clap state: tier-0 only (no custom state)", "[state]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<PlainFx>>(&fake_host);
+  fx->effect.effect.inputs.amount.value = 0.9f;
+
+  memory_streams mem;
+  REQUIRE(fx->state_ext.save(fx.get(), &mem.out));
+
+  fx->effect.effect.inputs.amount.value = 0.1f;
+  REQUIRE(fx->state_ext.load(fx.get(), &mem.in));
+  REQUIRE(fx->effect.effect.inputs.amount.value == Catch::Approx(0.9f));
+}

--- a/tests/objects/update_controls.cpp
+++ b/tests/objects/update_controls.cpp
@@ -125,7 +125,7 @@ TEST_CASE("vst3: apply_control fires update() once with the new value", "[update
   REQUIRE(obj.observed == Catch::Approx(75.f));
 }
 
-TEST_CASE("clap: state load dispatches update() with restored values", "[update]")
+TEST_CASE("clap: state load restores values without update() dispatch", "[update]")
 {
   auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<UpdateFx>>(&fake_host);
   auto& obj = fx->effect.effect;
@@ -163,8 +163,8 @@ TEST_CASE("clap: state load dispatches update() with restored values", "[update]
   REQUIRE(fx->state_ext.load(fx.get(), &mem.in));
 
   REQUIRE(obj.inputs.freq.value == Catch::Approx(80.f));
-  REQUIRE(obj.observed == Catch::Approx(80.f)); // update() saw the restore
-  REQUIRE(obj.update_count > base);
+  // A restore is an opaque bulk assignment: no update() dispatch.
+  REQUIRE(obj.update_count == base);
 }
 
 TEST_CASE("clap: params flush dispatches update() on a deactivated plug-in",

--- a/tests/objects/update_controls.cpp
+++ b/tests/objects/update_controls.cpp
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
+
+// Host parameter changes must invoke the ports' update() callbacks with the
+// new value already written, exactly once per change:
+//  - through the CLAP binding's parameter-event application;
+//  - through the VST3 parameter application path (stv3::apply_control);
+//  - after a bulk value restore (state load).
+
+#include <avnd/binding/clap/audio_effect.hpp>
+#include <avnd/binding/vst3/param_apply.hpp>
+
+#include <catch2/catch_all.hpp>
+
+namespace
+{
+struct UpdateFx
+{
+  static consteval auto name() { return "UpdateFx"; }
+  static consteval auto c_name() { return "update_fx"; }
+  static consteval auto uuid() { return "9a2c6a2e-08a1-4a7b-9930-45a86e4dbb1c"; }
+
+  struct
+  {
+    struct
+    {
+      static consteval auto name() { return "Freq"; }
+      struct range
+      {
+        float min = 0.f, max = 100.f, init = 10.f;
+      };
+      float value = 10.f;
+
+      void update(UpdateFx& self)
+      {
+        self.update_count++;
+        self.observed = value;
+      }
+    } freq;
+
+    struct
+    {
+      static consteval auto name() { return "Plain"; }
+      struct range
+      {
+        float min = 0.f, max = 1.f, init = 0.f;
+      };
+      float value = 0.f;
+      // no update(): must be a no-op in every path
+    } plain;
+  } inputs;
+
+  struct
+  {
+  } outputs;
+
+  int update_count = 0;
+  float observed = -1.f;
+
+  void operator()(int frames) { }
+};
+
+const clap_host fake_host{
+    .clap_version = CLAP_VERSION,
+    .host_data = nullptr,
+    .name = "test-host",
+    .vendor = "avnd",
+    .url = "",
+    .version = "1.0",
+    .get_extension = [](const clap_host*, const char*) -> const void* {
+      return nullptr;
+    },
+    .request_restart = [](const clap_host*) {},
+    .request_process = [](const clap_host*) {},
+    .request_callback = [](const clap_host*) {},
+};
+}
+
+TEST_CASE("clap: param event fires update() once with the new value", "[update]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<UpdateFx>>(&fake_host);
+  auto& obj = fx->effect.effect;
+  // Construction runs init_controls, which fires update() once per port.
+  const int base = obj.update_count;
+
+  clap_event_param_value ev{};
+  ev.param_id = 0; // Freq
+  ev.value = 0.5;  // normalized -> 50.
+  fx->process_param(ev);
+
+  REQUIRE(obj.update_count == base + 1);
+  REQUIRE(obj.observed == Catch::Approx(50.f));
+  REQUIRE(obj.inputs.freq.value == Catch::Approx(50.f));
+
+  // A port without update() is applied silently.
+  clap_event_param_value ev2{};
+  ev2.param_id = 1; // Plain
+  ev2.value = 1.;
+  fx->process_param(ev2);
+  REQUIRE(obj.update_count == base + 1);
+  REQUIRE(obj.inputs.plain.value == Catch::Approx(1.f));
+
+  // One invocation per change.
+  fx->process_param(ev);
+  REQUIRE(obj.update_count == base + 2);
+}
+
+TEST_CASE("vst3: apply_control fires update() once with the new value", "[update]")
+{
+  avnd::effect_container<UpdateFx> fx;
+  auto& obj = fx.effect;
+  const int base = obj.update_count;
+
+  // Raw field index 0 == Freq.
+  stv3::apply_control(fx, 0, 0.25);
+  REQUIRE(obj.update_count == base + 1);
+  REQUIRE(obj.observed == Catch::Approx(25.f));
+  REQUIRE(obj.inputs.freq.value == Catch::Approx(25.f));
+
+  stv3::apply_control(fx, 1, 1.0); // Plain: no callback
+  REQUIRE(obj.update_count == base + 1);
+  REQUIRE(obj.inputs.plain.value == Catch::Approx(1.f));
+
+  stv3::apply_control(fx, 0, 0.75);
+  REQUIRE(obj.update_count == base + 2);
+  REQUIRE(obj.observed == Catch::Approx(75.f));
+}
+
+TEST_CASE("clap: state load dispatches update() with restored values", "[update]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<UpdateFx>>(&fake_host);
+  auto& obj = fx->effect.effect;
+
+  struct memory_streams
+  {
+    std::vector<uint8_t> bytes;
+    size_t read_pos = 0;
+    clap_ostream out{
+        .ctx = this,
+        .write = [](const clap_ostream* stream, const void* buffer,
+                    uint64_t size) -> int64_t {
+          auto& self = *static_cast<memory_streams*>(stream->ctx);
+          auto b = static_cast<const uint8_t*>(buffer);
+          self.bytes.insert(self.bytes.end(), b, b + size);
+          return int64_t(size);
+        }};
+    clap_istream in{
+        .ctx = this,
+        .read = [](const clap_istream* stream, void* buffer,
+                   uint64_t size) -> int64_t {
+          auto& self = *static_cast<memory_streams*>(stream->ctx);
+          const auto n = std::min<uint64_t>(size, self.bytes.size() - self.read_pos);
+          std::memcpy(buffer, self.bytes.data() + self.read_pos, n);
+          self.read_pos += n;
+          return int64_t(n);
+        }};
+  } mem;
+
+  obj.inputs.freq.value = 80.f;
+  REQUIRE(fx->state_ext.save(fx.get(), &mem.out));
+
+  obj.inputs.freq.value = 10.f;
+  const int base = obj.update_count;
+  REQUIRE(fx->state_ext.load(fx.get(), &mem.in));
+
+  REQUIRE(obj.inputs.freq.value == Catch::Approx(80.f));
+  REQUIRE(obj.observed == Catch::Approx(80.f)); // update() saw the restore
+  REQUIRE(obj.update_count > base);
+}

--- a/tests/objects/update_controls.cpp
+++ b/tests/objects/update_controls.cpp
@@ -84,7 +84,7 @@ TEST_CASE("clap: param event fires update() once with the new value", "[update]"
 
   clap_event_param_value ev{};
   ev.param_id = 0; // Freq
-  ev.value = 0.5;  // normalized -> 50.
+  ev.value = 50.;  // plain value, per the advertised min/max
   fx->process_param(ev);
 
   REQUIRE(obj.update_count == base + 1);
@@ -165,4 +165,41 @@ TEST_CASE("clap: state load dispatches update() with restored values", "[update]
   REQUIRE(obj.inputs.freq.value == Catch::Approx(80.f));
   REQUIRE(obj.observed == Catch::Approx(80.f)); // update() saw the restore
   REQUIRE(obj.update_count > base);
+}
+
+TEST_CASE("clap: params flush dispatches update() on a deactivated plug-in",
+          "[update]")
+{
+  auto fx = std::make_unique<avnd_clap::SimpleAudioEffect<UpdateFx>>(&fake_host);
+  auto& obj = fx->effect.effect;
+  const int base = obj.update_count;
+
+  clap_event_param_value_t ev{};
+  ev.header.size = sizeof(ev);
+  ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+  ev.header.type = CLAP_EVENT_PARAM_VALUE;
+  ev.param_id = 0; // Freq
+  ev.note_id = -1;
+  ev.port_index = -1;
+  ev.channel = -1;
+  ev.key = -1;
+  ev.value = 50.; // plain value
+
+  struct one_event
+  {
+    const clap_event_header_t* h;
+    clap_input_events_t in{
+        .ctx = this,
+        .size = [](const clap_input_events_t*) -> uint32_t { return 1; },
+        .get = [](const clap_input_events_t* list,
+                  uint32_t) -> const clap_event_header_t* {
+          return static_cast<one_event*>(list->ctx)->h;
+        }};
+  } events{&ev.header};
+
+  fx->get_params()->flush(fx.get(), &events.in, nullptr);
+
+  REQUIRE(obj.inputs.freq.value == Catch::Approx(50.f));
+  REQUIRE(obj.update_count == base + 1); // exactly one dispatch
+  REQUIRE(obj.observed == Catch::Approx(50.f));
 }

--- a/tests/test_state.cpp
+++ b/tests/test_state.cpp
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
+
+// Static detection tests for the custom-state concepts (concepts/state.hpp)
+// and the normalizing wrappers (wrappers/state.hpp).
+
+#include <avnd/concepts/state.hpp>
+#include <avnd/wrappers/state.hpp>
+
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+// ---- accepted spellings ---------------------------------------------------
+
+// The most common spelling: vector return + (pointer, size) load.
+struct state_vector_ptr
+{
+  std::vector<uint8_t> save_state() { return {1, 2, 3}; }
+  bool load_state(const uint8_t*, size_t) { return true; }
+};
+static_assert(avnd::has_save_state_container<state_vector_ptr>);
+static_assert(avnd::has_load_state_ptr<state_vector_ptr>);
+static_assert(avnd::has_custom_state<state_vector_ptr>);
+
+// String container + char pointer load.
+struct state_string_char
+{
+  std::string save_state() { return "hello"; }
+  bool load_state(const char*, size_t) { return true; }
+};
+static_assert(avnd::has_custom_state<state_string_char>);
+
+// Writer-callback save + span load, void-returning load (cannot fail).
+struct state_writer_span
+{
+  void save_state(avnd::state_writer auto& write)
+  {
+    const uint8_t bytes[4] = {9, 9, 9, 9};
+    write(bytes, 2);
+    write(bytes, 2); // multiple calls concatenate
+  }
+  void load_state(std::span<const uint8_t>) { }
+};
+static_assert(avnd::has_save_state_writer<state_writer_span>);
+static_assert(avnd::has_custom_state<state_writer_span>);
+
+// std::byte flavour.
+struct state_bytes
+{
+  std::vector<std::byte> save_state() { return {}; }
+  bool load_state(const std::byte*, size_t) { return true; }
+};
+static_assert(avnd::has_custom_state<state_bytes>);
+
+// ---- rejected shapes ------------------------------------------------------
+
+struct no_state
+{
+  void operator()() { }
+};
+static_assert(!avnd::has_save_state<no_state>);
+static_assert(!avnd::has_load_state<no_state>);
+static_assert(!avnd::has_custom_state<no_state>);
+
+// Save without load (or vice versa) is not the feature.
+struct only_save
+{
+  std::vector<uint8_t> save_state() { return {}; }
+};
+static_assert(avnd::has_save_state<only_save>);
+static_assert(!avnd::has_custom_state<only_save>);
+
+struct only_load
+{
+  bool load_state(const uint8_t*, size_t) { return true; }
+};
+static_assert(!avnd::has_custom_state<only_load>);
+
+// A non-byte container return does not count as state.
+struct wrong_save
+{
+  std::vector<int> save_state() { return {}; }
+  bool load_state(const uint8_t*, size_t) { return true; }
+};
+static_assert(!avnd::has_save_state_container<wrong_save>);
+
+// ---- wrapper behavior (runtime, exercised by the linker-visible fn) -------
+
+bool state_wrappers_smoke()
+{
+  // Container save -> sink.
+  std::vector<uint8_t> collected;
+  auto sink = [&](const void* d, std::size_t n) {
+    auto b = static_cast<const uint8_t*>(d);
+    collected.insert(collected.end(), b, b + n);
+  };
+
+  state_vector_ptr a;
+  avnd::save_state(a, sink);
+  bool ok = collected == std::vector<uint8_t>{1, 2, 3};
+
+  // Writer save concatenates.
+  collected.clear();
+  state_writer_span w;
+  avnd::save_state(w, sink);
+  ok &= collected.size() == 4;
+
+  // Load normalization across spellings.
+  const uint8_t data[3] = {5, 6, 7};
+  ok &= avnd::load_state(a, data, 3);
+  state_string_char s;
+  ok &= avnd::load_state(s, data, 3);
+  ok &= avnd::load_state(w, data, 3); // void load -> success
+  state_bytes b;
+  ok &= avnd::load_state(b, data, 3);
+  return ok;
+}

--- a/tests/test_transport.cpp
+++ b/tests/test_transport.cpp
@@ -1,0 +1,263 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
+
+// Transport-to-tick conversion tests:
+//  - clap_event_transport -> avnd::transport_tick (fixed-point beat/second
+//    conversion, flag fallbacks, end-position computation);
+//  - ProcessContext -> avnd::transport_tick through a structural mirror of
+//    the SDK type (validity-flag fallbacks);
+//  - transport_tick -> a processor's own tick type via current_tick.
+
+#include <avnd/binding/clap/transport.hpp>
+#include <avnd/binding/vst3/transport.hpp>
+#include <avnd/wrappers/process_execution.hpp>
+#include <avnd/wrappers/effect_container.hpp>
+
+#include <catch2/catch_all.hpp>
+
+TEST_CASE("clap: fixed-point beat conversion is exact", "[transport]")
+{
+  clap_event_transport_t tr{};
+  tr.flags = CLAP_TRANSPORT_HAS_BEATS_TIMELINE | CLAP_TRANSPORT_HAS_TEMPO;
+  tr.tempo = 120.;
+  tr.song_pos_beats = (clap_beattime(5) << 31) + (clap_beattime(1) << 30); // 5.5
+  auto t = avnd_clap::tick_from_transport(tr, 512, 48000.);
+  REQUIRE(t.start_position_in_quarters == 5.5);
+  REQUIRE(t.tempo == 120.);
+}
+
+TEST_CASE("clap: full transport", "[transport]")
+{
+  clap_event_transport_t tr{};
+  tr.flags = CLAP_TRANSPORT_HAS_TEMPO | CLAP_TRANSPORT_HAS_BEATS_TIMELINE
+             | CLAP_TRANSPORT_HAS_SECONDS_TIMELINE
+             | CLAP_TRANSPORT_HAS_TIME_SIGNATURE | CLAP_TRANSPORT_IS_PLAYING;
+  tr.tempo = 140.;
+  tr.tsig_num = 3;
+  tr.tsig_denom = 4;
+  tr.song_pos_beats = clap_beattime(2.5 * CLAP_BEATTIME_FACTOR);
+  tr.song_pos_seconds = clap_sectime(10.25 * CLAP_SECTIME_FACTOR);
+  tr.bar_start = clap_beattime(1.5 * CLAP_BEATTIME_FACTOR);
+
+  auto t = avnd_clap::tick_from_transport(tr, 24000, 48000.);
+  REQUIRE(t.frames == 24000);
+  REQUIRE(t.tempo == 140.);
+  REQUIRE(t.signature.num == 3);
+  REQUIRE(t.signature.denom == 4);
+  REQUIRE(t.playing);
+  REQUIRE(t.speed == 1.);
+  REQUIRE(t.start_position_in_quarters == Catch::Approx(2.5));
+  // end = start + frames * tempo / (60 * rate)
+  REQUIRE(
+      t.end_position_in_quarters
+      == Catch::Approx(2.5 + 24000. * 140. / (60. * 48000.)));
+  // Seconds timeline preferred.
+  REQUIRE(t.position_in_seconds == Catch::Approx(10.25));
+  REQUIRE(t.position_in_frames == 10.25 * 48000);
+  // 3/4: bars are 3 quarters; end = 3.6667 -> last bar from 1.5 is 1.5.
+  REQUIRE(t.bar_at_start == Catch::Approx(1.5));
+  REQUIRE(t.bar_at_end == Catch::Approx(1.5));
+  REQUIRE(
+      t.start_in_flicks
+      == std::llround(10.25 * avnd::flicks_per_second));
+}
+
+TEST_CASE("clap: bar_at_end advances across a bar boundary", "[transport]")
+{
+  clap_event_transport_t tr{};
+  tr.flags = CLAP_TRANSPORT_HAS_TEMPO | CLAP_TRANSPORT_HAS_BEATS_TIMELINE
+             | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
+  tr.tempo = 120.;
+  tr.tsig_num = 4;
+  tr.tsig_denom = 4;
+  tr.song_pos_beats = clap_beattime(3.9 * CLAP_BEATTIME_FACTOR);
+  tr.bar_start = 0;
+
+  // 0.2 quarters in this block: crosses the bar at 4.
+  auto t = avnd_clap::tick_from_transport(tr, 4800, 48000.);
+  REQUIRE(t.end_position_in_quarters == Catch::Approx(4.1));
+  REQUIRE(t.bar_at_start == 0.);
+  REQUIRE(t.bar_at_end == Catch::Approx(4.));
+}
+
+TEST_CASE("clap: absent flags fall back to defaults", "[transport]")
+{
+  clap_event_transport_t tr{};
+  auto t = avnd_clap::tick_from_transport(tr, 4800, 48000.);
+  REQUIRE(t.tempo == 120.);
+  REQUIRE(t.signature.num == 4);
+  REQUIRE(t.signature.denom == 4);
+  REQUIRE(!t.playing);
+  REQUIRE(t.speed == 0.);
+  REQUIRE(t.start_position_in_quarters == 0.);
+  // end still derived from the default tempo.
+  REQUIRE(t.end_position_in_quarters == Catch::Approx(4800. * 2. / 48000.));
+  REQUIRE(t.position_in_frames == 0);
+
+  // steady_time is the last-resort frame position.
+  auto t2 = avnd_clap::tick_from_transport(tr, 4800, 48000., 555);
+  REQUIRE(t2.position_in_frames == 555);
+}
+
+TEST_CASE("clap: seconds derived from beats when absent", "[transport]")
+{
+  clap_event_transport_t tr{};
+  tr.flags = CLAP_TRANSPORT_HAS_TEMPO | CLAP_TRANSPORT_HAS_BEATS_TIMELINE;
+  tr.tempo = 90.;
+  tr.song_pos_beats = clap_beattime(3. * CLAP_BEATTIME_FACTOR);
+  auto t = avnd_clap::tick_from_transport(tr, 512, 48000.);
+  REQUIRE(t.position_in_seconds == Catch::Approx(3. * 60. / 90.));
+  REQUIRE(t.position_in_frames == std::llround(2. * 48000.));
+}
+
+// ---------------------------------------------------------------------------
+// Structural mirror of Steinberg::Vst::ProcessContext (same field names and
+// flag values; the converter is templated precisely so this compiles
+// without the SDK).
+struct FakeProcessContext
+{
+  enum StatesAndFlags : uint32_t
+  {
+    kPlaying = 1 << 1,
+    kSystemTimeValid = 1 << 8,
+    kProjectTimeMusicValid = 1 << 9,
+    kTempoValid = 1 << 10,
+    kBarPositionValid = 1 << 11,
+    kTimeSigValid = 1 << 13,
+  };
+  uint32_t state{};
+  double sampleRate{48000.};
+  int64_t projectTimeSamples{};
+  int64_t systemTime{};
+  double projectTimeMusic{};
+  double barPositionMusic{};
+  double tempo{};
+  int32_t timeSigNumerator{};
+  int32_t timeSigDenominator{};
+};
+
+TEST_CASE("vst3: all fields valid", "[transport]")
+{
+  FakeProcessContext ctx;
+  ctx.state = FakeProcessContext::kPlaying | FakeProcessContext::kTempoValid
+              | FakeProcessContext::kProjectTimeMusicValid
+              | FakeProcessContext::kBarPositionValid
+              | FakeProcessContext::kTimeSigValid
+              | FakeProcessContext::kSystemTimeValid;
+  ctx.tempo = 140.;
+  ctx.timeSigNumerator = 6;
+  ctx.timeSigDenominator = 8;
+  ctx.projectTimeMusic = 7.25;
+  ctx.barPositionMusic = 6.;
+  ctx.projectTimeSamples = 96000;
+  ctx.systemTime = 123456789;
+
+  auto t = stv3::tick_from_context(ctx, 4800, 44100.);
+  REQUIRE(t.tempo == 140.);
+  REQUIRE(t.signature.num == 6);
+  REQUIRE(t.signature.denom == 8);
+  REQUIRE(t.playing);
+  REQUIRE(t.start_position_in_quarters == 7.25);
+  REQUIRE(t.bar_at_start == 6.);
+  REQUIRE(t.position_in_frames == 96000);
+  REQUIRE(t.position_in_seconds == Catch::Approx(2.));
+  REQUIRE(t.position_in_nanoseconds == 123456789.);
+  REQUIRE(
+      t.end_position_in_quarters
+      == Catch::Approx(7.25 + 4800. * 140. / (60. * 48000.)));
+}
+
+TEST_CASE("vst3: musical position derived when only tempo is valid", "[transport]")
+{
+  FakeProcessContext ctx;
+  ctx.state = FakeProcessContext::kTempoValid;
+  ctx.tempo = 90.;
+  ctx.projectTimeSamples = 48000; // 1 s at the context rate
+  auto t = stv3::tick_from_context(ctx, 512, 44100.);
+  REQUIRE(t.start_position_in_quarters == Catch::Approx(1.5));
+  REQUIRE(t.signature.num == 4);
+  REQUIRE(t.signature.denom == 4);
+  // Bar fallback: bars aligned at 0 in 4/4 -> last bar before 1.5 is 0.
+  REQUIRE(t.bar_at_start == 0.);
+  REQUIRE(!t.playing);
+}
+
+TEST_CASE("vst3: nothing valid", "[transport]")
+{
+  FakeProcessContext ctx;
+  ctx.projectTimeSamples = 24000; // 0.5 s
+  auto t = stv3::tick_from_context(ctx, 512, 44100.);
+  REQUIRE(t.tempo == 120.);
+  REQUIRE(t.start_position_in_quarters == Catch::Approx(1.)); // 0.5 s at 120
+  REQUIRE(t.position_in_nanoseconds == 0.);
+}
+
+TEST_CASE("vst3: bar position advances across the block", "[transport]")
+{
+  FakeProcessContext ctx;
+  ctx.state = FakeProcessContext::kTempoValid
+              | FakeProcessContext::kProjectTimeMusicValid
+              | FakeProcessContext::kBarPositionValid
+              | FakeProcessContext::kTimeSigValid;
+  ctx.tempo = 120.;
+  ctx.timeSigNumerator = 4;
+  ctx.timeSigDenominator = 4;
+  ctx.projectTimeMusic = 3.9;
+  ctx.barPositionMusic = 0.;
+  auto t = stv3::tick_from_context(ctx, 4800, 48000.);
+  REQUIRE(t.end_position_in_quarters == Catch::Approx(4.1));
+  REQUIRE(t.bar_at_end == Catch::Approx(4.));
+}
+
+// ---------------------------------------------------------------------------
+// End to end: the transport tick lands in a processor's own tick type.
+struct TickProcessor
+{
+  static consteval auto name() { return "TickProcessor"; }
+  struct
+  {
+  } inputs;
+  struct
+  {
+  } outputs;
+
+  struct tick
+  {
+    int frames{};
+    double tempo{};
+    struct
+    {
+      int num{}, denom{};
+    } signature;
+    double start_position_in_quarters{};
+    double end_position_in_quarters{};
+    bool playing{};
+  };
+
+  tick last{};
+  void operator()(tick t) { last = t; }
+};
+
+TEST_CASE("transport tick maps onto the processor's tick", "[transport]")
+{
+  avnd::effect_container<TickProcessor> fx;
+
+  avnd::transport_tick tr;
+  tr.frames = 256;
+  tr.tempo = 133.;
+  tr.signature.num = 7;
+  tr.signature.denom = 8;
+  tr.start_position_in_quarters = 11.5;
+  tr.end_position_in_quarters = 11.75;
+  tr.playing = true;
+
+  auto t = avnd::get_tick_or_frames(fx, tr);
+  avnd::invoke_effect(fx, t);
+
+  REQUIRE(fx.effect.last.frames == 256);
+  REQUIRE(fx.effect.last.tempo == 133.);
+  REQUIRE(fx.effect.last.signature.num == 7);
+  REQUIRE(fx.effect.last.signature.denom == 8);
+  REQUIRE(fx.effect.last.start_position_in_quarters == 11.5);
+  REQUIRE(fx.effect.last.end_position_in_quarters == 11.75);
+  REQUIRE(fx.effect.last.playing);
+}


### PR DESCRIPTION
Session persistence for custom processor state, host transport ticks, and `update()` dispatch on host parameter changes.

This branch now carries the transport work as well: #174 was merged into it rather than into `main`, so the two features arrive together. Rebased onto `main` after #175 landed; the parameter-space commits it shares with #175 were dropped as already-upstream. The design rationale lives in the new "Host state" chapter of the manual.

## Host state
- `avnd::has_custom_state`: a processor's opaque, self-versioned blob, detected through concepts and accepted in several spellings (byte-container return or zero-alloc writer; ptr+size or span load, `bool`- or `void`-returning).
- CLAP gains `CLAP_EXT_STATE` (it had none): a versioned container holding parameter values and the blob, tolerant of partial stream IO.
- VST3 stores the blob in a magic-tagged trailer after the existing parameter doubles, so sessions written by earlier builds still load.
- Parameters are restored before the blob; a rejected blob leaves the object untouched rather than half-applied.
- Parameters in the container are addressed by id rather than by ordinal, so processors whose parameters follow other ports (audio, MIDI) restore onto the right fields. `update()` is not dispatched while restoring: a port that derives other state from its own value would otherwise clobber freshly restored values in save-order-dependent ways.

## Transport
- `avnd::transport_tick`, a host-independent carrier that the existing `current_tick()` machinery maps onto whatever tick a processor declares.
- CLAP fills it from `clap_process::transport` plus `CLAP_EVENT_TRANSPORT`; VST3 from `ProcessContext`, honouring each validity flag with documented fallbacks.
- Both converters are pure functions, unit-tested without a host; the VST3 one is templated over the context type so it can be exercised against a structural mirror.
- A processor that never receives transport information gets exactly today's frames-only tick.

## `update()` dispatch
Host parameter changes now invoke a port's `update()` callback in the CLAP and VST3 bindings, matching the ossia binding and the documented contract (the book previously listed ossia as the only support).

## Testing
`test_state`, `test_state_clap`, `test_transport`, `test_update_controls`, plus the pre-existing suites: **106 tests pass** locally (MSVC 19.50, Windows). The CLAP state path is covered by a round-trip through the real extension with forced 3-byte partial transfers and corruption/truncation rejection.

Validated against clap-validator 0.3.2 with a plug-in whose shape exercises the id-addressing path (audio and MIDI ports *before* ~14 mixed-type parameters, plus a large custom blob): **16 passed / 0 failed**, and pluginval strictness 10 passes on its VST3 build.

## Open
- The VST3 state path is compile-verified and covered through the shared container logic, but has no runtime test against a real `IBStream`.
- Loop/cycle ranges and intra-block tempo ramps are not carried by the tick; `last_signature_change` stays 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
