### PR TITLE
ossia: handle std::vector<bool> in to_ossia_value

### DIFF
--- a/include/avnd/binding/ossia/to_value.hpp
+++ b/include/avnd/binding/ossia/to_value.hpp
@@ -188,6 +188,15 @@ struct to_ossia_value_impl
     val = std::move(v);
   }
 
+  void operator()(const std::vector<bool>& f)
+  {
+    std::vector<ossia::value> v;
+    v.resize(f.size());
+    for(std::size_t i = 0, n = f.size(); i < n; i++)
+      v[i] = bool(f[i]);
+    val = std::move(v);
+  }
+
   template <typename T>
     requires avnd::tensor_like<T>
   void operator()(const T& t)


### PR DESCRIPTION
std::vector<bool> satisfies `avnd::vector_ish`, so the generic container overload at to_value.hpp:182 is selected and calls `to_ossia_value_impl` on `f[i]`.

- On **libstdc++**, `vector<bool>::const_reference` is plainly `bool`, so that resolves to the `bool` overload and works by accident.
- On **libc++**, it is the proxy class `std::__bit_const_reference<std::vector<bool>>`, which is neither integral, nor `bool`, nor a container. It matches none of the constrained overloads and binds to the deleted catch-all `operator()(const auto&)` by identity (exact match beats the user-defined conversion to `bool`), so the build fails with `call to deleted function call operator`.

This adds a dedicated `std::vector<bool>` overload that materializes each element to `bool`. Being a non-template exact match it is preferred over the `vector_ish` template with no ambiguity, and nothing changes for any other type. (A `static_cast<value_type>` inside the generic loop would also work but would force a copy of every element for all container types.)

Found while building ossia/score on macOS (Apple clang / libc++), where `Avnd_ossia_value_Test` failed to compile — the round-trip test at `from_ossia_value_Test.cpp:300` exercises a `std::vector<bool>` parameter.

Verified: compiles and links cleanly on Linux/libstdc++ (no regression); the fix removes the proxy from the call entirely so it resolves identically on both standard libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)