### PR TITLE
state: automatic serialization of a processor's state struct

### DIFF
--- a/cmake/avendish.tests.cmake
+++ b/cmake/avendish.tests.cmake
@@ -49,6 +49,10 @@ if(BUILD_TESTING)
   avnd_add_catch_test(test_gain tests/objects/gain.cpp)
   avnd_add_catch_test(test_patternal tests/objects/patternal.cpp)
 
+  # Custom-state feature
+  avnd_add_catch_test(test_state_serial tests/test_state_serial.cpp)
+  avnd_add_catch_test(test_state_object tests/test_state_object.cpp)
+
   # clap_plugin_params::flush event application.
   if(AVND_ENABLE_CLAP AND CLAP_HEADER)
     avnd_add_catch_test(test_params_flush tests/objects/params_flush.cpp)

--- a/include/avnd/wrappers/state_object.hpp
+++ b/include/avnd/wrappers/state_object.hpp
@@ -15,12 +15,13 @@
  *     };
  *
  * Members are saved and restored positionally through the reflection-based
- * format in state_serial.hpp. Appending members, dropping trailing ones and
- * changing a member's type are absorbed without any bookkeeping; a change
- * the layout hash notices but the format cannot interpret on its own --
- * members reordered or inserted in the middle -- is a layout change, and
- * loading data across one requires the processor to declare a new
- * state_version and a migration.
+ * format in state_serial.hpp, so state members -- like inlets -- are added
+ * at the end. Appending, dropping trailing members and changing a member's
+ * type are absorbed without any bookkeeping. Reordering or inserting in the
+ * middle is detected and refused unless the processor declares a new
+ * state_version together with a migration; the one edit nothing can detect
+ * is swapping two members of the identical type, which is exactly what the
+ * version is there to cover.
  *
  * A processor that wants to control its own bytes defines save/load on the
  * state object; those take precedence over reflection:
@@ -151,16 +152,16 @@ bool load_object_state(
   {
     const auto res = avnd::state::load(obj.state, data, n);
     ok = res.ok;
-    // The struct's layout changed since this data was written. Whatever
-    // still lined up has been applied, but the rest cannot be recovered by
-    // position alone -- only the processor knows what moved where. Without a
-    // migration to say so, refuse rather than hand back a half-filled state.
-    if(ok && res.layout_drift)
+    // A record described something other than the member at its position, so
+    // the members after it cannot be trusted either -- only the processor
+    // knows what moved where. Members merely appended since the data was
+    // written are not this: those load cleanly and keep their defaults.
+    if(ok && res.type_mismatch)
     {
       if constexpr(has_migration<T>)
       {
         if(written_version >= current)
-          return false; // drift with nothing to migrate from
+          return false; // nothing to migrate from
       }
       else
       {

--- a/include/avnd/wrappers/state_object.hpp
+++ b/include/avnd/wrappers/state_object.hpp
@@ -14,9 +14,13 @@
  *       struct { std::vector<uint8_t> program; int mode{}; } state;
  *     };
  *
- * Members are saved and restored by name through the reflection-based
- * format in state_serial.hpp, so adding, removing and reordering them does
- * not invalidate existing session data.
+ * Members are saved and restored positionally through the reflection-based
+ * format in state_serial.hpp. Appending members, dropping trailing ones and
+ * changing a member's type are absorbed without any bookkeeping; a change
+ * the layout hash notices but the format cannot interpret on its own --
+ * members reordered or inserted in the middle -- is a layout change, and
+ * loading data across one requires the processor to declare a new
+ * state_version and a migration.
  *
  * A processor that wants to control its own bytes defines save/load on the
  * state object; those take precedence over reflection:
@@ -145,7 +149,24 @@ bool load_object_state(
   }
   else
   {
-    ok = avnd::state::load(obj.state, data, n);
+    const auto res = avnd::state::load(obj.state, data, n);
+    ok = res.ok;
+    // The struct's layout changed since this data was written. Whatever
+    // still lined up has been applied, but the rest cannot be recovered by
+    // position alone -- only the processor knows what moved where. Without a
+    // migration to say so, refuse rather than hand back a half-filled state.
+    if(ok && res.layout_drift)
+    {
+      if constexpr(has_migration<T>)
+      {
+        if(written_version >= current)
+          return false; // drift with nothing to migrate from
+      }
+      else
+      {
+        return false;
+      }
+    }
   }
 
   if(!ok)

--- a/include/avnd/wrappers/state_object.hpp
+++ b/include/avnd/wrappers/state_object.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+/**
+ * A processor's persistent state.
+ *
+ * Declared like the other port groups:
+ *
+ *     struct MyProcessor
+ *     {
+ *       struct { ... } inputs;
+ *       struct { ... } outputs;
+ *       struct { std::vector<uint8_t> program; int mode{}; } state;
+ *     };
+ *
+ * Members are saved and restored by name through the reflection-based
+ * format in state_serial.hpp, so adding, removing and reordering them does
+ * not invalidate existing session data.
+ *
+ * A processor that wants to control its own bytes defines save/load on the
+ * state object; those take precedence over reflection:
+ *
+ *     struct {
+ *       std::vector<uint8_t> save() const;
+ *       bool load(const uint8_t* data, std::size_t n);
+ *     } state;
+ *
+ * Semantic changes that renaming cannot express -- a field that changes
+ * meaning or unit -- are handled by declaring a version and a migration:
+ *
+ *     halp_meta(state_version, 3)
+ *     static void migrate_state(auto& state, int from)
+ *     {
+ *       if(from < 2) state.cutoff_hz = normalized_to_hz(state.cutoff_hz);
+ *       if(from < 3) state.mode = remap(state.mode);
+ *     }
+ *
+ * The version is written with the state; on load the reflection pass runs
+ * first, then migrate_state is called once with the version the data was
+ * written at. State written by a *newer* version than the binary
+ * understands is rejected rather than misinterpreted.
+ */
+
+#include <avnd/common/concepts_polyfill.hpp>
+#include <avnd/wrappers/state_serial.hpp>
+
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+namespace avnd
+{
+// ---------------------------------------------------------------------------
+// Detection
+
+template <typename T>
+concept has_state = requires(T t) { t.state; };
+
+template <typename T>
+using state_type_t = std::remove_cvref_t<decltype(std::declval<T&>().state)>;
+
+template <typename T>
+concept state_saves_itself = has_state<T> && requires(T t) {
+  { t.state.save() };
+};
+
+template <typename T>
+concept state_loads_itself
+    = has_state<T> && requires(T t, const std::uint8_t* p, std::size_t n) {
+        t.state.load(p, n);
+      };
+
+template <typename T>
+concept state_is_reflectable
+    = has_state<T> && avnd::state::serializable<state_type_t<T>>;
+
+// A processor has usable state if it can either serialize itself or be
+// reflected over.
+template <typename T>
+concept persistable
+    = has_state<T> && (state_saves_itself<T> || state_is_reflectable<T>);
+
+// ---------------------------------------------------------------------------
+// Versioning
+
+template <typename T>
+consteval int state_version()
+{
+  if constexpr(requires { T::state_version(); })
+    return T::state_version();
+  else if constexpr(requires { T::state_version; })
+    return T::state_version;
+  else
+    return 0;
+}
+
+template <typename T>
+concept has_migration = requires(state_type_t<T>& s) { T::migrate_state(s, 0); };
+
+// ---------------------------------------------------------------------------
+// Save / load
+
+template <typename T>
+  requires persistable<T>
+std::vector<std::uint8_t> save_object_state(const T& obj)
+{
+  if constexpr(state_saves_itself<T>)
+  {
+    const auto blob = obj.state.save();
+    return std::vector<std::uint8_t>(blob.begin(), blob.end());
+  }
+  else
+  {
+    return avnd::state::save(obj.state);
+  }
+}
+
+/**
+ * Restores `obj.state` from `data`. `written_version` is the version the
+ * blob was produced with, as recorded by the container.
+ *
+ * Returns false without touching the state when the data was written by a
+ * newer version of the processor than this binary knows how to read.
+ */
+template <typename T>
+  requires persistable<T>
+bool load_object_state(
+    T& obj, const std::uint8_t* data, std::size_t n, int written_version)
+{
+  constexpr int current = state_version<T>();
+  if(written_version > current)
+    return false;
+
+  bool ok = false;
+  if constexpr(state_loads_itself<T>)
+  {
+    if constexpr(requires { { obj.state.load(data, n) } -> std::same_as<bool>; })
+      ok = obj.state.load(data, n);
+    else
+    {
+      obj.state.load(data, n);
+      ok = true;
+    }
+  }
+  else
+  {
+    ok = avnd::state::load(obj.state, data, n);
+  }
+
+  if(!ok)
+    return false;
+
+  if constexpr(has_migration<T>)
+  {
+    if(written_version < current)
+      T::migrate_state(obj.state, written_version);
+  }
+  return true;
+}
+
+} // namespace avnd

--- a/include/avnd/wrappers/state_serial.hpp
+++ b/include/avnd/wrappers/state_serial.hpp
@@ -1,0 +1,387 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+/**
+ * Reflection-based serialization for a processor's `state` struct.
+ *
+ * Every member is written as a self-describing record keyed by its *field
+ * name*, not its position:
+ *
+ *     [u16 name length][name][u8 type tag][u32 payload size][payload]
+ *
+ * A reader matches records to members by name, skips records it does not
+ * recognise (the size makes that possible without understanding them) and
+ * leaves members that no record mentions at their default value. Adding,
+ * removing and reordering members therefore needs no migration code, which
+ * is the property property-store formats (LV2 state, Audio Unit ClassInfo)
+ * are built around. The type tag lets a reader detect that a member changed
+ * shape and fall back to its default instead of reinterpreting the bytes.
+ *
+ * The state struct must be a *named* type -- reflection cannot name the
+ * fields of an unnamed one, and the diagnostic it produces is obscure:
+ *
+ *     struct state_t { int mode; };  state_t state;  // yes
+ *     struct { int mode; } state;                    // no
+ *
+ * That is the one place this differs from the inputs/outputs groups, which
+ * only ever need positional reflection. The cost is a name; the benefit is
+ * that field identity survives the struct being edited.
+ *
+ * Supported members, recursively: trivially-copyable types, contiguous
+ * containers of them (std::string, std::vector<int>, ...), aggregates, and
+ * lists of any of those. Members whose type is not serializable make
+ * `serializable_state` false; the processor then has to provide save/load
+ * itself.
+ *
+ * Byte order is native: the writer and reader are the same binary. Sizes and
+ * tags are fixed-width so a foreign-endian reader can at least skip records
+ * rather than misparse them.
+ */
+
+#include <avnd/common/for_nth.hpp>
+
+#include <boost/pfr.hpp>
+#include <boost/pfr/core_name.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace avnd::state
+{
+enum class tag : std::uint8_t
+{
+  raw = 0,       // trivially copyable: payload is the object's bytes
+  bytes = 1,     // contiguous container of trivially copyable elements
+  aggregate = 2, // nested records, one per field
+  list = 3,      // u32 count followed by that many encoded elements
+  unknown = 255
+};
+
+// ---------------------------------------------------------------------------
+// Type classification
+
+template <typename T>
+concept trivial_member = std::is_trivially_copyable_v<std::remove_cvref_t<T>>;
+
+template <typename T>
+concept contiguous_container = requires(T t) {
+  { t.size() } -> std::convertible_to<std::size_t>;
+  t.resize(std::size_t{});
+  t.data();
+} && trivial_member<std::remove_cvref_t<decltype(*std::declval<T&>().data())>>;
+
+template <typename T>
+concept list_container = requires(T t) {
+  { t.size() } -> std::convertible_to<std::size_t>;
+  t.clear();
+  t.emplace_back();
+  t.begin();
+  t.end();
+} && !contiguous_container<T>;
+
+template <typename T>
+constexpr bool serializable_impl();
+
+template <typename T, std::size_t... I>
+constexpr bool aggregate_serializable(std::index_sequence<I...>)
+{
+  return (serializable_impl<boost::pfr::tuple_element_t<I, T>>() && ...);
+}
+
+template <typename T>
+constexpr bool serializable_impl()
+{
+  using type = std::remove_cvref_t<T>;
+  if constexpr(trivial_member<type>)
+    return true;
+  else if constexpr(contiguous_container<type>)
+    return true;
+  else if constexpr(list_container<type>)
+    return serializable_impl<typename type::value_type>();
+  else if constexpr(std::is_aggregate_v<type>)
+    return aggregate_serializable<type>(
+        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+  else
+    return false;
+}
+
+template <typename T>
+concept serializable = serializable_impl<std::remove_cvref_t<T>>();
+
+template <typename T>
+constexpr tag tag_of()
+{
+  using type = std::remove_cvref_t<T>;
+  if constexpr(trivial_member<type>)
+    return tag::raw;
+  else if constexpr(contiguous_container<type>)
+    return tag::bytes;
+  else if constexpr(list_container<type>)
+    return tag::list;
+  else
+    return tag::aggregate;
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+
+struct writer
+{
+  std::vector<std::uint8_t> bytes;
+
+  void raw(const void* p, std::size_t n)
+  {
+    const auto at = bytes.size();
+    bytes.resize(at + n);
+    if(n > 0)
+      std::memcpy(bytes.data() + at, p, n);
+  }
+
+  template <typename T>
+    requires std::is_trivially_copyable_v<T>
+  void pod(const T& v)
+  {
+    raw(&v, sizeof(T));
+  }
+
+  // Reserve a length slot, fill it once the payload is known.
+  std::size_t begin_sized()
+  {
+    const auto at = bytes.size();
+    pod(std::uint32_t{0});
+    return at;
+  }
+  void end_sized(std::size_t at)
+  {
+    const auto size = std::uint32_t(bytes.size() - at - sizeof(std::uint32_t));
+    std::memcpy(bytes.data() + at, &size, sizeof(size));
+  }
+};
+
+// Payload format marker, so a future change of encoding is detectable
+// rather than silently misread.
+inline constexpr std::uint8_t format_version = 1;
+
+template <typename T>
+void encode_value(writer& w, const T& v);
+
+template <typename T>
+void encode_fields(writer& w, const T& agg)
+{
+  w.pod(format_version);
+  constexpr auto names = boost::pfr::names_as_array<T>();
+  [&]<std::size_t... I>(std::index_sequence<I...>) {
+    (
+        [&] {
+          const std::string_view name = names[I];
+          w.pod(std::uint16_t(name.size()));
+          w.raw(name.data(), name.size());
+          w.pod(tag_of<boost::pfr::tuple_element_t<I, T>>());
+          const auto slot = w.begin_sized();
+          encode_value(w, boost::pfr::get<I>(agg));
+          w.end_sized(slot);
+        }(),
+        ...);
+  }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>{});
+}
+
+template <typename T>
+void encode_value(writer& w, const T& v)
+{
+  using type = std::remove_cvref_t<T>;
+  if constexpr(trivial_member<type>)
+  {
+    w.pod(v);
+  }
+  else if constexpr(contiguous_container<type>)
+  {
+    using elem = std::remove_cvref_t<decltype(*v.data())>;
+    w.pod(std::uint32_t(v.size()));
+    w.raw(v.data(), v.size() * sizeof(elem));
+  }
+  else if constexpr(list_container<type>)
+  {
+    w.pod(std::uint32_t(v.size()));
+    for(const auto& e : v)
+      encode_value(w, e);
+  }
+  else
+  {
+    encode_fields(w, v);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reading
+
+struct reader
+{
+  const std::uint8_t* data{};
+  std::size_t size{};
+  std::size_t pos{};
+  bool ok{true};
+
+  bool has(std::size_t n) const noexcept { return ok && pos + n <= size; }
+
+  bool raw(void* out, std::size_t n)
+  {
+    if(!has(n))
+      return ok = false;
+    if(n > 0)
+      std::memcpy(out, data + pos, n);
+    pos += n;
+    return true;
+  }
+
+  template <typename T>
+    requires std::is_trivially_copyable_v<T>
+  bool pod(T& v)
+  {
+    return raw(&v, sizeof(T));
+  }
+
+  void skip(std::size_t n)
+  {
+    if(!has(n))
+      ok = false;
+    else
+      pos += n;
+  }
+};
+
+template <typename T>
+bool decode_value(reader& r, T& v, std::size_t payload_size);
+
+template <typename T>
+bool decode_fields(reader& r, T& agg, std::size_t payload_size)
+{
+  const std::size_t end = r.pos + payload_size;
+
+  std::uint8_t fmt{};
+  if(!r.pod(fmt))
+    return false;
+  if(fmt != format_version)
+    return false;
+
+  while(r.ok && r.pos < end)
+  {
+    std::uint16_t name_len{};
+    if(!r.pod(name_len))
+      return false;
+    if(!r.has(name_len))
+      return false;
+    const std::string_view name{
+        reinterpret_cast<const char*>(r.data + r.pos), name_len};
+    r.pos += name_len;
+
+    tag t{};
+    std::uint32_t size{};
+    if(!r.pod(t) || !r.pod(size))
+      return false;
+    if(!r.has(size))
+      return false;
+
+    const std::size_t payload_start = r.pos;
+    bool matched = false;
+
+    [&]<std::size_t... I>(std::index_sequence<I...>) {
+      (
+          [&] {
+            constexpr auto names = boost::pfr::names_as_array<T>();
+            if(matched || names[I] != name)
+              return;
+            using field_t = boost::pfr::tuple_element_t<I, T>;
+            matched = true;
+            // A member that changed shape keeps its default rather than
+            // reinterpreting bytes written for a different type.
+            if(t != tag_of<field_t>())
+              return;
+            decode_value(r, boost::pfr::get<I>(agg), size);
+          }(),
+          ...);
+    }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>{});
+
+    // Unknown, mismatched or partially-read records: resume at the next one.
+    r.pos = payload_start;
+    r.skip(size);
+  }
+  return r.ok;
+}
+
+template <typename T>
+bool decode_value(reader& r, T& v, std::size_t payload_size)
+{
+  using type = std::remove_cvref_t<T>;
+  if constexpr(trivial_member<type>)
+  {
+    return r.pod(v);
+  }
+  else if constexpr(contiguous_container<type>)
+  {
+    using elem = std::remove_cvref_t<decltype(*v.data())>;
+    std::uint32_t count{};
+    if(!r.pod(count))
+      return false;
+    // Trust the record size, not the count: a corrupt count must not make us
+    // allocate or read out of bounds.
+    if(count > (payload_size - sizeof(count)) / sizeof(elem))
+      return false;
+    v.resize(count);
+    return r.raw(v.data(), std::size_t(count) * sizeof(elem));
+  }
+  else if constexpr(list_container<type>)
+  {
+    std::uint32_t count{};
+    if(!r.pod(count))
+      return false;
+    v.clear();
+    const std::size_t end = r.pos + (payload_size - sizeof(count));
+    for(std::uint32_t i = 0; i < count && r.ok && r.pos < end; i++)
+    {
+      v.emplace_back();
+      if(!decode_value(r, *std::prev(v.end()), end - r.pos))
+        return false;
+    }
+    return r.ok;
+  }
+  else
+  {
+    return decode_fields(r, v, payload_size);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+
+template <typename S>
+  requires serializable<S>
+std::vector<std::uint8_t> save(const S& s)
+{
+  writer w;
+  encode_fields(w, s);
+  return std::move(w.bytes);
+}
+
+// Members not mentioned by the blob keep the value they already hold, so the
+// caller decides what "missing" means by pre-seeding defaults. An empty
+// payload mentions nothing and therefore succeeds without changing anything;
+// deciding whether a host handing over *no state at all* is an error belongs
+// to the container above this one.
+template <typename S>
+  requires serializable<S>
+bool load(S& s, const std::uint8_t* data, std::size_t n)
+{
+  if(n == 0)
+    return true;
+  if(!data)
+    return false;
+  reader r{data, n, 0, true};
+  return decode_fields(r, s, n);
+}
+
+} // namespace avnd::state

--- a/include/avnd/wrappers/state_serial.hpp
+++ b/include/avnd/wrappers/state_serial.hpp
@@ -30,9 +30,10 @@
  * shape changes it); the second is what `state_version` and `migrate_state`
  * are for.
  *
- * On a layout-hash mismatch the reader does not guess: it decodes what
- * still matches record-by-record and reports the drift, so the caller can
- * refuse the load when the processor has not declared a migration.
+ * A record that does not describe the member at its position is reported as
+ * a type mismatch, which tells the caller the remaining positions cannot be
+ * trusted; it refuses the load unless the processor declared a migration.
+ * Appending members and dropping trailing ones are not mismatches.
  *
  * Supported members, recursively: trivially-copyable types, contiguous
  * containers of them (std::string, std::vector<int>, ...), aggregates, and
@@ -340,10 +341,16 @@ struct reader
 struct load_result
 {
   bool ok{false};
-  // The data was written from a struct whose layout differs from this one:
-  // records still matched by position and tag were applied, the rest were
-  // left at their defaults.
-  bool layout_drift{false};
+
+  // A record did not describe the member sitting at its position. Members
+  // appended since, and records left over from members since removed, do
+  // *not* set this: only a genuine disagreement about what lives where,
+  // which means the remaining positions can no longer be trusted.
+  bool type_mismatch{false};
+
+  // The layout hash differed. True for any structural edit, including the
+  // benign ones, so it is informational rather than a reason to refuse.
+  bool layout_changed{false};
 
   explicit operator bool() const noexcept { return ok; }
 };
@@ -352,7 +359,8 @@ template <typename T>
 bool decode_value(reader& r, T& v, std::size_t payload_size);
 
 template <typename T>
-bool decode_fields(reader& r, T& agg, std::size_t payload_size, bool& drift)
+bool decode_fields(
+    reader& r, T& agg, std::size_t payload_size, bool& mismatch, bool& changed)
 {
   const std::size_t end = r.pos + payload_size;
 
@@ -364,11 +372,11 @@ bool decode_fields(reader& r, T& agg, std::size_t payload_size, bool& drift)
   if(fmt != format_version)
     return false;
   if(hash != layout_hash_of<T>())
-    drift = true;
+    changed = true;
 
   constexpr std::size_t fields = boost::pfr::tuple_size_v<T>;
   if(count != fields)
-    drift = true;
+    changed = true;
 
   for(std::size_t index = 0; index < count && r.ok && r.pos < end; index++)
   {
@@ -393,7 +401,7 @@ bool decode_fields(reader& r, T& agg, std::size_t payload_size, bool& drift)
             // reinterpreted.
             if(t != tag_of<field_t>() || k != std::uint8_t(kind_of<field_t>()))
             {
-              drift = true;
+              mismatch = true;
               return;
             }
             decode_value(r, boost::pfr::get<I>(agg), size);
@@ -447,8 +455,8 @@ bool decode_value(reader& r, T& v, std::size_t payload_size)
   }
   else
   {
-    bool nested_drift = false;
-    return decode_fields(r, v, payload_size, nested_drift);
+    bool nested_mismatch = false, nested_changed = false;
+    return decode_fields(r, v, payload_size, nested_mismatch, nested_changed);
   }
 }
 
@@ -474,12 +482,12 @@ template <typename S>
 load_result load(S& s, const std::uint8_t* data, std::size_t n)
 {
   if(n == 0)
-    return {.ok = true, .layout_drift = false};
+    return {.ok = true};
   if(!data)
     return {};
   reader r{data, n, 0, true};
   load_result res;
-  res.ok = decode_fields(r, s, n, res.layout_drift);
+  res.ok = decode_fields(r, s, n, res.type_mismatch, res.layout_changed);
   return res;
 }
 

--- a/include/avnd/wrappers/state_serial.hpp
+++ b/include/avnd/wrappers/state_serial.hpp
@@ -51,7 +51,8 @@
 
 #include <avnd/concepts/generic.hpp>
 
-#include <boost/pfr.hpp>
+#include <avnd/common/aggregates.hpp>
+#include <avnd/common/for_nth.hpp>
 
 #include <array>
 #include <cstdint>
@@ -117,7 +118,7 @@ constexpr bool borrows_memory();
 template <typename T, std::size_t... I>
 constexpr bool any_member_borrows(std::index_sequence<I...>)
 {
-  return (borrows_memory<boost::pfr::tuple_element_t<I, T>>() || ...);
+  return (borrows_memory<avnd::pfr::tuple_element_t<I, T>>() || ...);
 }
 
 template <typename T, std::size_t... I>
@@ -161,7 +162,7 @@ constexpr bool borrows_memory()
     return true;
   else if constexpr(std::is_aggregate_v<type>)
     return any_member_borrows<type>(
-        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+        std::make_index_sequence<avnd::pfr::tuple_size_v<type>>{});
   else
     return false;
 }
@@ -172,7 +173,7 @@ constexpr bool serializable_impl();
 template <typename T, std::size_t... I>
 constexpr bool aggregate_serializable(std::index_sequence<I...>)
 {
-  return (serializable_impl<boost::pfr::tuple_element_t<I, T>>() && ...);
+  return (serializable_impl<avnd::pfr::tuple_element_t<I, T>>() && ...);
 }
 
 template <typename T, std::size_t... I>
@@ -216,7 +217,7 @@ constexpr bool serializable_impl()
     return true;
   else if constexpr(std::is_aggregate_v<type>)
     return aggregate_serializable<type>(
-        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+        std::make_index_sequence<avnd::pfr::tuple_size_v<type>>{});
   else
     return false;
 }
@@ -300,7 +301,7 @@ template <typename T, std::size_t... I>
 constexpr std::uint32_t
 layout_hash_fields(std::uint32_t h, std::index_sequence<I...>)
 {
-  ((h = layout_hash_of<boost::pfr::tuple_element_t<I, T>>(h)), ...);
+  ((h = layout_hash_of<avnd::pfr::tuple_element_t<I, T>>(h)), ...);
   return h;
 }
 
@@ -352,14 +353,14 @@ constexpr std::uint32_t layout_hash_of(std::uint32_t h)
   // shapes still feed the hash so that {int, float} and {float, int} differ.
   else if constexpr(std::is_aggregate_v<type> && !std::is_array_v<type>)
     return layout_hash_fields<type>(
-        hash_step(h, std::uint32_t(boost::pfr::tuple_size_v<type>)),
-        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+        hash_step(h, std::uint32_t(avnd::pfr::tuple_size_v<type>)),
+        std::make_index_sequence<avnd::pfr::tuple_size_v<type>>{});
   else if constexpr(trivial_member<type>)
     return hash_step(h, std::uint32_t(sizeof(type)));
   else
     return layout_hash_fields<type>(
-        hash_step(h, std::uint32_t(boost::pfr::tuple_size_v<type>)),
-        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+        hash_step(h, std::uint32_t(avnd::pfr::tuple_size_v<type>)),
+        std::make_index_sequence<avnd::pfr::tuple_size_v<type>>{});
 }
 
 // ---------------------------------------------------------------------------
@@ -418,11 +419,11 @@ void encode_fields(writer& w, const T& agg)
 {
   w.pod(format_version);
   w.pod(layout_hash_of<T>());
-  w.pod(std::uint16_t(boost::pfr::tuple_size_v<T>));
+  w.pod(std::uint16_t(avnd::pfr::tuple_size_v<T>));
 
-  [&]<std::size_t... I>(std::index_sequence<I...>) {
-    (encode_record(w, boost::pfr::get<I>(agg)), ...);
-  }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>{});
+  avnd::for_each_field_ref(agg, [&](const auto& field) {
+    encode_record(w, field);
+  });
 }
 
 template <typename T>
@@ -584,42 +585,49 @@ bool decode_fields(
   if(hash != layout_hash_of<T>())
     changed = true;
 
-  constexpr std::size_t fields = boost::pfr::tuple_size_v<T>;
+  constexpr std::size_t fields = avnd::pfr::tuple_size_v<T>;
   if(count != fields)
     changed = true;
 
-  for(std::size_t index = 0; index < count && r.ok && r.pos < end; index++)
+  // One record per field, in declaration order. A record whose shape does
+  // not match its field is skipped (mismatch); a field with no record left
+  // keeps its default (appended member).
+  std::size_t index = 0;
+  avnd::for_each_field_ref(agg, [&](auto& field) {
+    if(!r.ok || index >= count)
+    {
+      index++;
+      return;
+    }
+    tag t{};
+    std::uint8_t k{};
+    std::uint32_t size{};
+    if(!(r.pod(t) && r.pod(k) && r.pod(size) && r.has(size)))
+    {
+      r.ok = false;
+      return;
+    }
+    const std::size_t payload_start = r.pos;
+    using field_t = std::remove_cvref_t<decltype(field)>;
+    if(t != tag_of<field_t>() || k != std::uint8_t(kind_of<field_t>()))
+      mismatch = true;
+    else
+      decode_value(r, field, size);
+    r.pos = payload_start;
+    r.skip(size);
+    index++;
+  });
+
+  // Records past the last field (members removed since) are skipped.
+  while(r.ok && index < count && r.pos < end)
   {
     tag t{};
     std::uint8_t k{};
     std::uint32_t size{};
-    if(!r.pod(t) || !r.pod(k) || !r.pod(size))
+    if(!(r.pod(t) && r.pod(k) && r.pod(size) && r.has(size)))
       return false;
-    if(!r.has(size))
-      return false;
-
-    const std::size_t payload_start = r.pos;
-
-    [&]<std::size_t... I>(std::index_sequence<I...>) {
-      (
-          [&] {
-            if(I != index)
-              return;
-            using field_t = boost::pfr::tuple_element_t<I, T>;
-            if(t != tag_of<field_t>() || k != std::uint8_t(kind_of<field_t>()))
-            {
-              mismatch = true;
-              return;
-            }
-            decode_value(r, boost::pfr::get<I>(agg), size);
-          }(),
-          ...);
-    }(std::make_index_sequence<fields>{});
-
-    // Trailing records, mismatched ones and partially-read ones all resume
-    // at the next record.
-    r.pos = payload_start;
     r.skip(size);
+    index++;
   }
   return r.ok;
 }

--- a/include/avnd/wrappers/state_serial.hpp
+++ b/include/avnd/wrappers/state_serial.hpp
@@ -19,84 +19,97 @@
  *  - appending a member: older data simply has fewer records, and the new
  *    member keeps its default;
  *  - dropping trailing members: the extra records are skipped;
- *  - a member whose type changed: the record no longer matches the member
+ *  - a member whose type changed: the record no longer describes the member
  *    at that position -- including an int becoming a float, which the
  *    scalar kind distinguishes despite the identical width -- so it is
  *    skipped instead of being reinterpreted.
- *
- * What it cannot see is a change that leaves the layout identical -- two
- * members of the same type swapped, or a member's *meaning* changed. The
- * layout hash catches the first class (any change of field count, order or
- * shape changes it); the second is what `state_version` and `migrate_state`
- * are for.
  *
  * A record that does not describe the member at its position is reported as
  * a type mismatch, which tells the caller the remaining positions cannot be
  * trusted; it refuses the load unless the processor declared a migration.
  * Appending members and dropping trailing ones are not mismatches.
  *
- * Supported members, recursively: trivially-copyable types, contiguous
- * containers of them (std::string, std::vector<int>, ...), aggregates, and
- * lists of any of those.
+ * The one edit nothing here can see is a swap of two members of the
+ * identical type, or a change in what a member *means*: that is what
+ * state_version and migrate_state are for.
+ *
+ * Member types are classified with the same concepts the value bindings
+ * use (avnd/concepts/generic.hpp), so anything a processor may carry is
+ * covered: scalars and enums, strings, vectors and other list containers,
+ * sets and maps, optionals, variants, pairs and tuples, fixed arrays,
+ * aggregates, and any nesting of those.
+ *
+ * What is refused, at compile time: anything that only *borrows* its data.
+ * A pointer, reference or view is trivially copyable, so it would be
+ * written out as an address that means nothing to the process reading it
+ * back. A processor needing one provides save/load on its state instead.
  *
  * Byte order is native: writer and reader are the same binary. Sizes and
  * tags are fixed-width so a foreign-endian reader can at least skip records
  * rather than misparse them.
  */
 
+#include <avnd/concepts/generic.hpp>
+
 #include <boost/pfr.hpp>
 
 #include <array>
-#include <tuple>
-
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <tuple>
 #include <type_traits>
+#include <utility>
+#include <variant>
 #include <vector>
 
 namespace avnd::state
 {
 enum class tag : std::uint8_t
 {
-  raw = 0,       // trivially copyable: payload is the object's bytes
-  bytes = 1,     // contiguous container of trivially copyable elements
-  aggregate = 2, // nested records, one per field
-  list = 3,      // u32 count followed by that many encoded elements
-  unknown = 255
+  raw = 0,        // trivially copyable: payload is the object's bytes
+  bytes = 1,      // contiguous block of trivially copyable elements
+  aggregate = 2,  // nested records, one per field
+  list = 3,       // u32 count, then that many encoded elements
+  optional = 4,   // u8 engaged, then the value if engaged
+  variant = 5,    // u32 alternative index, then that alternative
+  map = 6,        // u32 count, then key/value pairs
+  set = 7,        // u32 count, then keys
+  tuple = 8,      // the elements in order, no count
+  fixed_array = 9 // u32 count, then that many elements
 };
 
 // ---------------------------------------------------------------------------
-// Type classification
+// Classification.
+//
+// Order matters: a std::string is span_ish and list_ish, a std::array is
+// span_ish and tuple_ish, so the more specific test comes first.
 
 template <typename T>
 concept trivial_member = std::is_trivially_copyable_v<std::remove_cvref_t<T>>;
 
 template <typename T>
-concept contiguous_container = requires(T t) {
-  { t.size() } -> std::convertible_to<std::size_t>;
-  t.resize(std::size_t{});
+concept byte_block = avnd::vector_ish<T> && requires(T t) {
   t.data();
-} && trivial_member<std::remove_cvref_t<decltype(*std::declval<T&>().data())>>;
+} && trivial_member<typename std::remove_cvref_t<T>::value_type>;
 
+// A string we own. std::string_view is string_ish too, but it borrows its
+// characters, so it must not take this path.
 template <typename T>
-concept list_container = requires(T t) {
-  { t.size() } -> std::convertible_to<std::size_t>;
-  t.clear();
-  t.emplace_back();
-  t.begin();
-  t.end();
-} && !contiguous_container<T>;
+concept string_member = avnd::string_ish<T> && requires(T& t) {
+  t.resize(std::size_t{});
+  { t.data() } -> std::convertible_to<const char*>;
+};
 
-// A type that only borrows its data: trivially copyable, so it would be
-// written out as raw bytes, and those bytes are an address that means
-// nothing in the process that reads them back.
+// A type that only borrows: data() is a pointer and the size is not ours to
+// change, so the bytes we would store are an address.
 template <typename T>
 concept view_like = requires(const T& t) {
   t.data();
   { t.size() } -> std::convertible_to<std::size_t>;
 } && std::is_pointer_v<decltype(std::declval<const T&>().data())>
-     && !requires(T& t) { t.resize(std::size_t{}); };
+     && !requires(T& t) { t.resize(std::size_t{}); }
+     && !avnd::tuple_ish<std::remove_cvref_t<T>>;
 
 template <typename T>
 constexpr bool borrows_memory();
@@ -107,25 +120,17 @@ constexpr bool any_member_borrows(std::index_sequence<I...>)
   return (borrows_memory<boost::pfr::tuple_element_t<I, T>>() || ...);
 }
 
-// Persisted state has to own what it describes. Pointers, references and
-// views survive a memcpy syntactically and mean nothing once reloaded, so
-// they are refused rather than written into a session file.
-// std::array, pair and tuple carry a std::tuple_size, which the aggregate
-// reflection cannot decompose on every compiler. They are handled through
-// the standard interface instead of being taken apart field by field.
-template <typename T>
-concept tuple_like = requires { std::tuple_size<std::remove_cvref_t<T>>::value; };
+template <typename T, std::size_t... I>
+constexpr bool any_element_borrows(std::index_sequence<I...>)
+{
+  return (borrows_memory<std::tuple_element_t<I, T>>() || ...);
+}
 
-// std::array is the one tuple-like type worth supporting: it is a fixed
-// block of elements and, when they are trivially copyable, it is one too.
-// Whether std::pair and std::tuple are trivially copyable differs between
-// standard libraries, so accepting them on that basis would make a state
-// struct compile on one toolchain and not another. They are refused
-// everywhere instead.
-template <typename T>
-inline constexpr bool is_std_array_v = false;
-template <typename T, std::size_t N>
-inline constexpr bool is_std_array_v<std::array<T, N>> = true;
+template <typename T, std::size_t... I>
+constexpr bool any_alternative_borrows(std::index_sequence<I...>)
+{
+  return (borrows_memory<std::variant_alternative_t<I, T>>() || ...);
+}
 
 template <typename T>
 constexpr bool borrows_memory()
@@ -135,22 +140,28 @@ constexpr bool borrows_memory()
     return true;
   else if constexpr(std::is_array_v<type>)
     return borrows_memory<std::remove_extent_t<type>>();
-  else if constexpr(tuple_like<type>)
-  {
-    // Same element type throughout for std::array; for pair and tuple this
-    // only inspects the first, which is enough to reject the obvious cases
-    // -- they are not serializable anyway unless trivially copyable.
-    if constexpr(std::tuple_size_v<type> > 0)
-      return borrows_memory<std::tuple_element_t<0, type>>();
-    else
-      return false;
-  }
-  // An aggregate owns whatever it holds; look at what that is.
+  else if constexpr(string_member<type>)
+    return false;
+  else if constexpr(avnd::optional_ish<type>)
+    return borrows_memory<typename type::value_type>();
+  else if constexpr(avnd::variant_ish<type>)
+    return any_alternative_borrows<type>(
+        std::make_index_sequence<std::variant_size_v<type>>{});
+  else if constexpr(avnd::map_ish<type>)
+    return borrows_memory<typename type::key_type>()
+           || borrows_memory<typename type::mapped_type>();
+  else if constexpr(avnd::set_ish<type>)
+    return borrows_memory<typename type::key_type>();
+  else if constexpr(avnd::vector_ish<type>)
+    return borrows_memory<typename type::value_type>();
+  else if constexpr(avnd::tuple_ish<type>)
+    return any_element_borrows<type>(
+        std::make_index_sequence<std::tuple_size_v<type>>{});
+  else if constexpr(view_like<type>)
+    return true;
   else if constexpr(std::is_aggregate_v<type>)
     return any_member_borrows<type>(
         std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
-  else if constexpr(view_like<type>)
-    return true;
   else
     return false;
 }
@@ -164,25 +175,46 @@ constexpr bool aggregate_serializable(std::index_sequence<I...>)
   return (serializable_impl<boost::pfr::tuple_element_t<I, T>>() && ...);
 }
 
+template <typename T, std::size_t... I>
+constexpr bool elements_serializable(std::index_sequence<I...>)
+{
+  return (serializable_impl<std::tuple_element_t<I, T>>() && ...);
+}
+
+template <typename T, std::size_t... I>
+constexpr bool alternatives_serializable(std::index_sequence<I...>)
+{
+  return (serializable_impl<std::variant_alternative_t<I, T>>() && ...);
+}
+
 template <typename T>
 constexpr bool serializable_impl()
 {
   using type = std::remove_cvref_t<T>;
   if constexpr(borrows_memory<type>())
     return false;
-  else if constexpr(tuple_like<type> && !is_std_array_v<type>)
-    return false;
+  else if constexpr(string_member<type>)
+    return true;
+  else if constexpr(avnd::optional_ish<type>)
+    return serializable_impl<typename type::value_type>();
+  else if constexpr(avnd::variant_ish<type>)
+    return alternatives_serializable<type>(
+        std::make_index_sequence<std::variant_size_v<type>>{});
+  else if constexpr(avnd::map_ish<type>)
+    return serializable_impl<typename type::key_type>()
+           && serializable_impl<typename type::mapped_type>();
+  else if constexpr(avnd::set_ish<type>)
+    return serializable_impl<typename type::key_type>();
+  else if constexpr(byte_block<type>)
+    return true;
+  else if constexpr(avnd::vector_ish<type>)
+    return serializable_impl<typename type::value_type>();
+  else if constexpr(avnd::tuple_ish<type>)
+    return elements_serializable<type>(
+        std::make_index_sequence<std::tuple_size_v<type>>{});
   else if constexpr(trivial_member<type>)
     return true;
-  else if constexpr(contiguous_container<type>)
-    return true;
-  else if constexpr(list_container<type>)
-    return serializable_impl<typename type::value_type>();
-  // A tuple-like type that got this far is not trivially copyable, so it
-  // would have to be taken apart -- which is exactly what the aggregate
-  // reflection cannot do for them. std::array of non-trivial elements ends
-  // up here, and is left to the processor's own save/load.
-  else if constexpr(std::is_aggregate_v<type> && !tuple_like<type>)
+  else if constexpr(std::is_aggregate_v<type>)
     return aggregate_serializable<type>(
         std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
   else
@@ -196,50 +228,41 @@ template <typename T>
 constexpr tag tag_of()
 {
   using type = std::remove_cvref_t<T>;
-  if constexpr(trivial_member<type>)
-    return tag::raw;
-  else if constexpr(contiguous_container<type>)
+  if constexpr(string_member<type>)
     return tag::bytes;
-  else if constexpr(list_container<type>)
+  else if constexpr(avnd::optional_ish<type>)
+    return tag::optional;
+  else if constexpr(avnd::variant_ish<type>)
+    return tag::variant;
+  else if constexpr(avnd::map_ish<type>)
+    return tag::map;
+  else if constexpr(avnd::set_ish<type>)
+    return tag::set;
+  else if constexpr(byte_block<type>)
+    return tag::bytes;
+  else if constexpr(avnd::vector_ish<type>)
     return tag::list;
+  else if constexpr(avnd::tuple_ish<type>)
+    return std::is_trivially_copyable_v<type> ? tag::raw : tag::tuple;
+  else if constexpr(trivial_member<type>)
+    return tag::raw;
   else
     return tag::aggregate;
 }
 
 // ---------------------------------------------------------------------------
-// Layout hash: field count, order and shape. Two structs with the same hash
-// are interchangeable as far as this format is concerned; any structural
-// edit changes it.
+// Scalar kind: size alone does not identify a scalar, and an int read back
+// as a float of the same width is silent corruption.
 
-constexpr std::uint32_t hash_step(std::uint32_t h, std::uint32_t v)
-{
-  h ^= v;
-  return h * 16777619u; // FNV-1a
-}
-
-template <typename T>
-constexpr std::uint32_t layout_hash_of(std::uint32_t h = 2166136261u);
-
-template <typename T, std::size_t... I>
-constexpr std::uint32_t
-layout_hash_fields(std::uint32_t h, std::index_sequence<I...>)
-{
-  ((h = layout_hash_of<boost::pfr::tuple_element_t<I, T>>(h)), ...);
-  return h;
-}
-
-// Size alone does not identify a scalar: an int and a float of the same
-// width would hash the same, and swapping them would reinterpret one as the
-// other. Encode what kind of scalar it is as well.
 enum class scalar_kind : std::uint32_t
 {
+  none = 0,
   boolean = 1,
   signed_int = 2,
   unsigned_int = 3,
   floating = 4,
   enumeration = 5,
-  pointer = 6,
-  other = 7
+  composite = 6
 };
 
 template <typename T>
@@ -255,10 +278,49 @@ constexpr scalar_kind kind_of()
   else if constexpr(std::is_integral_v<type>)
     return std::is_signed_v<type> ? scalar_kind::signed_int
                                   : scalar_kind::unsigned_int;
-  else if constexpr(std::is_pointer_v<type>)
-    return scalar_kind::pointer;
+  else if constexpr(trivial_member<type>)
+    return scalar_kind::composite;
   else
-    return scalar_kind::other;
+    return scalar_kind::none;
+}
+
+// ---------------------------------------------------------------------------
+// Layout hash
+
+constexpr std::uint32_t hash_step(std::uint32_t h, std::uint32_t v)
+{
+  h ^= v;
+  return h * 16777619u; // FNV-1a
+}
+
+template <typename T>
+constexpr std::uint32_t layout_hash_of(std::uint32_t h = 2166136261u);
+
+template <typename T, std::size_t... I>
+constexpr std::uint32_t
+layout_hash_fields(std::uint32_t h, std::index_sequence<I...>)
+{
+  // Fold the position in between fields so that {int, float} and
+  // {float, int} do not hash alike -- the FNV step alone is too symmetric
+  // over short runs of small values.
+  ((h = layout_hash_of<boost::pfr::tuple_element_t<I, T>>(hash_step(h, I))), ...);
+  return h;
+}
+
+template <typename T, std::size_t... I>
+constexpr std::uint32_t
+layout_hash_elements(std::uint32_t h, std::index_sequence<I...>)
+{
+  ((h = layout_hash_of<std::tuple_element_t<I, T>>(h)), ...);
+  return h;
+}
+
+template <typename T, std::size_t... I>
+constexpr std::uint32_t
+layout_hash_alternatives(std::uint32_t h, std::index_sequence<I...>)
+{
+  ((h = layout_hash_of<std::variant_alternative_t<I, T>>(h)), ...);
+  return h;
 }
 
 template <typename T>
@@ -266,26 +328,38 @@ constexpr std::uint32_t layout_hash_of(std::uint32_t h)
 {
   using type = std::remove_cvref_t<T>;
   h = hash_step(h, std::uint32_t(tag_of<type>()));
-  if constexpr(trivial_member<type>)
-  {
-    h = hash_step(h, std::uint32_t(sizeof(type)));
-    h = hash_step(h, std::uint32_t(kind_of<type>()));
-    // A trivially-copyable aggregate is memcpy'd, but its shape still has to
-    // be part of the hash: two structs of the same size are not the same
-    // state.
-    if constexpr(std::is_aggregate_v<type> && !std::is_array_v<type>)
-      return layout_hash_fields<type>(
-          h, std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+  h = hash_step(h, std::uint32_t(kind_of<type>()));
+
+  if constexpr(string_member<type>)
     return h;
-  }
-  else if constexpr(contiguous_container<type>)
-  {
-    using elem = std::remove_cvref_t<decltype(*std::declval<type&>().data())>;
-    h = hash_step(h, std::uint32_t(sizeof(elem)));
-    return hash_step(h, std::uint32_t(kind_of<elem>()));
-  }
-  else if constexpr(list_container<type>)
+  else if constexpr(avnd::optional_ish<type>)
     return layout_hash_of<typename type::value_type>(h);
+  else if constexpr(avnd::variant_ish<type>)
+    return layout_hash_alternatives<type>(
+        hash_step(h, std::uint32_t(std::variant_size_v<type>)),
+        std::make_index_sequence<std::variant_size_v<type>>{});
+  else if constexpr(avnd::map_ish<type>)
+    return layout_hash_of<typename type::mapped_type>(
+        layout_hash_of<typename type::key_type>(h));
+  else if constexpr(avnd::set_ish<type>)
+    return layout_hash_of<typename type::key_type>(h);
+  else if constexpr(byte_block<type>)
+    return layout_hash_of<typename type::value_type>(h);
+  else if constexpr(avnd::vector_ish<type>)
+    return layout_hash_of<typename type::value_type>(h);
+  else if constexpr(avnd::tuple_ish<type>)
+    return layout_hash_elements<type>(
+        hash_step(h, std::uint32_t(std::tuple_size_v<type>)),
+        std::make_index_sequence<std::tuple_size_v<type>>{});
+  // A trivially-copyable aggregate is written as one blob, but its shape
+  // still has to reach the hash: two 8-byte structs are not the same state
+  // just because they memcpy the same way ({int,float} vs {float,int}).
+  else if constexpr(std::is_aggregate_v<type> && !std::is_array_v<type>)
+    return layout_hash_fields<type>(
+        hash_step(h, std::uint32_t(boost::pfr::tuple_size_v<type>)),
+        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+  else if constexpr(trivial_member<type>)
+    return hash_step(h, std::uint32_t(sizeof(type)));
   else
     return layout_hash_fields<type>(
         hash_step(h, std::uint32_t(boost::pfr::tuple_size_v<type>)),
@@ -332,6 +406,17 @@ struct writer
 template <typename T>
 void encode_value(writer& w, const T& v);
 
+// One record: what it is, then how long it is, then it.
+template <typename T>
+void encode_record(writer& w, const T& v)
+{
+  w.pod(tag_of<T>());
+  w.pod(std::uint8_t(kind_of<T>()));
+  const auto slot = w.begin_sized();
+  encode_value(w, v);
+  w.end_sized(slot);
+}
+
 template <typename T>
 void encode_fields(writer& w, const T& agg)
 {
@@ -340,15 +425,7 @@ void encode_fields(writer& w, const T& agg)
   w.pod(std::uint16_t(boost::pfr::tuple_size_v<T>));
 
   [&]<std::size_t... I>(std::index_sequence<I...>) {
-    (
-        [&] {
-          w.pod(tag_of<boost::pfr::tuple_element_t<I, T>>());
-          w.pod(std::uint8_t(kind_of<boost::pfr::tuple_element_t<I, T>>()));
-          const auto slot = w.begin_sized();
-          encode_value(w, boost::pfr::get<I>(agg));
-          w.end_sized(slot);
-        }(),
-        ...);
+    (encode_record(w, boost::pfr::get<I>(agg)), ...);
   }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>{});
 }
 
@@ -356,21 +433,58 @@ template <typename T>
 void encode_value(writer& w, const T& v)
 {
   using type = std::remove_cvref_t<T>;
-  if constexpr(trivial_member<type>)
+  if constexpr(string_member<type>)
   {
-    w.pod(v);
+    w.pod(std::uint32_t(v.size()));
+    w.raw(v.data(), v.size());
   }
-  else if constexpr(contiguous_container<type>)
+  else if constexpr(avnd::optional_ish<type>)
   {
-    using elem = std::remove_cvref_t<decltype(*v.data())>;
+    w.pod(std::uint8_t(bool(v) ? 1 : 0));
+    if(bool(v))
+      encode_value(w, *v);
+  }
+  else if constexpr(avnd::variant_ish<type>)
+  {
+    w.pod(std::uint32_t(v.index()));
+    std::visit([&](const auto& alt) { encode_value(w, alt); }, v);
+  }
+  else if constexpr(avnd::map_ish<type>)
+  {
+    w.pod(std::uint32_t(v.size()));
+    for(const auto& [key, mapped] : v)
+    {
+      encode_value(w, key);
+      encode_value(w, mapped);
+    }
+  }
+  else if constexpr(avnd::set_ish<type>)
+  {
+    w.pod(std::uint32_t(v.size()));
+    for(const auto& key : v)
+      encode_value(w, key);
+  }
+  else if constexpr(byte_block<type>)
+  {
+    using elem = typename type::value_type;
     w.pod(std::uint32_t(v.size()));
     w.raw(v.data(), v.size() * sizeof(elem));
   }
-  else if constexpr(list_container<type>)
+  else if constexpr(avnd::vector_ish<type>)
   {
     w.pod(std::uint32_t(v.size()));
     for(const auto& e : v)
       encode_value(w, e);
+  }
+  else if constexpr(avnd::tuple_ish<type> && !std::is_trivially_copyable_v<type>)
+  {
+    [&]<std::size_t... I>(std::index_sequence<I...>) {
+      (encode_value(w, std::get<I>(v)), ...);
+    }(std::make_index_sequence<std::tuple_size_v<type>>{});
+  }
+  else if constexpr(trivial_member<type>)
+  {
+    w.pod(v);
   }
   else
   {
@@ -436,6 +550,28 @@ struct load_result
 template <typename T>
 bool decode_value(reader& r, T& v, std::size_t payload_size);
 
+// Construct variant alternative `index` and decode into it.
+template <typename V, std::size_t I = 0>
+bool decode_variant(reader& r, V& v, std::uint32_t index, std::size_t payload)
+{
+  if constexpr(I < std::variant_size_v<V>)
+  {
+    if(index == I)
+    {
+      std::variant_alternative_t<I, V> alt{};
+      if(!decode_value(r, alt, payload))
+        return false;
+      v = std::move(alt);
+      return true;
+    }
+    return decode_variant<V, I + 1>(r, v, index, payload);
+  }
+  else
+  {
+    return false; // an alternative this build does not have
+  }
+}
+
 template <typename T>
 bool decode_fields(
     reader& r, T& agg, std::size_t payload_size, bool& mismatch, bool& changed)
@@ -474,9 +610,6 @@ bool decode_fields(
             if(I != index)
               return;
             using field_t = boost::pfr::tuple_element_t<I, T>;
-            // A record whose shape no longer matches the member at this
-            // position keeps the member's default rather than being
-            // reinterpreted.
             if(t != tag_of<field_t>() || k != std::uint8_t(kind_of<field_t>()))
             {
               mismatch = true;
@@ -487,8 +620,8 @@ bool decode_fields(
           ...);
     }(std::make_index_sequence<fields>{});
 
-    // Trailing records (members since removed), mismatched ones, and
-    // partially-read ones all resume at the next record.
+    // Trailing records, mismatched ones and partially-read ones all resume
+    // at the next record.
     r.pos = payload_start;
     r.skip(size);
   }
@@ -499,37 +632,113 @@ template <typename T>
 bool decode_value(reader& r, T& v, std::size_t payload_size)
 {
   using type = std::remove_cvref_t<T>;
-  if constexpr(trivial_member<type>)
+  const std::size_t end = r.pos + payload_size;
+
+  if constexpr(string_member<type>)
   {
-    return r.pod(v);
-  }
-  else if constexpr(contiguous_container<type>)
-  {
-    using elem = std::remove_cvref_t<decltype(*v.data())>;
     std::uint32_t count{};
     if(!r.pod(count))
       return false;
-    // Trust the record size, not the count: a corrupt count must not make us
-    // allocate or read out of bounds.
-    if(count > (payload_size - sizeof(count)) / sizeof(elem))
+    if(count > payload_size - sizeof(count))
       return false;
     v.resize(count);
-    return r.raw(v.data(), std::size_t(count) * sizeof(elem));
+    return count == 0 ? true : r.raw(v.data(), count);
   }
-  else if constexpr(list_container<type>)
+  else if constexpr(avnd::optional_ish<type>)
+  {
+    std::uint8_t engaged{};
+    if(!r.pod(engaged))
+      return false;
+    if(!engaged)
+    {
+      v.reset();
+      return true;
+    }
+    typename type::value_type inner{};
+    if(!decode_value(r, inner, end - r.pos))
+      return false;
+    v = std::move(inner);
+    return true;
+  }
+  else if constexpr(avnd::variant_ish<type>)
+  {
+    std::uint32_t index{};
+    if(!r.pod(index))
+      return false;
+    return decode_variant(r, v, index, end - r.pos);
+  }
+  else if constexpr(avnd::map_ish<type>)
   {
     std::uint32_t count{};
     if(!r.pod(count))
       return false;
     v.clear();
-    const std::size_t end = r.pos + (payload_size - sizeof(count));
     for(std::uint32_t i = 0; i < count && r.ok && r.pos < end; i++)
     {
-      v.emplace_back();
-      if(!decode_value(r, *std::prev(v.end()), end - r.pos))
+      std::remove_const_t<typename type::key_type> key{};
+      typename type::mapped_type mapped{};
+      if(!decode_value(r, key, end - r.pos))
         return false;
+      if(!decode_value(r, mapped, end - r.pos))
+        return false;
+      v.insert(typename type::value_type(std::move(key), std::move(mapped)));
     }
     return r.ok;
+  }
+  else if constexpr(avnd::set_ish<type>)
+  {
+    std::uint32_t count{};
+    if(!r.pod(count))
+      return false;
+    v.clear();
+    for(std::uint32_t i = 0; i < count && r.ok && r.pos < end; i++)
+    {
+      std::remove_const_t<typename type::key_type> key{};
+      if(!decode_value(r, key, end - r.pos))
+        return false;
+      v.insert(std::move(key));
+    }
+    return r.ok;
+  }
+  else if constexpr(byte_block<type>)
+  {
+    using elem = typename type::value_type;
+    std::uint32_t count{};
+    if(!r.pod(count))
+      return false;
+    // Trust the record size, not the count: a corrupt count must not make
+    // us allocate or read out of bounds.
+    if(count > (payload_size - sizeof(count)) / sizeof(elem))
+      return false;
+    v.resize(count);
+    return r.raw(v.data(), std::size_t(count) * sizeof(elem));
+  }
+  else if constexpr(avnd::vector_ish<type>)
+  {
+    std::uint32_t count{};
+    if(!r.pod(count))
+      return false;
+    v.clear();
+    for(std::uint32_t i = 0; i < count && r.ok && r.pos < end; i++)
+    {
+      typename type::value_type elem{};
+      if(!decode_value(r, elem, end - r.pos))
+        return false;
+      v.push_back(std::move(elem));
+    }
+    return r.ok;
+  }
+  else if constexpr(avnd::tuple_ish<type> && !std::is_trivially_copyable_v<type>)
+  {
+    bool ok = true;
+    [&]<std::size_t... I>(std::index_sequence<I...>) {
+      ((ok = ok && decode_value(r, std::get<I>(v), end - r.pos)), ...);
+    }(std::make_index_sequence<std::tuple_size_v<type>>{});
+    return ok;
+  }
+  else if constexpr(trivial_member<type>)
+  {
+    return r.pod(v);
   }
   else
   {
@@ -552,8 +761,8 @@ std::vector<std::uint8_t> save(const S& s)
 
 // Members no record covers keep the value they already hold, so the caller
 // decides what "missing" means by pre-seeding defaults. An empty payload
-// covers nothing and therefore succeeds without changing anything; whether a
-// host handing over no state at all is an error belongs to the container
+// covers nothing and therefore succeeds without changing anything; whether
+// a host handing over no state at all is an error belongs to the container
 // above this one.
 template <typename S>
   requires serializable<S>

--- a/include/avnd/wrappers/state_serial.hpp
+++ b/include/avnd/wrappers/state_serial.hpp
@@ -46,6 +46,9 @@
 
 #include <boost/pfr.hpp>
 
+#include <array>
+#include <tuple>
+
 #include <cstdint>
 #include <cstring>
 #include <string>
@@ -85,6 +88,73 @@ concept list_container = requires(T t) {
   t.end();
 } && !contiguous_container<T>;
 
+// A type that only borrows its data: trivially copyable, so it would be
+// written out as raw bytes, and those bytes are an address that means
+// nothing in the process that reads them back.
+template <typename T>
+concept view_like = requires(const T& t) {
+  t.data();
+  { t.size() } -> std::convertible_to<std::size_t>;
+} && std::is_pointer_v<decltype(std::declval<const T&>().data())>
+     && !requires(T& t) { t.resize(std::size_t{}); };
+
+template <typename T>
+constexpr bool borrows_memory();
+
+template <typename T, std::size_t... I>
+constexpr bool any_member_borrows(std::index_sequence<I...>)
+{
+  return (borrows_memory<boost::pfr::tuple_element_t<I, T>>() || ...);
+}
+
+// Persisted state has to own what it describes. Pointers, references and
+// views survive a memcpy syntactically and mean nothing once reloaded, so
+// they are refused rather than written into a session file.
+// std::array, pair and tuple carry a std::tuple_size, which the aggregate
+// reflection cannot decompose on every compiler. They are handled through
+// the standard interface instead of being taken apart field by field.
+template <typename T>
+concept tuple_like = requires { std::tuple_size<std::remove_cvref_t<T>>::value; };
+
+// std::array is the one tuple-like type worth supporting: it is a fixed
+// block of elements and, when they are trivially copyable, it is one too.
+// Whether std::pair and std::tuple are trivially copyable differs between
+// standard libraries, so accepting them on that basis would make a state
+// struct compile on one toolchain and not another. They are refused
+// everywhere instead.
+template <typename T>
+inline constexpr bool is_std_array_v = false;
+template <typename T, std::size_t N>
+inline constexpr bool is_std_array_v<std::array<T, N>> = true;
+
+template <typename T>
+constexpr bool borrows_memory()
+{
+  using type = std::remove_cvref_t<T>;
+  if constexpr(std::is_pointer_v<type> || std::is_reference_v<type>)
+    return true;
+  else if constexpr(std::is_array_v<type>)
+    return borrows_memory<std::remove_extent_t<type>>();
+  else if constexpr(tuple_like<type>)
+  {
+    // Same element type throughout for std::array; for pair and tuple this
+    // only inspects the first, which is enough to reject the obvious cases
+    // -- they are not serializable anyway unless trivially copyable.
+    if constexpr(std::tuple_size_v<type> > 0)
+      return borrows_memory<std::tuple_element_t<0, type>>();
+    else
+      return false;
+  }
+  // An aggregate owns whatever it holds; look at what that is.
+  else if constexpr(std::is_aggregate_v<type>)
+    return any_member_borrows<type>(
+        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+  else if constexpr(view_like<type>)
+    return true;
+  else
+    return false;
+}
+
 template <typename T>
 constexpr bool serializable_impl();
 
@@ -98,13 +168,21 @@ template <typename T>
 constexpr bool serializable_impl()
 {
   using type = std::remove_cvref_t<T>;
-  if constexpr(trivial_member<type>)
+  if constexpr(borrows_memory<type>())
+    return false;
+  else if constexpr(tuple_like<type> && !is_std_array_v<type>)
+    return false;
+  else if constexpr(trivial_member<type>)
     return true;
   else if constexpr(contiguous_container<type>)
     return true;
   else if constexpr(list_container<type>)
     return serializable_impl<typename type::value_type>();
-  else if constexpr(std::is_aggregate_v<type>)
+  // A tuple-like type that got this far is not trivially copyable, so it
+  // would have to be taken apart -- which is exactly what the aggregate
+  // reflection cannot do for them. std::array of non-trivial elements ends
+  // up here, and is left to the processor's own save/load.
+  else if constexpr(std::is_aggregate_v<type> && !tuple_like<type>)
     return aggregate_serializable<type>(
         std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
   else

--- a/include/avnd/wrappers/state_serial.hpp
+++ b/include/avnd/wrappers/state_serial.hpp
@@ -251,8 +251,8 @@ constexpr tag tag_of()
 }
 
 // ---------------------------------------------------------------------------
-// Scalar kind: size alone does not identify a scalar, and an int read back
-// as a float of the same width is silent corruption.
+// Scalar kind: distinguishes types of equal width (an int from a float) so
+// one is never read back as the other.
 
 enum class scalar_kind : std::uint32_t
 {
@@ -300,10 +300,7 @@ template <typename T, std::size_t... I>
 constexpr std::uint32_t
 layout_hash_fields(std::uint32_t h, std::index_sequence<I...>)
 {
-  // Fold the position in between fields so that {int, float} and
-  // {float, int} do not hash alike -- the FNV step alone is too symmetric
-  // over short runs of small values.
-  ((h = layout_hash_of<boost::pfr::tuple_element_t<I, T>>(hash_step(h, I))), ...);
+  ((h = layout_hash_of<boost::pfr::tuple_element_t<I, T>>(h)), ...);
   return h;
 }
 
@@ -351,9 +348,8 @@ constexpr std::uint32_t layout_hash_of(std::uint32_t h)
     return layout_hash_elements<type>(
         hash_step(h, std::uint32_t(std::tuple_size_v<type>)),
         std::make_index_sequence<std::tuple_size_v<type>>{});
-  // A trivially-copyable aggregate is written as one blob, but its shape
-  // still has to reach the hash: two 8-byte structs are not the same state
-  // just because they memcpy the same way ({int,float} vs {float,int}).
+  // A trivially-copyable aggregate is one blob on the wire, but its field
+  // shapes still feed the hash so that {int, float} and {float, int} differ.
   else if constexpr(std::is_aggregate_v<type> && !std::is_array_v<type>)
     return layout_hash_fields<type>(
         hash_step(h, std::uint32_t(boost::pfr::tuple_size_v<type>)),

--- a/include/avnd/wrappers/state_serial.hpp
+++ b/include/avnd/wrappers/state_serial.hpp
@@ -5,49 +5,49 @@
 /**
  * Reflection-based serialization for a processor's `state` struct.
  *
- * Every member is written as a self-describing record keyed by its *field
- * name*, not its position:
+ * Members are written in declaration order, each as a self-describing
+ * record:
  *
- *     [u16 name length][name][u8 type tag][u32 payload size][payload]
+ *     [u8 type tag][u8 scalar kind][u32 payload size][payload]
  *
- * A reader matches records to members by name, skips records it does not
- * recognise (the size makes that possible without understanding them) and
- * leaves members that no record mentions at their default value. Adding,
- * removing and reordering members therefore needs no migration code, which
- * is the property property-store formats (LV2 state, Audio Unit ClassInfo)
- * are built around. The type tag lets a reader detect that a member changed
- * shape and fall back to its default instead of reinterpreting the bytes.
+ * preceded by a header holding the format marker, a hash of the struct's
+ * layout and the number of records. Positional encoding means the state
+ * struct can be an unnamed type, exactly like the inputs and outputs groups.
  *
- * The state struct must be a *named* type -- reflection cannot name the
- * fields of an unnamed one, and the diagnostic it produces is obscure:
+ * What the shape of the data buys, without any version bookkeeping:
  *
- *     struct state_t { int mode; };  state_t state;  // yes
- *     struct { int mode; } state;                    // no
+ *  - appending a member: older data simply has fewer records, and the new
+ *    member keeps its default;
+ *  - dropping trailing members: the extra records are skipped;
+ *  - a member whose type changed: the record no longer matches the member
+ *    at that position -- including an int becoming a float, which the
+ *    scalar kind distinguishes despite the identical width -- so it is
+ *    skipped instead of being reinterpreted.
  *
- * That is the one place this differs from the inputs/outputs groups, which
- * only ever need positional reflection. The cost is a name; the benefit is
- * that field identity survives the struct being edited.
+ * What it cannot see is a change that leaves the layout identical -- two
+ * members of the same type swapped, or a member's *meaning* changed. The
+ * layout hash catches the first class (any change of field count, order or
+ * shape changes it); the second is what `state_version` and `migrate_state`
+ * are for.
+ *
+ * On a layout-hash mismatch the reader does not guess: it decodes what
+ * still matches record-by-record and reports the drift, so the caller can
+ * refuse the load when the processor has not declared a migration.
  *
  * Supported members, recursively: trivially-copyable types, contiguous
  * containers of them (std::string, std::vector<int>, ...), aggregates, and
- * lists of any of those. Members whose type is not serializable make
- * `serializable_state` false; the processor then has to provide save/load
- * itself.
+ * lists of any of those.
  *
- * Byte order is native: the writer and reader are the same binary. Sizes and
+ * Byte order is native: writer and reader are the same binary. Sizes and
  * tags are fixed-width so a foreign-endian reader can at least skip records
  * rather than misparse them.
  */
 
-#include <avnd/common/for_nth.hpp>
-
 #include <boost/pfr.hpp>
-#include <boost/pfr/core_name.hpp>
 
 #include <cstdint>
 #include <cstring>
 #include <string>
-#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -128,7 +128,95 @@ constexpr tag tag_of()
 }
 
 // ---------------------------------------------------------------------------
+// Layout hash: field count, order and shape. Two structs with the same hash
+// are interchangeable as far as this format is concerned; any structural
+// edit changes it.
+
+constexpr std::uint32_t hash_step(std::uint32_t h, std::uint32_t v)
+{
+  h ^= v;
+  return h * 16777619u; // FNV-1a
+}
+
+template <typename T>
+constexpr std::uint32_t layout_hash_of(std::uint32_t h = 2166136261u);
+
+template <typename T, std::size_t... I>
+constexpr std::uint32_t
+layout_hash_fields(std::uint32_t h, std::index_sequence<I...>)
+{
+  ((h = layout_hash_of<boost::pfr::tuple_element_t<I, T>>(h)), ...);
+  return h;
+}
+
+// Size alone does not identify a scalar: an int and a float of the same
+// width would hash the same, and swapping them would reinterpret one as the
+// other. Encode what kind of scalar it is as well.
+enum class scalar_kind : std::uint32_t
+{
+  boolean = 1,
+  signed_int = 2,
+  unsigned_int = 3,
+  floating = 4,
+  enumeration = 5,
+  pointer = 6,
+  other = 7
+};
+
+template <typename T>
+constexpr scalar_kind kind_of()
+{
+  using type = std::remove_cvref_t<T>;
+  if constexpr(std::is_same_v<type, bool>)
+    return scalar_kind::boolean;
+  else if constexpr(std::is_enum_v<type>)
+    return scalar_kind::enumeration;
+  else if constexpr(std::is_floating_point_v<type>)
+    return scalar_kind::floating;
+  else if constexpr(std::is_integral_v<type>)
+    return std::is_signed_v<type> ? scalar_kind::signed_int
+                                  : scalar_kind::unsigned_int;
+  else if constexpr(std::is_pointer_v<type>)
+    return scalar_kind::pointer;
+  else
+    return scalar_kind::other;
+}
+
+template <typename T>
+constexpr std::uint32_t layout_hash_of(std::uint32_t h)
+{
+  using type = std::remove_cvref_t<T>;
+  h = hash_step(h, std::uint32_t(tag_of<type>()));
+  if constexpr(trivial_member<type>)
+  {
+    h = hash_step(h, std::uint32_t(sizeof(type)));
+    h = hash_step(h, std::uint32_t(kind_of<type>()));
+    // A trivially-copyable aggregate is memcpy'd, but its shape still has to
+    // be part of the hash: two structs of the same size are not the same
+    // state.
+    if constexpr(std::is_aggregate_v<type> && !std::is_array_v<type>)
+      return layout_hash_fields<type>(
+          h, std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+    return h;
+  }
+  else if constexpr(contiguous_container<type>)
+  {
+    using elem = std::remove_cvref_t<decltype(*std::declval<type&>().data())>;
+    h = hash_step(h, std::uint32_t(sizeof(elem)));
+    return hash_step(h, std::uint32_t(kind_of<elem>()));
+  }
+  else if constexpr(list_container<type>)
+    return layout_hash_of<typename type::value_type>(h);
+  else
+    return layout_hash_fields<type>(
+        hash_step(h, std::uint32_t(boost::pfr::tuple_size_v<type>)),
+        std::make_index_sequence<boost::pfr::tuple_size_v<type>>{});
+}
+
+// ---------------------------------------------------------------------------
 // Writing
+
+inline constexpr std::uint8_t format_version = 1;
 
 struct writer
 {
@@ -149,7 +237,6 @@ struct writer
     raw(&v, sizeof(T));
   }
 
-  // Reserve a length slot, fill it once the payload is known.
   std::size_t begin_sized()
   {
     const auto at = bytes.size();
@@ -163,10 +250,6 @@ struct writer
   }
 };
 
-// Payload format marker, so a future change of encoding is detectable
-// rather than silently misread.
-inline constexpr std::uint8_t format_version = 1;
-
 template <typename T>
 void encode_value(writer& w, const T& v);
 
@@ -174,14 +257,14 @@ template <typename T>
 void encode_fields(writer& w, const T& agg)
 {
   w.pod(format_version);
-  constexpr auto names = boost::pfr::names_as_array<T>();
+  w.pod(layout_hash_of<T>());
+  w.pod(std::uint16_t(boost::pfr::tuple_size_v<T>));
+
   [&]<std::size_t... I>(std::index_sequence<I...>) {
     (
         [&] {
-          const std::string_view name = names[I];
-          w.pod(std::uint16_t(name.size()));
-          w.raw(name.data(), name.size());
           w.pod(tag_of<boost::pfr::tuple_element_t<I, T>>());
+          w.pod(std::uint8_t(kind_of<boost::pfr::tuple_element_t<I, T>>()));
           const auto slot = w.begin_sized();
           encode_value(w, boost::pfr::get<I>(agg));
           w.end_sized(slot);
@@ -254,59 +337,72 @@ struct reader
   }
 };
 
+struct load_result
+{
+  bool ok{false};
+  // The data was written from a struct whose layout differs from this one:
+  // records still matched by position and tag were applied, the rest were
+  // left at their defaults.
+  bool layout_drift{false};
+
+  explicit operator bool() const noexcept { return ok; }
+};
+
 template <typename T>
 bool decode_value(reader& r, T& v, std::size_t payload_size);
 
 template <typename T>
-bool decode_fields(reader& r, T& agg, std::size_t payload_size)
+bool decode_fields(reader& r, T& agg, std::size_t payload_size, bool& drift)
 {
   const std::size_t end = r.pos + payload_size;
 
   std::uint8_t fmt{};
-  if(!r.pod(fmt))
+  std::uint32_t hash{};
+  std::uint16_t count{};
+  if(!r.pod(fmt) || !r.pod(hash) || !r.pod(count))
     return false;
   if(fmt != format_version)
     return false;
+  if(hash != layout_hash_of<T>())
+    drift = true;
 
-  while(r.ok && r.pos < end)
+  constexpr std::size_t fields = boost::pfr::tuple_size_v<T>;
+  if(count != fields)
+    drift = true;
+
+  for(std::size_t index = 0; index < count && r.ok && r.pos < end; index++)
   {
-    std::uint16_t name_len{};
-    if(!r.pod(name_len))
-      return false;
-    if(!r.has(name_len))
-      return false;
-    const std::string_view name{
-        reinterpret_cast<const char*>(r.data + r.pos), name_len};
-    r.pos += name_len;
-
     tag t{};
+    std::uint8_t k{};
     std::uint32_t size{};
-    if(!r.pod(t) || !r.pod(size))
+    if(!r.pod(t) || !r.pod(k) || !r.pod(size))
       return false;
     if(!r.has(size))
       return false;
 
     const std::size_t payload_start = r.pos;
-    bool matched = false;
 
     [&]<std::size_t... I>(std::index_sequence<I...>) {
       (
           [&] {
-            constexpr auto names = boost::pfr::names_as_array<T>();
-            if(matched || names[I] != name)
+            if(I != index)
               return;
             using field_t = boost::pfr::tuple_element_t<I, T>;
-            matched = true;
-            // A member that changed shape keeps its default rather than
-            // reinterpreting bytes written for a different type.
-            if(t != tag_of<field_t>())
+            // A record whose shape no longer matches the member at this
+            // position keeps the member's default rather than being
+            // reinterpreted.
+            if(t != tag_of<field_t>() || k != std::uint8_t(kind_of<field_t>()))
+            {
+              drift = true;
               return;
+            }
             decode_value(r, boost::pfr::get<I>(agg), size);
           }(),
           ...);
-    }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>{});
+    }(std::make_index_sequence<fields>{});
 
-    // Unknown, mismatched or partially-read records: resume at the next one.
+    // Trailing records (members since removed), mismatched ones, and
+    // partially-read ones all resume at the next record.
     r.pos = payload_start;
     r.skip(size);
   }
@@ -351,7 +447,8 @@ bool decode_value(reader& r, T& v, std::size_t payload_size)
   }
   else
   {
-    return decode_fields(r, v, payload_size);
+    bool nested_drift = false;
+    return decode_fields(r, v, payload_size, nested_drift);
   }
 }
 
@@ -367,21 +464,29 @@ std::vector<std::uint8_t> save(const S& s)
   return std::move(w.bytes);
 }
 
-// Members not mentioned by the blob keep the value they already hold, so the
-// caller decides what "missing" means by pre-seeding defaults. An empty
-// payload mentions nothing and therefore succeeds without changing anything;
-// deciding whether a host handing over *no state at all* is an error belongs
-// to the container above this one.
+// Members no record covers keep the value they already hold, so the caller
+// decides what "missing" means by pre-seeding defaults. An empty payload
+// covers nothing and therefore succeeds without changing anything; whether a
+// host handing over no state at all is an error belongs to the container
+// above this one.
 template <typename S>
   requires serializable<S>
-bool load(S& s, const std::uint8_t* data, std::size_t n)
+load_result load(S& s, const std::uint8_t* data, std::size_t n)
 {
   if(n == 0)
-    return true;
+    return {.ok = true, .layout_drift = false};
   if(!data)
-    return false;
+    return {};
   reader r{data, n, 0, true};
-  return decode_fields(r, s, n);
+  load_result res;
+  res.ok = decode_fields(r, s, n, res.layout_drift);
+  return res;
+}
+
+template <typename S>
+constexpr std::uint32_t layout_hash()
+{
+  return layout_hash_of<std::remove_cvref_t<S>>();
 }
 
 } // namespace avnd::state

--- a/tests/test_state_object.cpp
+++ b/tests/test_state_object.cpp
@@ -1,0 +1,181 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+// The processor-facing state API: automatic reflection by default, explicit
+// save/load when the object provides it, and version migration.
+
+#include <avnd/wrappers/state_object.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+namespace test_state_objects
+{
+// Reflected: no save/load anywhere.
+struct Plain
+{
+  struct state_t
+  {
+    int mode{7};
+    float gain{0.5f};
+    std::string label{"init"};
+  };
+  state_t state;
+};
+
+// The state object serializes itself; reflection must not be used.
+struct SelfSerializing
+{
+  struct
+  {
+    int value{0};
+    int load_calls{0};
+
+    std::vector<std::uint8_t> save() const
+    {
+      return {std::uint8_t(value & 0xFF), 0xAB};
+    }
+    bool load(const std::uint8_t* d, std::size_t n)
+    {
+      if(n != 2 || d[1] != 0xAB)
+        return false; // reject anything not written by us
+      value = d[0];
+      load_calls++;
+      return true;
+    }
+  } state;
+};
+
+// Versioned with a migration: v1 stored gain normalized, v2 stores Hz.
+struct Versioned
+{
+  static constexpr int state_version = 2;
+
+  struct state_t
+  {
+    float cutoff{1000.f};
+    int migrated_from{-1};
+  };
+  state_t state;
+
+  static void migrate_state(state_t& s, int from)
+  {
+    s.migrated_from = from;
+    if(from < 2)
+      s.cutoff = s.cutoff * 20000.f; // normalized -> Hz
+  }
+};
+
+// No state member at all.
+struct Stateless
+{
+  struct
+  {
+    int x{};
+  } inputs;
+};
+}
+
+using namespace test_state_objects;
+
+TEST_CASE("state object: detection", "[state]")
+{
+  static_assert(avnd::has_state<Plain>);
+  static_assert(avnd::persistable<Plain>);
+  static_assert(avnd::state_is_reflectable<Plain>);
+  static_assert(!avnd::state_saves_itself<Plain>);
+
+  static_assert(avnd::state_saves_itself<SelfSerializing>);
+  static_assert(avnd::state_loads_itself<SelfSerializing>);
+  static_assert(avnd::persistable<SelfSerializing>);
+
+  static_assert(!avnd::has_state<Stateless>);
+  static_assert(!avnd::persistable<Stateless>);
+
+  static_assert(avnd::state_version<Plain>() == 0);
+  static_assert(avnd::state_version<Versioned>() == 2);
+  static_assert(avnd::has_migration<Versioned>);
+  static_assert(!avnd::has_migration<Plain>);
+  SUCCEED();
+}
+
+TEST_CASE("state object: reflected round-trip", "[state]")
+{
+  Plain a;
+  a.state.mode = 42;
+  a.state.gain = 0.25f;
+  a.state.label = "saved";
+  const auto blob = avnd::save_object_state(a);
+
+  Plain b;
+  REQUIRE(avnd::load_object_state(b, blob.data(), blob.size(), 0));
+  REQUIRE(b.state.mode == 42);
+  REQUIRE(b.state.gain == Catch::Approx(0.25f));
+  REQUIRE(b.state.label == "saved");
+}
+
+TEST_CASE("state object: an explicit save/load overrides reflection", "[state]")
+{
+  SelfSerializing a;
+  a.state.value = 99;
+  const auto blob = avnd::save_object_state(a);
+  REQUIRE(blob.size() == 2); // its own format, not the reflected one
+  REQUIRE(blob[1] == 0xAB);
+
+  SelfSerializing b;
+  REQUIRE(avnd::load_object_state(b, blob.data(), blob.size(), 0));
+  REQUIRE(b.state.value == 99);
+  REQUIRE(b.state.load_calls == 1);
+
+  // Its own rejection is honoured.
+  const std::uint8_t junk[3]{1, 2, 3};
+  SelfSerializing c;
+  REQUIRE(!avnd::load_object_state(c, junk, 3, 0));
+  REQUIRE(c.state.value == 0);
+  REQUIRE(c.state.load_calls == 0);
+}
+
+TEST_CASE("state object: migration runs for older data only", "[state][version]")
+{
+  Versioned a;
+  a.state.cutoff = 0.5f; // as a v1 build would have stored it
+  const auto blob = avnd::save_object_state(a);
+
+  // Loading v1 data into the v2 binary migrates it.
+  Versioned from_v1;
+  REQUIRE(avnd::load_object_state(from_v1, blob.data(), blob.size(), 1));
+  REQUIRE(from_v1.state.migrated_from == 1);
+  REQUIRE(from_v1.state.cutoff == Catch::Approx(10000.f));
+
+  // Loading current-version data does not migrate.
+  Versioned current;
+  REQUIRE(avnd::load_object_state(current, blob.data(), blob.size(), 2));
+  REQUIRE(current.state.migrated_from == -1);
+  REQUIRE(current.state.cutoff == Catch::Approx(0.5f));
+}
+
+TEST_CASE("state object: data from a newer version is refused", "[state][version]")
+{
+  Versioned a;
+  a.state.cutoff = 123.f;
+  const auto blob = avnd::save_object_state(a);
+
+  Versioned b;
+  const float before = b.state.cutoff;
+  // Written by a hypothetical v3 build: refuse rather than misread.
+  REQUIRE(!avnd::load_object_state(b, blob.data(), blob.size(), 3));
+  REQUIRE(b.state.cutoff == Catch::Approx(before));
+  REQUIRE(b.state.migrated_from == -1);
+}
+
+TEST_CASE("state object: unversioned processors round-trip at version 0", "[state]")
+{
+  Plain a;
+  a.state.mode = 3;
+  const auto blob = avnd::save_object_state(a);
+  Plain b;
+  REQUIRE(avnd::load_object_state(b, blob.data(), blob.size(), 0));
+  REQUIRE(b.state.mode == 3);
+}

--- a/tests/test_state_object.cpp
+++ b/tests/test_state_object.cpp
@@ -177,3 +177,39 @@ TEST_CASE("state object: unversioned processors round-trip at version 0", "[stat
   REQUIRE(avnd::load_object_state(b, blob.data(), blob.size(), 0));
   REQUIRE(b.state.mode == 3);
 }
+
+TEST_CASE("state object: appending a member does not need a migration",
+          "[state][schema]")
+{
+  // The documented rule for both state members and inlets: append at the
+  // end. Doing so must load cleanly on a processor that declares no
+  // migration at all.
+  struct Before
+  {
+    struct
+    {
+      int mode{};
+      float gain{};
+    } state;
+  };
+  struct After
+  {
+    struct
+    {
+      int mode{};
+      float gain{};
+      int added{99};
+    } state;
+  };
+
+  Before a;
+  a.state.mode = 5;
+  a.state.gain = 0.5f;
+  const auto blob = avnd::save_object_state(a);
+
+  After b;
+  REQUIRE(avnd::load_object_state(b, blob.data(), blob.size(), 0));
+  REQUIRE(b.state.mode == 5);
+  REQUIRE(b.state.gain == Catch::Approx(0.5f));
+  REQUIRE(b.state.added == 99);
+}

--- a/tests/test_state_object.cpp
+++ b/tests/test_state_object.cpp
@@ -16,13 +16,12 @@ namespace test_state_objects
 // Reflected: no save/load anywhere.
 struct Plain
 {
-  struct state_t
+  struct
   {
     int mode{7};
     float gain{0.5f};
     std::string label{"init"};
-  };
-  state_t state;
+  } state;
 };
 
 // The state object serializes itself; reflection must not be used.
@@ -53,14 +52,13 @@ struct Versioned
 {
   static constexpr int state_version = 2;
 
-  struct state_t
+  struct
   {
     float cutoff{1000.f};
     int migrated_from{-1};
-  };
-  state_t state;
+  } state;
 
-  static void migrate_state(state_t& s, int from)
+  static void migrate_state(decltype(state)& s, int from)
   {
     s.migrated_from = from;
     if(from < 2)

--- a/tests/test_state_serial.cpp
+++ b/tests/test_state_serial.cpp
@@ -14,6 +14,8 @@
 #include <string_view>
 #include <tuple>
 #include <utility>
+#include <set>
+#include <unordered_map>
 #include <variant>
 #include <cstdint>
 #include <string>
@@ -352,27 +354,93 @@ TEST_CASE("state: borrowed memory is refused", "[state]")
   static_assert(!avnd::state::serializable<has_view>);
 
   // Owning containers that look like views -- data() and size(), no
-  // resize() -- are still fine.
+  // resize() -- are fine, including of non-trivial elements.
   static_assert(avnd::state::serializable<std::array<int, 4>>);
-  // A fixed array of non-trivial elements is not: taking it apart needs
-  // reflection that does not work on tuple-like types everywhere.
-  static_assert(!avnd::state::serializable<std::array<std::string, 2>>);
+  static_assert(avnd::state::serializable<std::array<std::string, 2>>);
   SUCCEED();
 }
 
 TEST_CASE("state: the supported type surface", "[state]")
 {
-  // Trivially-copyable types are written as bytes, which covers optional
-  // and variant of trivial alternatives.
+  // Everything the value bindings can carry, in any combination.
   static_assert(avnd::state::serializable<std::optional<int>>);
+  static_assert(avnd::state::serializable<std::optional<std::string>>);
   static_assert(avnd::state::serializable<std::variant<int, float>>);
-
-  // Their non-trivial forms, and the associative/tuple containers, are not
-  // supported: a processor needing one provides save/load on its state.
-  static_assert(!avnd::state::serializable<std::optional<std::string>>);
-  static_assert(!avnd::state::serializable<std::variant<int, std::string>>);
-  static_assert(!avnd::state::serializable<std::map<std::string, int>>);
-  static_assert(!avnd::state::serializable<std::pair<int, float>>);
-  static_assert(!avnd::state::serializable<std::tuple<int, float>>);
+  static_assert(avnd::state::serializable<std::variant<int, std::string>>);
+  static_assert(avnd::state::serializable<std::map<std::string, int>>);
+  static_assert(avnd::state::serializable<std::set<std::string>>);
+  static_assert(avnd::state::serializable<std::pair<int, float>>);
+  static_assert(avnd::state::serializable<std::tuple<int, float, std::string>>);
+  static_assert(
+      avnd::state::serializable<std::map<std::string, std::vector<int>>>);
   SUCCEED();
+}
+
+// ---------------------------------------------------------------------------
+// The full type surface, classified with the same concepts the value
+// bindings use. Anything a processor can carry should survive a round-trip.
+
+namespace
+{
+enum class Mode
+{
+  A,
+  B,
+  C
+};
+
+template <typename T>
+bool round_trips(const T& in)
+{
+  struct Box
+  {
+    T v;
+  };
+  Box b{in};
+  const auto bytes = avnd::state::save(b);
+  Box out{};
+  const auto r = avnd::state::load(out, bytes.data(), bytes.size());
+  return r.ok && !r.type_mismatch && !r.layout_changed && out.v == in;
+}
+}
+
+TEST_CASE("state: optionals and variants", "[state][types]")
+{
+  CHECK(round_trips(std::optional<std::string>{"hi"}));
+  CHECK(round_trips(std::optional<std::string>{}));
+  CHECK(round_trips(std::optional<int>{42}));
+  CHECK(round_trips(std::optional<std::vector<std::string>>{
+      std::vector<std::string>{"n1", "n2"}}));
+  CHECK(round_trips(std::variant<int, std::string>{std::string("v")}));
+  CHECK(round_trips(std::variant<int, std::string>{7}));
+  CHECK(round_trips(std::variant<int, float>{2.5f}));
+}
+
+TEST_CASE("state: associative containers", "[state][types]")
+{
+  CHECK(round_trips(std::map<std::string, int>{{"a", 1}, {"b", 2}}));
+  CHECK(round_trips(std::map<int, std::string>{{1, "x"}, {2, "y"}}));
+  CHECK(round_trips(std::unordered_map<std::string, int>{{"k", 9}}));
+  CHECK(round_trips(std::set<std::string>{"p", "q"}));
+  CHECK(round_trips(std::set<int>{3, 1, 2}));
+  CHECK(round_trips(std::map<std::string, std::vector<int>>{{"k", {1, 2, 3}}}));
+}
+
+TEST_CASE("state: tuples, pairs and fixed arrays", "[state][types]")
+{
+  CHECK(round_trips(std::pair<int, std::string>{4, "pair"}));
+  CHECK(round_trips(std::tuple<int, float, std::string>{1, 2.f, "t"}));
+  CHECK(round_trips(std::array<std::string, 2>{"a0", "a1"}));
+  CHECK(round_trips(std::array<int, 4>{1, 2, 3, 4}));
+  CHECK(round_trips(std::vector<std::pair<int, std::string>>{{1, "a"}, {2, "b"}}));
+}
+
+TEST_CASE("state: enums and nesting", "[state][types]")
+{
+  CHECK(round_trips(Mode::B));
+  CHECK(round_trips(std::vector<Mode>{Mode::A, Mode::C}));
+  CHECK(round_trips(std::vector<std::optional<int>>{1, std::nullopt, 3}));
+  CHECK(round_trips(std::vector<std::vector<std::string>>{{"a"}, {"b", "c"}}));
+  CHECK(round_trips(std::string("plain")));
+  CHECK(round_trips(std::vector<int>{1, 2, 3}));
 }

--- a/tests/test_state_serial.cpp
+++ b/tests/test_state_serial.cpp
@@ -8,6 +8,13 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
+#include <map>
+#include <optional>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <variant>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -324,4 +331,48 @@ TEST_CASE("state: unnamed state structs work", "[state][schema]")
   REQUIRE_FALSE(res.type_mismatch);
   REQUIRE(out.state.a == 9);
   REQUIRE(out.state.s == "inline");
+}
+
+TEST_CASE("state: borrowed memory is refused", "[state]")
+{
+  // A pointer survives a memcpy syntactically and means nothing in the
+  // process that reads the session back, so these never reach a file.
+  struct has_pointer
+  {
+    int n;
+    float* buffer;
+  };
+  struct has_view
+  {
+    std::string_view sv;
+  };
+  static_assert(!avnd::state::serializable<float*>);
+  static_assert(!avnd::state::serializable<has_pointer>);
+  static_assert(!avnd::state::serializable<std::string_view>);
+  static_assert(!avnd::state::serializable<has_view>);
+
+  // Owning containers that look like views -- data() and size(), no
+  // resize() -- are still fine.
+  static_assert(avnd::state::serializable<std::array<int, 4>>);
+  // A fixed array of non-trivial elements is not: taking it apart needs
+  // reflection that does not work on tuple-like types everywhere.
+  static_assert(!avnd::state::serializable<std::array<std::string, 2>>);
+  SUCCEED();
+}
+
+TEST_CASE("state: the supported type surface", "[state]")
+{
+  // Trivially-copyable types are written as bytes, which covers optional
+  // and variant of trivial alternatives.
+  static_assert(avnd::state::serializable<std::optional<int>>);
+  static_assert(avnd::state::serializable<std::variant<int, float>>);
+
+  // Their non-trivial forms, and the associative/tuple containers, are not
+  // supported: a processor needing one provides save/load on its state.
+  static_assert(!avnd::state::serializable<std::optional<std::string>>);
+  static_assert(!avnd::state::serializable<std::variant<int, std::string>>);
+  static_assert(!avnd::state::serializable<std::map<std::string, int>>);
+  static_assert(!avnd::state::serializable<std::pair<int, float>>);
+  static_assert(!avnd::state::serializable<std::tuple<int, float>>);
+  SUCCEED();
 }

--- a/tests/test_state_serial.cpp
+++ b/tests/test_state_serial.cpp
@@ -1,0 +1,252 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Reflection-based state serialization: the round-trip, and the schema
+// changes it is meant to absorb without migration code.
+
+#include <avnd/wrappers/state_serial.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace test_state_types
+{
+struct simple
+{
+  int a{};
+  float b{};
+  bool c{};
+};
+
+struct nested
+{
+  int id{};
+  simple inner{};
+};
+
+struct with_containers
+{
+  std::string name;
+  std::vector<std::uint8_t> blob;
+  std::vector<int> numbers;
+};
+
+struct with_list
+{
+  std::vector<simple> items;
+  int trailing{};
+};
+
+// Schema evolution: same struct name, different members.
+namespace v1
+{
+struct cfg
+{
+  int mode{};
+  float gain{};
+};
+}
+namespace v2_added
+{
+struct cfg
+{
+  int mode{};
+  float gain{};
+  int extra{42}; // added since v1
+};
+}
+namespace v2_removed
+{
+struct cfg
+{
+  int mode{}; // gain removed
+};
+}
+namespace v2_reordered
+{
+struct cfg
+{
+  float gain{};
+  int mode{}; // swapped order
+};
+}
+namespace v2_retyped
+{
+struct cfg
+{
+  int mode{};
+  std::string gain{"untouched"}; // gain changed type
+};
+}
+}
+
+using namespace test_state_types;
+TEST_CASE("state: aggregates round-trip", "[state]")
+{
+  simple in{.a = -7, .b = 2.5f, .c = true};
+  const auto bytes = avnd::state::save(in);
+  REQUIRE(!bytes.empty());
+
+  simple out{};
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(out.a == -7);
+  REQUIRE(out.b == Catch::Approx(2.5f));
+  REQUIRE(out.c == true);
+}
+
+TEST_CASE("state: nested aggregates round-trip", "[state]")
+{
+  nested in{.id = 3, .inner = {.a = 1, .b = -0.5f, .c = true}};
+  const auto bytes = avnd::state::save(in);
+
+  nested out{};
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(out.id == 3);
+  REQUIRE(out.inner.a == 1);
+  REQUIRE(out.inner.b == Catch::Approx(-0.5f));
+  REQUIRE(out.inner.c == true);
+}
+
+TEST_CASE("state: strings and vectors round-trip", "[state]")
+{
+  with_containers in;
+  in.name = "hello state";
+  in.blob = {0, 1, 2, 250, 255};
+  in.numbers = {-1, 0, 99999};
+  const auto bytes = avnd::state::save(in);
+
+  with_containers out;
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(out.name == "hello state");
+  REQUIRE(out.blob == std::vector<std::uint8_t>{0, 1, 2, 250, 255});
+  REQUIRE(out.numbers == std::vector<int>{-1, 0, 99999});
+}
+
+TEST_CASE("state: empty containers round-trip", "[state]")
+{
+  with_containers in; // all empty
+  const auto bytes = avnd::state::save(in);
+
+  with_containers out;
+  out.name = "clobber me";
+  out.numbers = {1, 2, 3};
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(out.name.empty());
+  REQUIRE(out.numbers.empty());
+}
+
+TEST_CASE("state: lists of aggregates round-trip", "[state]")
+{
+  with_list in;
+  in.items = {{1, 1.5f, false}, {2, -2.5f, true}, {3, 0.f, false}};
+  in.trailing = 77;
+  const auto bytes = avnd::state::save(in);
+
+  with_list out;
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(out.items.size() == 3);
+  REQUIRE(out.items[1].a == 2);
+  REQUIRE(out.items[1].b == Catch::Approx(-2.5f));
+  REQUIRE(out.items[2].a == 3);
+  REQUIRE(out.trailing == 77); // the record after the list is still found
+}
+
+TEST_CASE("state: a member added later keeps its default", "[state][schema]")
+{
+  const v1::cfg old{.mode = 5, .gain = 0.25f};
+  const auto bytes = avnd::state::save(old);
+
+  v2_added::cfg loaded{};
+  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
+  REQUIRE(loaded.mode == 5);
+  REQUIRE(loaded.gain == Catch::Approx(0.25f));
+  REQUIRE(loaded.extra == 42); // untouched default, no migration code
+}
+
+TEST_CASE("state: a removed member is skipped", "[state][schema]")
+{
+  const v1::cfg old{.mode = 5, .gain = 0.25f};
+  const auto bytes = avnd::state::save(old);
+
+  v2_removed::cfg loaded{};
+  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
+  REQUIRE(loaded.mode == 5); // the record after the unknown one still lands
+}
+
+TEST_CASE("state: reordering members does not shuffle values", "[state][schema]")
+{
+  const v1::cfg old{.mode = 5, .gain = 0.25f};
+  const auto bytes = avnd::state::save(old);
+
+  v2_reordered::cfg loaded{};
+  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
+  REQUIRE(loaded.mode == 5);
+  REQUIRE(loaded.gain == Catch::Approx(0.25f));
+}
+
+TEST_CASE("state: a member that changed type keeps its default", "[state][schema]")
+{
+  const v1::cfg old{.mode = 5, .gain = 0.25f};
+  const auto bytes = avnd::state::save(old);
+
+  v2_retyped::cfg loaded{};
+  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
+  REQUIRE(loaded.mode == 5);
+  // The float bytes are NOT reinterpreted as a string.
+  REQUIRE(loaded.gain == "untouched");
+}
+
+TEST_CASE("state: truncated and corrupt blobs are rejected", "[state]")
+{
+  with_containers in;
+  in.name = "some name";
+  in.blob = {1, 2, 3, 4};
+  in.numbers = {5, 6};
+  const auto bytes = avnd::state::save(in);
+
+  // Every truncation is either rejected or leaves a readable prefix; none
+  // may read out of bounds (ASan/valgrind territory) or hang.
+  for(std::size_t n = 0; n < bytes.size(); n++)
+  {
+    with_containers out;
+    (void)avnd::state::load(out, bytes.data(), n);
+  }
+
+  // A record claiming a huge payload must not be believed.
+  auto corrupt = bytes;
+  for(std::size_t i = 0; i + 4 < corrupt.size(); i++)
+  {
+    auto c = corrupt;
+    std::uint32_t huge = 0xFFFFFFF0u;
+    std::memcpy(c.data() + i, &huge, sizeof(huge));
+    with_containers out;
+    (void)avnd::state::load(out, c.data(), c.size());
+  }
+  SUCCEED("no out-of-bounds access or hang on truncated/corrupt input");
+}
+
+TEST_CASE("state: empty input leaves the target untouched", "[state]")
+{
+  simple out{.a = 11, .b = 1.f, .c = true};
+  REQUIRE(avnd::state::load(out, nullptr, 0));
+  REQUIRE(out.a == 11); // nothing said about it, nothing changed
+}
+
+TEST_CASE("state: serializability is detected statically", "[state]")
+{
+  struct deep
+  {
+    int ok{};
+    std::vector<std::vector<std::string>> nested_lists;
+  };
+  static_assert(avnd::state::serializable<simple>);
+  static_assert(avnd::state::serializable<nested>);
+  static_assert(avnd::state::serializable<with_containers>);
+  static_assert(avnd::state::serializable<with_list>);
+  // Nested lists resolve too: list -> list -> bytes.
+  static_assert(avnd::state::serializable<deep>);
+  SUCCEED();
+}

--- a/tests/test_state_serial.cpp
+++ b/tests/test_state_serial.cpp
@@ -91,7 +91,7 @@ TEST_CASE("state: aggregates round-trip", "[state]")
   REQUIRE(!bytes.empty());
 
   simple out{};
-  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()).ok);
   REQUIRE(out.a == -7);
   REQUIRE(out.b == Catch::Approx(2.5f));
   REQUIRE(out.c == true);
@@ -103,7 +103,7 @@ TEST_CASE("state: nested aggregates round-trip", "[state]")
   const auto bytes = avnd::state::save(in);
 
   nested out{};
-  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()).ok);
   REQUIRE(out.id == 3);
   REQUIRE(out.inner.a == 1);
   REQUIRE(out.inner.b == Catch::Approx(-0.5f));
@@ -119,7 +119,7 @@ TEST_CASE("state: strings and vectors round-trip", "[state]")
   const auto bytes = avnd::state::save(in);
 
   with_containers out;
-  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()).ok);
   REQUIRE(out.name == "hello state");
   REQUIRE(out.blob == std::vector<std::uint8_t>{0, 1, 2, 250, 255});
   REQUIRE(out.numbers == std::vector<int>{-1, 0, 99999});
@@ -133,7 +133,7 @@ TEST_CASE("state: empty containers round-trip", "[state]")
   with_containers out;
   out.name = "clobber me";
   out.numbers = {1, 2, 3};
-  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()).ok);
   REQUIRE(out.name.empty());
   REQUIRE(out.numbers.empty());
 }
@@ -146,7 +146,7 @@ TEST_CASE("state: lists of aggregates round-trip", "[state]")
   const auto bytes = avnd::state::save(in);
 
   with_list out;
-  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()));
+  REQUIRE(avnd::state::load(out, bytes.data(), bytes.size()).ok);
   REQUIRE(out.items.size() == 3);
   REQUIRE(out.items[1].a == 2);
   REQUIRE(out.items[1].b == Catch::Approx(-2.5f));
@@ -154,37 +154,48 @@ TEST_CASE("state: lists of aggregates round-trip", "[state]")
   REQUIRE(out.trailing == 77); // the record after the list is still found
 }
 
-TEST_CASE("state: a member added later keeps its default", "[state][schema]")
+TEST_CASE("state: appending a member keeps its default", "[state][schema]")
 {
   const v1::cfg old{.mode = 5, .gain = 0.25f};
   const auto bytes = avnd::state::save(old);
 
   v2_added::cfg loaded{};
-  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
+  const auto res = avnd::state::load(loaded, bytes.data(), bytes.size());
+  REQUIRE(res.ok);
   REQUIRE(loaded.mode == 5);
   REQUIRE(loaded.gain == Catch::Approx(0.25f));
-  REQUIRE(loaded.extra == 42); // untouched default, no migration code
+  REQUIRE(loaded.extra == 42); // appended member keeps its default
+  REQUIRE(res.layout_drift); // but the change is reported
 }
 
-TEST_CASE("state: a removed member is skipped", "[state][schema]")
+TEST_CASE("state: dropping a trailing member skips its record",
+          "[state][schema]")
 {
   const v1::cfg old{.mode = 5, .gain = 0.25f};
   const auto bytes = avnd::state::save(old);
 
   v2_removed::cfg loaded{};
-  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
-  REQUIRE(loaded.mode == 5); // the record after the unknown one still lands
+  const auto res = avnd::state::load(loaded, bytes.data(), bytes.size());
+  REQUIRE(res.ok);
+  REQUIRE(loaded.mode == 5); // the surviving member is still read
+  REQUIRE(res.layout_drift); // and the change is reported
 }
 
-TEST_CASE("state: reordering members does not shuffle values", "[state][schema]")
+TEST_CASE("state: reordering members is reported as layout drift",
+          "[state][schema]")
 {
+  // Positional encoding cannot follow a reorder. What it can do is notice:
+  // the layout hash differs, so the caller is told rather than silently
+  // handed values that landed on the wrong members.
   const v1::cfg old{.mode = 5, .gain = 0.25f};
   const auto bytes = avnd::state::save(old);
 
   v2_reordered::cfg loaded{};
-  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
-  REQUIRE(loaded.mode == 5);
-  REQUIRE(loaded.gain == Catch::Approx(0.25f));
+  const auto res = avnd::state::load(loaded, bytes.data(), bytes.size());
+  REQUIRE(res.layout_drift);
+  // The two members have different tags-with-sizes, so neither is applied.
+  REQUIRE(loaded.mode == 0);
+  REQUIRE(loaded.gain == Catch::Approx(0.f));
 }
 
 TEST_CASE("state: a member that changed type keeps its default", "[state][schema]")
@@ -193,7 +204,7 @@ TEST_CASE("state: a member that changed type keeps its default", "[state][schema
   const auto bytes = avnd::state::save(old);
 
   v2_retyped::cfg loaded{};
-  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()));
+  REQUIRE(avnd::state::load(loaded, bytes.data(), bytes.size()).ok);
   REQUIRE(loaded.mode == 5);
   // The float bytes are NOT reinterpreted as a string.
   REQUIRE(loaded.gain == "untouched");
@@ -231,7 +242,7 @@ TEST_CASE("state: truncated and corrupt blobs are rejected", "[state]")
 TEST_CASE("state: empty input leaves the target untouched", "[state]")
 {
   simple out{.a = 11, .b = 1.f, .c = true};
-  REQUIRE(avnd::state::load(out, nullptr, 0));
+  REQUIRE(avnd::state::load(out, nullptr, 0).ok);
   REQUIRE(out.a == 11); // nothing said about it, nothing changed
 }
 
@@ -249,4 +260,64 @@ TEST_CASE("state: serializability is detected statically", "[state]")
   // Nested lists resolve too: list -> list -> bytes.
   static_assert(avnd::state::serializable<deep>);
   SUCCEED();
+}
+
+TEST_CASE("state: an unchanged layout reports no drift", "[state][schema]")
+{
+  const v1::cfg a{.mode = 1, .gain = 2.f};
+  const auto bytes = avnd::state::save(a);
+  v1::cfg b{};
+  const auto res = avnd::state::load(b, bytes.data(), bytes.size());
+  REQUIRE(res.ok);
+  REQUIRE_FALSE(res.layout_drift);
+  REQUIRE(b.mode == 1);
+  REQUIRE(b.gain == Catch::Approx(2.f));
+}
+
+TEST_CASE("state: the layout hash distinguishes shapes", "[state][schema]")
+{
+  // Same members, different order or count: different hash.
+  REQUIRE(
+      avnd::state::layout_hash<v1::cfg>()
+      != avnd::state::layout_hash<v2_reordered::cfg>());
+  REQUIRE(
+      avnd::state::layout_hash<v1::cfg>()
+      != avnd::state::layout_hash<v2_added::cfg>());
+  REQUIRE(
+      avnd::state::layout_hash<v1::cfg>()
+      != avnd::state::layout_hash<v2_retyped::cfg>());
+  // Renaming a member without touching its shape is invisible, by design:
+  // positionally the two structs are the same state.
+  struct renamed
+  {
+    int operating_mode{};
+    float level{};
+  };
+  REQUIRE(
+      avnd::state::layout_hash<v1::cfg>() == avnd::state::layout_hash<renamed>());
+}
+
+TEST_CASE("state: unnamed state structs work", "[state][schema]")
+{
+  // The point of positional encoding: state can be declared inline, like
+  // the inputs and outputs groups.
+  struct Host
+  {
+    struct
+    {
+      int a{};
+      std::string s;
+    } state;
+  };
+  Host in;
+  in.state.a = 9;
+  in.state.s = "inline";
+  const auto bytes = avnd::state::save(in.state);
+
+  Host out;
+  const auto res = avnd::state::load(out.state, bytes.data(), bytes.size());
+  REQUIRE(res.ok);
+  REQUIRE_FALSE(res.layout_drift);
+  REQUIRE(out.state.a == 9);
+  REQUIRE(out.state.s == "inline");
 }

--- a/tests/test_state_serial.cpp
+++ b/tests/test_state_serial.cpp
@@ -165,7 +165,8 @@ TEST_CASE("state: appending a member keeps its default", "[state][schema]")
   REQUIRE(loaded.mode == 5);
   REQUIRE(loaded.gain == Catch::Approx(0.25f));
   REQUIRE(loaded.extra == 42); // appended member keeps its default
-  REQUIRE(res.layout_drift); // but the change is reported
+  REQUIRE(res.layout_changed); // the change is visible, but benign
+  REQUIRE_FALSE(res.type_mismatch);
 }
 
 TEST_CASE("state: dropping a trailing member skips its record",
@@ -178,7 +179,8 @@ TEST_CASE("state: dropping a trailing member skips its record",
   const auto res = avnd::state::load(loaded, bytes.data(), bytes.size());
   REQUIRE(res.ok);
   REQUIRE(loaded.mode == 5); // the surviving member is still read
-  REQUIRE(res.layout_drift); // and the change is reported
+  REQUIRE(res.layout_changed);
+  REQUIRE_FALSE(res.type_mismatch); // dropping a trailing member is benign
 }
 
 TEST_CASE("state: reordering members is reported as layout drift",
@@ -192,7 +194,7 @@ TEST_CASE("state: reordering members is reported as layout drift",
 
   v2_reordered::cfg loaded{};
   const auto res = avnd::state::load(loaded, bytes.data(), bytes.size());
-  REQUIRE(res.layout_drift);
+  REQUIRE(res.type_mismatch);
   // The two members have different tags-with-sizes, so neither is applied.
   REQUIRE(loaded.mode == 0);
   REQUIRE(loaded.gain == Catch::Approx(0.f));
@@ -269,7 +271,8 @@ TEST_CASE("state: an unchanged layout reports no drift", "[state][schema]")
   v1::cfg b{};
   const auto res = avnd::state::load(b, bytes.data(), bytes.size());
   REQUIRE(res.ok);
-  REQUIRE_FALSE(res.layout_drift);
+  REQUIRE_FALSE(res.layout_changed);
+  REQUIRE_FALSE(res.type_mismatch);
   REQUIRE(b.mode == 1);
   REQUIRE(b.gain == Catch::Approx(2.f));
 }
@@ -317,7 +320,8 @@ TEST_CASE("state: unnamed state structs work", "[state][schema]")
   Host out;
   const auto res = avnd::state::load(out.state, bytes.data(), bytes.size());
   REQUIRE(res.ok);
-  REQUIRE_FALSE(res.layout_drift);
+  REQUIRE_FALSE(res.layout_changed);
+  REQUIRE_FALSE(res.type_mismatch);
   REQUIRE(out.state.a == 9);
   REQUIRE(out.state.s == "inline");
 }


### PR DESCRIPTION
Serialize a processor's persistent state by reflecting over a `state` struct, the way the value bindings already reflect over `inputs` and `outputs` -- no hand-written byte code.

```cpp
struct MyProcessor
{
  struct { … } inputs;
  struct { … } outputs;
  struct { std::vector<uint8_t> program; int mode{}; std::string label; } state;
};
```

The presence of the `state` member is enough; `avnd::save_object_state` / `load_object_state` do the rest. This is the core only -- concepts, the serializer and its tests. Wiring it into the CLAP and VST3 state containers is a follow-up.

## What is covered

Member types are classified with the same concepts the value bindings use (`avnd/concepts/generic.hpp`), so anything a processor can carry round-trips: scalars and enums, strings, `vector` and other list containers, `set` and `map`, `optional`, `variant`, `pair` and `tuple`, `std::array`, aggregates, and any nesting of those. Verified on GCC 16 and MSVC across 21 type combinations.

Refused at compile time: anything that only *borrows* its data -- a pointer, reference or `string_view` -- since it would be written out as an address that means nothing to the process reading it back. A processor needing one provides `save`/`load` on its state instead, which takes precedence over reflection.

## Format and schema changes

Members are encoded positionally, each as a self-describing record `[tag][scalar kind][size][payload]`, behind a header carrying a format marker, a layout hash and the field count. The shape of the data absorbs the common edits without any version bookkeeping:

- appending a member: older data just has fewer records, the new member keeps its default;
- dropping a trailing member: its record is skipped;
- changing a member's type: the record no longer matches, so it is skipped rather than reinterpreted -- the scalar kind distinguishes an `int` from a `float` of the same width.

An edit the format cannot follow on its own -- reordering or inserting in the middle -- changes the layout hash and is refused unless the processor declares a `state_version` and a `migrate_state` hook, which is also how a change of *meaning* (same type, new unit) is handled. Data written by a newer version than the binary understands is refused rather than misread.

The one edit nothing here can see is a swap of two members of the identical type; that is exactly what the version bump exists for, and it is documented as such. In practice this suggests the same discipline as inlets: add state members at the end.

## Override and versioning

```cpp
// full control of the bytes -- takes precedence over reflection
struct { std::vector<uint8_t> save() const; bool load(const uint8_t*, std::size_t); } state;

// or reflect, with a migration for the changes reflection cannot follow
halp_meta(state_version, 3)
static void migrate_state(auto& state, int from) { … }
```

## Testing

`test_state_serial` and `test_state_object`: the round-trip, the full type surface, the schema-change matrix (append / drop / retype / reorder), truncated and corrupt input, and the override and migration paths. All pass on MSVC; the type-coverage matrix was also run on GCC 16. `FindBoost` was not touched here (it lives in the transport/state PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
