### PR TITLE
CI: build in parallel

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -153,7 +153,7 @@ jobs:
             ${{ matrix.config.common_flags }} \
             ${{ matrix.config.debug_flags }}
 
-          cmake --build . -- ${{ matrix.config.build_flags }}
+          cmake --build . --parallel -- ${{ matrix.config.build_flags }}
 
       - name: Test debug
         shell: bash
@@ -194,7 +194,7 @@ jobs:
             ${{ matrix.config.common_flags }} \
             ${{ matrix.config.release_flags }}
 
-          cmake --build . -- ${{ matrix.config.build_flags }}
+          cmake --build . --parallel -- ${{ matrix.config.build_flags }}
 
       - name: Test release
         shell: bash

--- a/.github/workflows/build_vs.yml
+++ b/.github/workflows/build_vs.yml
@@ -75,7 +75,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src" \
             -G "Visual Studio 18 2026"
 
-          cmake --build . --config Debug
+          cmake --build . --parallel --config Debug
 
       - name: Test debug
         shell: bash
@@ -104,7 +104,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src" \
             -G "Visual Studio 18 2026"
 
-          cmake --build . --config Release
+          cmake --build . --parallel --config Release
 
       - name: Test release
         shell: bash

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -68,7 +68,7 @@ jobs:
             -DVST3_SDK_ROOT=$SDK_3RDPARTY/vst3 \
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src"
 
-          cmake --build .
+          cmake --build . --parallel
 
       - name: Test debug
         shell: msys2 {0}
@@ -94,7 +94,7 @@ jobs:
             -DVST3_SDK_ROOT=$SDK_3RDPARTY/vst3 \
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src"
 
-          cmake --build .
+          cmake --build . --parallel
 
       - name: Test release
         shell: msys2 {0}


### PR DESCRIPTION
`cmake --build` defaults to a single job under the Makefiles generator, so these builds compiled on one core no matter how many the machine has.

`--parallel` lets CMake choose the job count. It is a no-op where the generator already parallelises (Ninja), so it is safe to apply uniformly.

Test targets are left alone — running tests in parallel is a separate decision.