### PR TITLE
aggregates: key the structured backend on P1061, not the 202403L level

### DIFF
--- a/include/avnd/common/aggregates.base.hpp
+++ b/include/avnd/common/aggregates.base.hpp
@@ -24,7 +24,7 @@ struct typelist
     #define AVND_USE_BOOST_PFR 1   // clang < 21: no P1061 packs
   #elif defined(_MSC_VER) && (!defined(__clang_major__) || (__clang_major__ < 21))
     #define AVND_USE_BOOST_PFR 1   // MSVC (cl, or clang-cl < 21)
-  #elif !defined(__cpp_structured_bindings) || (__cpp_structured_bindings < 202403L) \
+  #elif !defined(__cpp_structured_bindings) || (__cpp_structured_bindings < 202411L) \
         || !defined(__cpp_pack_indexing) || (__cpp_pack_indexing < 202311L)
     #define AVND_USE_BOOST_PFR 1   // no P1061 / pack indexing (e.g. gcc < 16)
   #else


### PR DESCRIPTION
The aggregate backend guard admits a compiler that cannot compile the backend it selects.

`g++-15` reports `__cpp_structured_bindings=202403L` — that is P0609 (attributes on structured bindings), not P1061 (packs). The guard accepts `>= 202403L`, so g++-15 passes it, selects the structured backend, and then fails:

```
aggregates.structured.hpp:82:11: error: expected identifier before ‘...’ token
   82 |       auto&& [... members] = item;
```

P1061 — the paper the structured backend actually depends on — is `202411L`, which only g++-16 reports. The guard's own comments already say `gcc < 16` / `gcc >= 16`, so this is just the constant not matching the stated intent.

### Effect

Verified by preprocessing `AVND_USE_BOOST_PFR` against each compiler:

| compiler | before | after |
|---|---|---|
| g++-14 `gnu++23` / `gnu++26` | pfr | pfr |
| g++-15 `gnu++23` | pfr | pfr |
| **g++-15 `gnu++26`** | **structured (fails to compile)** | **pfr** |
| g++-16 `gnu++23` | pfr | pfr |
| g++-16 `gnu++26` | structured | structured |
| clang 23 `gnu++23` / `gnu++26` | structured | structured |

Only the broken cell changes; clang and g++-16 are unaffected.

### Why it matters beyond the hard error

On the pfr fallback, instantiating a large aggregate is very expensive. Compiling a ~336-field object (Kaboom, via score-addon-synthimi) with g++-14 peaks at **40.9 GB RSS and is OOM-killed**; `-fsyntax-only` alone reaches 10 GB, so it is front-end instantiation, not codegen — no optimisation flag affects it. The same TU on g++-16 `gnu++26`, i.e. on the structured backend, compiles in **151 s at 7.1 GB**. So which side of this guard a compiler lands on is the difference between building and exhausting memory, and g++-15 currently lands on a third option: neither.