### PR TITLE
Diagnostics: let an object report its condition to the host

### DIFF
--- a/.github/actions/parallelism/action.yml
+++ b/.github/actions/parallelism/action.yml
@@ -1,0 +1,59 @@
+name: "Build parallelism"
+description: >-
+  Export CMAKE_BUILD_PARALLEL_LEVEL with a job count that is safe on this
+  runner: bounded by the CPUs *and* by the memory available to the build.
+
+runs:
+  using: composite
+  steps:
+    - name: Compute build parallelism
+      shell: bash
+      run: |
+        set -u
+
+        # nproc is coreutils: it exists on Linux and in MSYS2/Git bash, but not
+        # on macOS. `--parallel "$(nproc)"` there expanded to an empty argument,
+        # which CMake turns into a bare `make -j` -- unbounded parallelism, and
+        # the build died forking ("Resource temporarily unavailable").
+        if command -v nproc > /dev/null 2>&1; then
+          cpus=$(nproc)
+        elif command -v sysctl > /dev/null 2>&1 && sysctl -n hw.logicalcpu > /dev/null 2>&1; then
+          cpus=$(sysctl -n hw.logicalcpu)
+        else
+          cpus=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)
+        fi
+        case "$cpus" in ''|*[!0-9]*) cpus=2 ;; esac
+        [ "$cpus" -ge 1 ] || cpus=2
+
+        # Avendish translation units are template-heavy and each compiler
+        # process can hold well over a gigabyte, so the core count alone is not
+        # a safe bound: on a container the cgroup gets a slice of the memory
+        # while nproc still reports every host core. Allow one job per 2 GB.
+        mem_mb=""
+        if [ -r /sys/fs/cgroup/memory.max ]; then
+          v=$(cat /sys/fs/cgroup/memory.max)
+          [ "$v" != "max" ] && mem_mb=$((v / 1024 / 1024))
+        elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+          v=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+          # Unlimited is reported as a huge sentinel value.
+          [ "$v" -lt 4611686018427387904 ] 2>/dev/null && mem_mb=$((v / 1024 / 1024))
+        fi
+        if [ -z "$mem_mb" ] && command -v sysctl > /dev/null 2>&1 && sysctl -n hw.memsize > /dev/null 2>&1; then
+          mem_mb=$(( $(sysctl -n hw.memsize) / 1024 / 1024 ))
+        fi
+        if [ -z "$mem_mb" ] && [ -r /proc/meminfo ]; then
+          mem_mb=$(( $(awk '/^MemTotal:/ {print $2}' /proc/meminfo) / 1024 ))
+        fi
+
+        jobs=$cpus
+        case "${mem_mb:-}" in
+          ''|*[!0-9]*) ;;
+          *)
+            by_mem=$((mem_mb / 2048))
+            [ "$by_mem" -lt 1 ] && by_mem=1
+            [ "$by_mem" -lt "$jobs" ] && jobs=$by_mem
+            ;;
+        esac
+
+        echo "CMAKE_BUILD_PARALLEL_LEVEL=$jobs" >> "$GITHUB_ENV"
+        echo "Using $jobs build jobs (cpus=$cpus, memory=${mem_mb:-unknown} MiB)"

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -130,6 +130,9 @@ jobs:
           chmod +x ./fetch-sdk.sh
           ./fetch-sdk.sh
 
+      - name: Compute build parallelism
+        uses: ./.github/actions/parallelism
+
       - name: Build debug
         shell: bash
         run: |
@@ -158,7 +161,7 @@ jobs:
             ${{ matrix.config.common_flags }} \
             ${{ matrix.config.debug_flags }}
 
-          cmake --build . --parallel "$(nproc)" -- ${{ matrix.config.build_flags }}
+          cmake --build . -- ${{ matrix.config.build_flags }}
 
       - name: Test debug
         shell: bash
@@ -199,7 +202,7 @@ jobs:
             ${{ matrix.config.common_flags }} \
             ${{ matrix.config.release_flags }}
 
-          cmake --build . --parallel "$(nproc)" -- ${{ matrix.config.build_flags }}
+          cmake --build . -- ${{ matrix.config.build_flags }}
 
       - name: Test release
         shell: bash

--- a/.github/workflows/build_vs.yml
+++ b/.github/workflows/build_vs.yml
@@ -51,6 +51,9 @@ jobs:
           chmod +x ./fetch-sdk.sh
           ./fetch-sdk.sh
 
+      - name: Compute build parallelism
+        uses: ./.github/actions/parallelism
+
       - name: Build debug
         shell: bash
         run: |
@@ -75,7 +78,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src" \
             -G "Visual Studio 18 2026"
 
-          cmake --build . --parallel "$(nproc)" --config Debug
+          cmake --build . --config Debug
 
       - name: Test debug
         shell: bash
@@ -104,7 +107,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src" \
             -G "Visual Studio 18 2026"
 
-          cmake --build . --parallel "$(nproc)" --config Release
+          cmake --build . --config Release
 
       - name: Test release
         shell: bash

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -50,6 +50,9 @@ jobs:
             boost:p
             gstreamer:p
 
+      - name: Compute build parallelism
+        uses: ./.github/actions/parallelism
+
       - name: Build debug
         shell: msys2 {0}
         run: |
@@ -68,7 +71,7 @@ jobs:
             -DVST3_SDK_ROOT=$SDK_3RDPARTY/vst3 \
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src"
 
-          cmake --build . --parallel "$(nproc)"
+          cmake --build .
 
       - name: Test debug
         shell: msys2 {0}
@@ -94,7 +97,7 @@ jobs:
             -DVST3_SDK_ROOT=$SDK_3RDPARTY/vst3 \
             -DCMAKE_PREFIX_PATH="$SDK_3RDPARTY/libpd/pure-data/src"
 
-          cmake --build . --parallel "$(nproc)"
+          cmake --build .
 
       - name: Test release
         shell: msys2 {0}

--- a/cmake/avendish.dump.cmake
+++ b/cmake/avendish.dump.cmake
@@ -60,8 +60,19 @@ function(avnd_make_dump)
     VERBATIM
   )
 
+  # A custom command with no owning target is copied into *every* target that
+  # lists its output in DEPENDS. Ninja and Make fold those copies back into one
+  # graph node, but the Visual Studio generator emits one custom build step per
+  # .vcxproj and MSBuild builds projects in parallel, so several copies rewrite
+  # the same JSON at once while another one is reading it -- generate_patches
+  # then fails with "attempting to parse an empty input" (exit code 3), which
+  # made the VS lane fail at random. Give the command one owning target and let
+  # every consumer order itself against that target instead of against the file.
+  add_custom_target(${AVND_FX_TARGET}_json DEPENDS "${_dump_file_path}")
+
   set_target_properties(${AVND_TARGET} PROPERTIES
     AVND_DUMP_PATH "${_dump_file_path}"
+    AVND_DUMP_TARGET "${AVND_FX_TARGET}_json"
   )
 
   avnd_common_setup("${AVND_TARGET}" "${AVND_FX_TARGET}")

--- a/cmake/avendish.help.cmake
+++ b/cmake/avendish.help.cmake
@@ -67,17 +67,24 @@ function(avnd_generate_help)
   if(NOT _dump_path)
     return()
   endif()
+  get_target_property(_dump_target ${AVND_SOURCE_TARGET} AVND_DUMP_TARGET)
+  if(NOT _dump_target)
+    set(_dump_target "")
+  endif()
 
+  # Only consume the dump JSON here: depending on the file would attach another
+  # copy of the rule that produces it to this target, and the copies race under
+  # the VS generator. See avendish.dump.cmake.
   add_custom_target(${AVND_FX_TARGET}_help ALL
       "$<TARGET_FILE:generate_patches>" "${AVND_BACKEND}" "${_dump_path}" "${AVND_DESTINATION}" ${AVND_EXTRA_ARG}
-      DEPENDS "${_dump_path}" generate_patches
       BYPRODUCTS "${AVND_DESTINATION}"
     )
   # DEPENDS on a target in add_custom_target does not reliably force build
   # ordering (esp. with the VS generator + parallel MSBuild): the help step
   # could run before generate_patches or the dump JSON existed (exit code 3).
   # Force it explicitly.
-  add_dependencies(${AVND_FX_TARGET}_help generate_patches ${AVND_SOURCE_TARGET})
+  add_dependencies(${AVND_FX_TARGET}_help
+    generate_patches ${AVND_SOURCE_TARGET} ${_dump_target})
   set_target_properties(${AVND_FX_TARGET}
     PROPERTIES "${AVND_PROPERTY}" "${AVND_DESTINATION}")
 endfunction()

--- a/cmake/avendish.max.cmake
+++ b/cmake/avendish.max.cmake
@@ -268,14 +268,19 @@ EXPORTS
       message(STATUS "_dump_path: ${_dump_path}")
       set(_maxref_template "${AVND_SOURCE_DIR}/examples/Demos/maxref_template.xml")
       set(_maxref_destination "max/$<IF:${multi_config},$<CONFIG>/,>${AVND_C_NAME}.maxref.xml")
+      # Depend on the target that owns the dump JSON, not on the file: see
+      # avendish.dump.cmake for why depending on the path races under VS.
       add_custom_target(dump_maxref_${AVND_FX_TARGET} ALL
           json_to_maxref "${_maxref_template}" "${_dump_path}" "${_maxref_destination}"
           DEPENDS
-            "${_dump_path}"
             json_to_maxref
           BYPRODUCTS
             "${_maxref_destination}"
         )
+      get_target_property(_dump_target ${AVND_TARGET} AVND_DUMP_TARGET)
+      if(_dump_target)
+        add_dependencies(dump_maxref_${AVND_FX_TARGET} ${_dump_target})
+      endif()
       set_target_properties(${AVND_FX_TARGET}
         PROPERTIES
           AVND_MAX_MAXREF_XML "${_maxref_destination}"

--- a/examples/Helpers/Diagnostics.hpp
+++ b/examples/Helpers/Diagnostics.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <halp/controls.hpp>
+#include <halp/diagnostics.hpp>
+#include <halp/meta.hpp>
+
+namespace examples::helpers
+{
+/**
+ * Reporting conditions to the host.
+ *
+ * Unlike the logger, which is a stream of lines for the developer, diagnostics
+ * are the object's current state, shown by the host on the node itself:
+ * TouchDesigner puts the node into a warning or error state, Max and Pd post to
+ * the console when it changes, and so on.
+ *
+ * The set is cleared before every run, so state what is true now and stop
+ * stating what is not.
+ */
+struct Diagnostics
+{
+  halp_meta(name, "Diagnostics")
+  halp_meta(c_name, "avnd_helpers_diagnostics")
+  halp_meta(category, "Demo")
+  halp_meta(author, "Jean-Michaël Celerier")
+  halp_meta(description, "Reporting errors, warnings and info to the host")
+  halp_meta(uuid, "8f6dc0a0-4c8a-4b16-9d47-2b4b3a8f1c02")
+
+  // The entire opt-in.
+  halp::diagnostics diagnostics;
+
+  struct
+  {
+    halp::hslider_f32<"Level", halp::range{0., 1., 0.5}> level;
+    halp::spinbox_i32<"Count", halp::range{0, 1000, 10}> count;
+  } inputs;
+
+  struct
+  {
+    halp::val_port<"Out", float> out;
+  } outputs;
+
+  void operator()()
+  {
+    // Plain messages: no identifier needed.
+    if(inputs.count == 0)
+      diagnostics.warning("nothing to process");
+
+    // With a stable identifier, for hosts that suppress or localise by id, for
+    // structured codes, and so tests can assert on the condition rather than on
+    // the wording.
+    if(inputs.level > 0.95f)
+      diagnostics.error<"level_too_high">("level {:.2f} is out of range", inputs.level.value);
+
+    diagnostics.info("processing {} items", inputs.count.value);
+
+    outputs.out = inputs.level * inputs.count;
+  }
+};
+}

--- a/include/avnd/binding/ossia/node.hpp
+++ b/include/avnd/binding/ossia/node.hpp
@@ -125,6 +125,14 @@ public:
   double sample_rate{};
   double tempo{ossia::root_tempo};
 
+  AVND_NO_UNIQUE_ADDRESS oscr::soundfile_storage<T> soundfiles;
+
+  AVND_NO_UNIQUE_ADDRESS oscr::midifile_storage<T> midifiles;
+
+#if defined(OSCR_HAS_MMAP_FILE_STORAGE)
+  AVND_NO_UNIQUE_ADDRESS oscr::raw_file_storage<T> rawfiles;
+#endif
+
   AVND_NO_UNIQUE_ADDRESS avnd::effect_container<T> impl;
 
   AVND_NO_UNIQUE_ADDRESS oscr::builtin_arg_audio_ports<T> audio_ports;
@@ -148,14 +156,6 @@ public:
   AVND_NO_UNIQUE_ADDRESS avnd::callback_storage<T> callbacks;
 
   AVND_NO_UNIQUE_ADDRESS avnd::smooth_storage<T> smooth;
-
-  AVND_NO_UNIQUE_ADDRESS oscr::soundfile_storage<T> soundfiles;
-
-  AVND_NO_UNIQUE_ADDRESS oscr::midifile_storage<T> midifiles;
-
-#if defined(OSCR_HAS_MMAP_FILE_STORAGE)
-  AVND_NO_UNIQUE_ADDRESS oscr::raw_file_storage<T> rawfiles;
-#endif
 
   AVND_NO_UNIQUE_ADDRESS oscr::spectrum_storage<T> spectrums;
 
@@ -668,29 +668,29 @@ public:
   }
 
   template <std::size_t N, std::size_t NField>
-  void soundfile_loaded(
+  ossia::audio_handle soundfile_loaded(
       ossia::audio_handle& hdl, avnd::predicate_index<N>, avnd::field_index<NField>)
   {
-    this->soundfiles.load(
+    return this->soundfiles.load(
         this->impl, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
   }
 
   template <std::size_t N, std::size_t NField>
-  void midifile_loaded(
+  std::shared_ptr<oscr::midifile_data> midifile_loaded(
       const std::shared_ptr<oscr::midifile_data>& hdl, avnd::predicate_index<N>,
       avnd::field_index<NField>)
   {
-    this->midifiles.load(
+    return this->midifiles.load(
         this->impl, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
   }
 
 #if OSCR_HAS_MMAP_FILE_STORAGE
   template <std::size_t N, std::size_t NField>
-  void file_loaded(
+  std::shared_ptr<oscr::raw_file_data> file_loaded(
       const std::shared_ptr<oscr::raw_file_data>& hdl, avnd::predicate_index<N>,
       avnd::field_index<NField>)
   {
-    this->rawfiles.load(
+    return this->rawfiles.load(
         this->impl, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
   }
 #endif

--- a/include/avnd/binding/ossia/soundfiles.hpp
+++ b/include/avnd/binding/ossia/soundfiles.hpp
@@ -137,6 +137,7 @@ struct soundfile_storage : soundfile_input_storage<T>
       audio_data_t<double>& g = get<N>(this->handles);
 
       // FIXME this allocates. :(
+      g.data.clear();
       g.data.reserve(chans * frames);
       buf.resize(chans);
       g.path = hdl->path;
@@ -340,19 +341,23 @@ struct raw_file_storage : raw_file_input_storage<T>
   {
     std::shared_ptr<raw_file_data>& g = get<N>(this->handles);
 
-    // Store the handle to keep the memory from being freed
-    std::exchange(g, hdl);
+    const std::shared_ptr<raw_file_data> previous = std::exchange(g, hdl);
 
     for(auto state : t.full_state())
     {
       avnd::raw_file_port auto& port = avnd::pfr::get<NField>(state.inputs);
 
-      if(port.file.filename != hdl->filename)
-      {
-        port.file.bytes
-            = decltype(port.file.bytes)(hdl->data.constData(), hdl->file.size());
-        port.file.filename = hdl->filename;
+      const bool changed = port.file.filename != hdl->filename;
 
+      // The views are always repointed to the new handle, even when the file
+      // name did not change: they would otherwise dangle as soon as the
+      // previous handle is released at the end of this function.
+      port.file.bytes
+          = decltype(port.file.bytes)(hdl->data.constData(), hdl->file.size());
+      port.file.filename = hdl->filename;
+
+      if(changed)
+      {
         if_possible(port.update(state.effect));
       }
     }
@@ -365,18 +370,19 @@ struct raw_file_storage : raw_file_input_storage<T>
   {
     std::shared_ptr<raw_file_data>& g = get<N>(this->handles);
 
-    // Store the handle to keep the memory from being freed
-    std::exchange(g, hdl);
+    const std::shared_ptr<raw_file_data> previous = std::exchange(g, hdl);
 
     // FIXME not generic enough.. GPU should also use effect_container
     avnd::raw_file_port auto& port = avnd::pfr::get<NField>(state.inputs);
 
-    if(port.file.filename != hdl->filename)
-    {
-      port.file.bytes
-          = decltype(port.file.bytes)(hdl->data.constData(), hdl->file.size());
-      port.file.filename = hdl->filename;
+    const bool changed = port.file.filename != hdl->filename;
 
+    port.file.bytes
+        = decltype(port.file.bytes)(hdl->data.constData(), hdl->file.size());
+    port.file.filename = hdl->filename;
+
+    if(changed)
+    {
       if_possible(port.update(state));
     }
   }

--- a/include/avnd/binding/ossia/soundfiles.hpp
+++ b/include/avnd/binding/ossia/soundfiles.hpp
@@ -96,8 +96,10 @@ struct soundfile_storage : soundfile_input_storage<T>
     }
   }
 
+  //! Returns the handle that the caller is now responsible for disposing of,
+  //! in a thread where deallocating is allowed.
   template <std::size_t N, std::size_t NField>
-  void load(
+  ossia::audio_handle load(
       avnd::effect_container<T>& t, ossia::audio_handle& hdl, avnd::predicate_index<N>,
       avnd::field_index<NField>)
   {
@@ -111,8 +113,11 @@ struct soundfile_storage : soundfile_input_storage<T>
     {
       ossia::audio_handle& g = get<N>(this->handles);
 
-      // Store the handle to keep the memory from being freed
-      std::exchange(g, hdl);
+      // Store the handle to keep the memory from being freed.
+      // The previous one is given back to the caller: the ports still point
+      // into it until they are updated below, and freeing it here would happen
+      // in whichever thread called us - generally the audio thread.
+      ossia::audio_handle previous = std::exchange(g, hdl);
       buf.resize(chans);
 
       // Copy the pointers in our storage if no conversion is needed
@@ -131,6 +136,7 @@ struct soundfile_storage : soundfile_input_storage<T>
 
         if_possible(port.update(state.effect));
       }
+      return previous;
     }
     else
     {
@@ -161,6 +167,9 @@ struct soundfile_storage : soundfile_input_storage<T>
 
         if_possible(port.update(state.effect));
       }
+
+      // The samples were copied into our own storage: nothing keeps hdl alive
+      return hdl;
     }
   }
 
@@ -207,15 +216,17 @@ struct midifile_storage : midifile_input_storage<T>
 {
   void init(avnd::effect_container<T>& t) { }
 
+  //! \see soundfile_storage::load
   template <std::size_t N, std::size_t NField>
-  void load(
+  std::shared_ptr<midifile_data> load(
       avnd::effect_container<T>& t, const std::shared_ptr<midifile_data>& hdl,
       avnd::predicate_index<N>, avnd::field_index<NField>)
   {
     std::shared_ptr<midifile_data>& g = get<N>(this->handles);
 
-    // Store the handle to keep the memory from being freed
-    std::exchange(g, hdl);
+    // Store the handle to keep the memory from being freed.
+    // The previous one is given back to the caller, see soundfile_storage::load
+    std::shared_ptr<midifile_data> previous = std::exchange(g, hdl);
 
     for(auto state : t.full_state())
     {
@@ -289,6 +300,7 @@ struct midifile_storage : midifile_input_storage<T>
 
       if_possible(port.update(state.effect));
     }
+    return previous;
   }
 };
 }
@@ -334,14 +346,18 @@ struct raw_file_storage : raw_file_input_storage<T>
 {
   void init(avnd::effect_container<T>& t) { }
 
+  //! \see soundfile_storage::load
   template <std::size_t N, std::size_t NField>
-  void load(
+  std::shared_ptr<raw_file_data> load(
       avnd::effect_container<T>& t, const std::shared_ptr<raw_file_data>& hdl,
       avnd::predicate_index<N>, avnd::field_index<NField>)
   {
     std::shared_ptr<raw_file_data>& g = get<N>(this->handles);
 
-    const std::shared_ptr<raw_file_data> previous = std::exchange(g, hdl);
+    // The previous handle has to stay alive until the ports have been
+    // repointed below; it is then given back to the caller so that it is not
+    // freed in whichever thread called us.
+    std::shared_ptr<raw_file_data> previous = std::exchange(g, hdl);
 
     for(auto state : t.full_state())
     {
@@ -361,16 +377,21 @@ struct raw_file_storage : raw_file_input_storage<T>
         if_possible(port.update(state.effect));
       }
     }
+    return previous;
   }
 
+  //! \see soundfile_storage::load
   template <std::size_t N, std::size_t NField>
-  void load(
+  std::shared_ptr<raw_file_data> load(
       T& state, const std::shared_ptr<raw_file_data>& hdl, avnd::predicate_index<N>,
       avnd::field_index<NField>)
   {
     std::shared_ptr<raw_file_data>& g = get<N>(this->handles);
 
-    const std::shared_ptr<raw_file_data> previous = std::exchange(g, hdl);
+    // The previous handle has to stay alive until the ports have been
+    // repointed below; it is then given back to the caller so that it is not
+    // freed in whichever thread called us.
+    std::shared_ptr<raw_file_data> previous = std::exchange(g, hdl);
 
     // FIXME not generic enough.. GPU should also use effect_container
     avnd::raw_file_port auto& port = avnd::pfr::get<NField>(state.inputs);
@@ -385,6 +406,7 @@ struct raw_file_storage : raw_file_input_storage<T>
     {
       if_possible(port.update(state));
     }
+    return previous;
   }
 };
 }

--- a/include/avnd/binding/touchdesigner/diagnostics.hpp
+++ b/include/avnd/binding/touchdesigner/diagnostics.hpp
@@ -72,9 +72,25 @@ struct diagnostics_state
 
       if(d.dropped > 0)
       {
-        if(!error.empty())
-          error += '\n';
-        error += "... and " + std::to_string(d.dropped) + " more";
+        // Report the overflow at the severity of what was actually lost:
+        // always using the error channel would turn a node red for dropped
+        // informational messages.
+        std::string* dst = &info;
+        switch(d.dropped_severity)
+        {
+          case avnd::diagnostic_severity::warning:
+            dst = &warning;
+            break;
+          case avnd::diagnostic_severity::error:
+          case avnd::diagnostic_severity::fatal:
+            dst = &error;
+            break;
+          case avnd::diagnostic_severity::info:
+            break;
+        }
+        if(!dst->empty())
+          *dst += '\n';
+        *dst += "... and " + std::to_string(d.dropped) + " more";
       }
     }
   }

--- a/include/avnd/binding/touchdesigner/diagnostics.hpp
+++ b/include/avnd/binding/touchdesigner/diagnostics.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/concepts/diagnostics.hpp>
+
+#include <string>
+
+namespace touchdesigner
+{
+
+/**
+ * Bridges an object's halp::diagnostics onto TouchDesigner's node state.
+ *
+ * TD polls getErrorString / getWarningString / getInfoPopupString after the
+ * cook and puts the node into the corresponding state, so the strings are
+ * rendered once per cook and cached here rather than rebuilt per call. Building
+ * them on this side keeps the object's storage fixed-size and allocation-free.
+ *
+ * A processor uses it as:
+ *   diag.begin(implementation);   // before invoking the object
+ *   ...cook...
+ *   diag.end(implementation);     // renders the three channels
+ */
+struct diagnostics_state
+{
+  std::string error;
+  std::string warning;
+  std::string info;
+
+  template <typename T>
+  void begin(T& implementation)
+  {
+    if constexpr(avnd::has_diagnostics<T>)
+      implementation.diagnostics.clear();
+  }
+
+  template <typename T>
+  void end(T& implementation)
+  {
+    if constexpr(avnd::has_diagnostics<T>)
+    {
+      error.clear();
+      warning.clear();
+      info.clear();
+
+      auto& d = implementation.diagnostics;
+      for(unsigned i = 0; i < d.count; ++i)
+      {
+        const auto& e = d.entries[i];
+        std::string* dst = nullptr;
+        switch(e.severity)
+        {
+          case avnd::diagnostic_severity::info:
+            dst = &info;
+            break;
+          case avnd::diagnostic_severity::warning:
+            dst = &warning;
+            break;
+          // TD has no separate fatal channel.
+          case avnd::diagnostic_severity::error:
+          case avnd::diagnostic_severity::fatal:
+            dst = &error;
+            break;
+        }
+        if(!dst)
+          continue;
+        if(!dst->empty())
+          *dst += '\n';
+        dst->append(e.message());
+      }
+
+      if(d.dropped > 0)
+      {
+        if(!error.empty())
+          error += '\n';
+        error += "... and " + std::to_string(d.dropped) + " more";
+      }
+    }
+  }
+};
+
+// TD only reads the pointer during the call, so a c_str() into our cache is fine.
+inline void set_string(TD::OP_String* out, const std::string& s)
+{
+  if(out && !s.empty())
+    out->setString(s.c_str());
+}
+
+}

--- a/include/avnd/binding/touchdesigner/pop/particle_processor.hpp
+++ b/include/avnd/binding/touchdesigner/pop/particle_processor.hpp
@@ -3,6 +3,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include <avnd/binding/touchdesigner/configure.hpp>
+#include <avnd/binding/touchdesigner/diagnostics.hpp>
 #include <avnd/binding/touchdesigner/geometry_helpers.hpp>
 #include <avnd/binding/touchdesigner/helpers.hpp>
 #include <avnd/binding/touchdesigner/file_ports.hpp>
@@ -56,6 +57,7 @@ struct particle_processor : public TD::POP_CPlusPlusBase
   touchdesigner::file_ports<T> file_setup;
   TD::POP_Context* context{};
   std::vector<TD::OP_SmartRef<TD::POP_Buffer>> m_input_buffers;
+  touchdesigner::diagnostics_state m_diagnostics;
 
   explicit particle_processor(const TD::OP_NodeInfo* info, TD::POP_Context* ctx)
       : context{ctx}
@@ -77,6 +79,9 @@ struct particle_processor : public TD::POP_CPlusPlusBase
 
   void execute(TD::POP_Output* output, const TD::OP_Inputs* inputs, void* reserved) override
   {
+    // Diagnostics are scoped to one cook: the object restates what still holds.
+    m_diagnostics.begin(implementation.effect);
+
     update_controls(inputs);
 
     // Read POP inputs into Avendish geometry inputs if applicable
@@ -95,6 +100,8 @@ struct particle_processor : public TD::POP_CPlusPlusBase
       // CPU path: run processor, then upload results
       execute_cpu(output, inputs);
     }
+
+    m_diagnostics.end(implementation.effect);
   }
 
   void execute_cpu(TD::POP_Output* output, const TD::OP_Inputs* inputs)
@@ -281,11 +288,20 @@ struct particle_processor : public TD::POP_CPlusPlusBase
     info_output<T>::get_info_dat_entries(implementation, index, nEntries, entries);
   }
 
-  void getWarningString(TD::OP_String* warning, void* reserved) override {}
+  void getWarningString(TD::OP_String* warning, void* reserved) override
+  {
+    touchdesigner::set_string(warning, m_diagnostics.warning);
+  }
 
-  void getErrorString(TD::OP_String* error, void* reserved) override {}
+  void getErrorString(TD::OP_String* error, void* reserved) override
+  {
+    touchdesigner::set_string(error, m_diagnostics.error);
+  }
 
-  void getInfoPopupString(TD::OP_String* info, void* reserved) override {}
+  void getInfoPopupString(TD::OP_String* info, void* reserved) override
+  {
+    touchdesigner::set_string(info, m_diagnostics.info);
+  }
 
 private:
   // ===== Output: write Avendish data to POP =====

--- a/include/avnd/concepts/diagnostics.hpp
+++ b/include/avnd/concepts/diagnostics.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
+
+#include <cstdint>
+
+namespace avnd
+{
+
+/**
+ * Severity of a condition an object reports about itself.
+ *
+ * The vocabulary follows OpenFX's message suite, which draws the distinctions
+ * most precisely:
+ *  - info:    conveys information to the user; not a problem
+ *  - warning: proceeds, but not optimally
+ *  - error:   recoverable by user intervention
+ *  - fatal:   the object can no longer operate
+ *
+ * Developer-facing tracing is *not* part of this: that is what avnd::logger is
+ * for. OFX draws the same line between "Message" and "Log".
+ */
+enum class diagnostic_severity : uint8_t
+{
+  info = 0,
+  warning = 1,
+  error = 2,
+  fatal = 3
+};
+
+/**
+ * Objects opt in by declaring a `diagnostics` member (see halp::diagnostics):
+ *
+ *   struct MyObject {
+ *     halp::diagnostics diagnostics;
+ *     void operator()() {
+ *       if(!connected) diagnostics.warning("no sender on port {}", port);
+ *     }
+ *   };
+ *
+ * Diagnostics are scoped to one run of the object: the binding clears them
+ * before invoking it, so an object simply states what is true now and stops
+ * stating what no longer is. Nothing to clear, no identifiers to manage.
+ */
+template <typename T>
+concept has_diagnostics = requires(T t) { t.diagnostics.entries; };
+
+}

--- a/include/halp/diagnostics.hpp
+++ b/include/halp/diagnostics.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/concepts/diagnostics.hpp>
+
+#include <halp/modules.hpp>
+#include <halp/static_string.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <string_view>
+#include <utility>
+
+#if __has_include(<fmt/format.h>) && !defined(AVND_DISABLE_FMT)
+#include <fmt/format.h>
+#define HALP_DIAGNOSTICS_FMT 1
+#endif
+
+HALP_MODULE_EXPORT
+namespace halp
+{
+
+/**
+ * A condition an object reports about itself, for the host to display.
+ *
+ *   struct MyObject
+ *   {
+ *     halp::diagnostics diagnostics;
+ *
+ *     void operator()()
+ *     {
+ *       if(!m_connected)
+ *         diagnostics.warning("no sender connected on port {}", port);
+ *       diagnostics.info("{} points", count);
+ *     }
+ *   };
+ *
+ * State what is true on each run; the binding clears the set before calling the
+ * object, so a condition disappears simply by not being restated.
+ *
+ * An optional compile-time identifier can be attached, for hosts that suppress
+ * or localise by id, for structured codes (GStreamer domains), and for tests
+ * that would rather assert on a condition than on English:
+ *
+ *   diagnostics.error<"port_in_use">("port {} is already in use", port);
+ *   REQUIRE(obj.diagnostics.has<"port_in_use">());
+ *
+ * The id has to be a template argument rather than a leading string: passing it
+ * as one would be ambiguous with the format string. It is compile-time because
+ * a stable id is by definition not computed at runtime, so only a pointer to a
+ * literal is ever stored.
+ *
+ * Fixed capacity throughout, so raising a diagnostic never allocates and is
+ * usable from an audio callback. Text beyond the capacity is truncated;
+ * entries beyond MaxEntries are dropped, lowest severity first, and counted.
+ */
+template <std::size_t MaxEntries = 8, std::size_t Capacity = 128>
+struct basic_diagnostics
+{
+  struct entry
+  {
+    avnd::diagnostic_severity severity{};
+    std::string_view id{};
+    std::array<char, Capacity> text{};
+    uint16_t length{};
+
+    std::string_view message() const noexcept { return {text.data(), length}; }
+  };
+
+  std::array<entry, MaxEntries> entries{};
+  uint8_t count{};
+  uint8_t dropped{};
+
+  void clear() noexcept
+  {
+    count = 0;
+    dropped = 0;
+  }
+
+  bool empty() const noexcept { return count == 0; }
+
+  avnd::diagnostic_severity worst() const noexcept
+  {
+    auto s = avnd::diagnostic_severity::info;
+    for(uint8_t i = 0; i < count; ++i)
+      if(entries[i].severity > s)
+        s = entries[i].severity;
+    return s;
+  }
+
+  bool has(std::string_view id) const noexcept
+  {
+    for(uint8_t i = 0; i < count; ++i)
+      if(entries[i].id == id)
+        return true;
+    return false;
+  }
+
+  template <static_string Id>
+  bool has() const noexcept
+  {
+    return has(std::string_view{Id.value});
+  }
+
+  // ---- raising -----------------------------------------------------------
+#if defined(HALP_DIAGNOSTICS_FMT)
+  template <typename... A>
+  void raise(
+      avnd::diagnostic_severity s, std::string_view id, fmt::format_string<A...> f,
+      A&&... args)
+  {
+    if(entry* e = acquire(s))
+    {
+      e->id = id;
+      auto res = fmt::format_to_n(
+          e->text.data(), Capacity, f, std::forward<A>(args)...);
+      e->length = static_cast<uint16_t>(res.size < Capacity ? res.size : Capacity);
+    }
+  }
+
+#define HALP_DIAG_LEVEL(name, sev)                                            \
+  template <typename... A>                                                    \
+  void name(fmt::format_string<A...> f, A&&... args)                          \
+  {                                                                           \
+    raise(sev, {}, f, std::forward<A>(args)...);                              \
+  }                                                                           \
+  template <static_string Id, typename... A>                                  \
+  void name(fmt::format_string<A...> f, A&&... args)                          \
+  {                                                                           \
+    raise(sev, std::string_view{Id.value}, f, std::forward<A>(args)...);      \
+  }
+#else
+  // No fmt: accept a plain message, still fixed-capacity.
+  void raise(avnd::diagnostic_severity s, std::string_view id, std::string_view msg)
+  {
+    if(entry* e = acquire(s))
+    {
+      e->id = id;
+      const std::size_t n = msg.size() < Capacity ? msg.size() : Capacity;
+      std::memcpy(e->text.data(), msg.data(), n);
+      e->length = static_cast<uint16_t>(n);
+    }
+  }
+
+#define HALP_DIAG_LEVEL(name, sev)                                            \
+  void name(std::string_view msg) { raise(sev, {}, msg); }                    \
+  template <static_string Id>                                                 \
+  void name(std::string_view msg)                                             \
+  {                                                                           \
+    raise(sev, std::string_view{Id.value}, msg);                              \
+  }
+#endif
+
+  HALP_DIAG_LEVEL(info, avnd::diagnostic_severity::info)
+  HALP_DIAG_LEVEL(warning, avnd::diagnostic_severity::warning)
+  HALP_DIAG_LEVEL(error, avnd::diagnostic_severity::error)
+  HALP_DIAG_LEVEL(fatal, avnd::diagnostic_severity::fatal)
+#undef HALP_DIAG_LEVEL
+
+private:
+  // Returns the slot to write into, or nullptr if this diagnostic is dropped.
+  // When full, the lowest-severity entry is evicted so the most serious
+  // condition is never the one lost.
+  entry* acquire(avnd::diagnostic_severity s) noexcept
+  {
+    if(count < MaxEntries)
+    {
+      entry* e = &entries[count++];
+      e->severity = s;
+      e->length = 0;
+      e->id = {};
+      return e;
+    }
+
+    uint8_t weakest = 0;
+    for(uint8_t i = 1; i < count; ++i)
+      if(entries[i].severity < entries[weakest].severity)
+        weakest = i;
+
+    ++dropped;
+    if(entries[weakest].severity >= s)
+      return nullptr;
+
+    entry* e = &entries[weakest];
+    e->severity = s;
+    e->length = 0;
+    e->id = {};
+    return e;
+  }
+};
+
+using diagnostics = basic_diagnostics<>;
+
+}

--- a/include/halp/diagnostics.hpp
+++ b/include/halp/diagnostics.hpp
@@ -70,14 +70,20 @@ struct basic_diagnostics
     std::string_view message() const noexcept { return {text.data(), length}; }
   };
 
+  static_assert(MaxEntries > 0 && MaxEntries <= 255, "count is a uint8_t");
+
   std::array<entry, MaxEntries> entries{};
   uint8_t count{};
-  uint8_t dropped{};
+  uint16_t dropped{};
+  // Severity of the most serious entry that had to be dropped, so a host can
+  // report the overflow at the right level rather than always as an error.
+  avnd::diagnostic_severity dropped_severity{};
 
   void clear() noexcept
   {
     count = 0;
     dropped = 0;
+    dropped_severity = avnd::diagnostic_severity::info;
   }
 
   bool empty() const noexcept { return count == 0; }
@@ -180,7 +186,14 @@ private:
       if(entries[i].severity < entries[weakest].severity)
         weakest = i;
 
-    ++dropped;
+    if(dropped < 0xFFFF)
+      ++dropped;
+
+    // Whichever of the two loses, its severity is what was dropped.
+    const auto lost = entries[weakest].severity >= s ? s : entries[weakest].severity;
+    if(lost > dropped_severity)
+      dropped_severity = lost;
+
     if(entries[weakest].severity >= s)
       return nullptr;
 


### PR DESCRIPTION
Objects currently have no way to say *"I am misconfigured right now"*.

`avnd::logger` is a stream of lines aimed at the developer — OFX draws the same
line between its `Log` and `Message` types — and a *state* rendered as a stream
becomes one identical console line per cook. TouchDesigner exposes exactly this
as node state (`getErrorString` / `getWarningString` / `getInfoPopupString`),
stubbed empty in every binding until now, and it feeds the Errors Dialog, the
Error DAT, `op.errors()` and OP Execute DAT callbacks. Houdini, Nuke, Blender
geometry nodes, OFX persistent messages and Node-RED all model the same thing.

## Object-side API

```cpp
struct MyObject
{
  halp::diagnostics diagnostics;          // the entire opt-in

  void operator()()
  {
    if(!connected)
      diagnostics.warning("no sender on port {}", port);
    diagnostics.info("{} points", count);
  }
};
```

Diagnostics are **scoped to one run** and cleared by the binding beforehand,
exactly as TouchDesigner's own `addError`/`addWarning` are ("only valid if added
while the operator is cooking") and as Blender and Houdini work. That is what
keeps the API this small — it removes:

- **identifiers to manage** — you restate what still holds
- **`clear()`** — not stating a condition *is* clearing it
- **thread-safety** — an object that learns something on a worker thread already
  has to publish that state for its outputs, and the cook reads it

## Optional stable ids

For hosts that suppress or localise by id, for structured codes (GStreamer
domains), and for tests:

```cpp
diagnostics.error<"port_in_use">("port {} is already in use", port);
REQUIRE(obj.diagnostics.has<"port_in_use">());
```

A template argument rather than a leading string, because
`error("id", "fmt {}", x)` is ambiguous with `error("fmt {}", "x")`. Compile-time
because a stable id is by definition not computed at runtime, so only a pointer
to a literal is stored. Users who do not want ids never type `<...>`.

## Properties

- Fixed capacity throughout: raising a diagnostic never allocates and is usable
  from an audio callback.
- Text truncates at the capacity; when the entry array is full the **lowest
  severity is evicted**, so the most serious condition is never the one lost,
  and the drop count is reported.
- Severity vocabulary follows OFX: `info` / `warning` / `error` / `fatal`.
- Zero cost for objects that do not declare the member.

## Contents

| file | |
|---|---|
| `avnd/concepts/diagnostics.hpp` | severity enum + `has_diagnostics` |
| `halp/diagnostics.hpp` | `basic_diagnostics<MaxEntries, Capacity>` |
| `avnd/binding/touchdesigner/diagnostics.hpp` | shared `diagnostics_state`, reusable by every TD family |
| `.../pop/particle_processor.hpp` | POP wiring: clear before cook, render the three channels |
| `examples/Helpers/Diagnostics.hpp` | example |

## Tested

Entries and severities, ids attached only where given, `has<>`, `clear()`,
eviction under overflow (12 `info` + 1 `error` → the error survives), and
truncation of a 1000-char message into a 128-byte buffer. The POP binding
compiles both for an object that opts in and one that does not.

## Not done here

- The other TD families (TOP/CHOP/SOP/DAT) reuse `diagnostics_state` the same
  way — three lines each.
- Stream backends should emit on change: Max `object_post/_warn/_error(x, …)`,
  Pd `logpost`/`pd_error(x, …)`, CLAP `clap_host_log`, Godot
  `push_error`/`push_warning`.

Surveying the field for this also turned up four independent one-line defects in
the existing loggers, which I have deliberately left out of this PR:

1. **TouchDesigner logging does nothing** — `logger::log_func` / `error_func` are
   `nullptr` and never assigned anywhere in the tree, so every method
   early-returns.
2. **Pd uses the wrong call** — `error()` routes to `::bug()`, which upstream Pd
   reserves for internal Pd faults; the object-facing call is `pd_error(x, …)`.
3. **Max and Pd pass `NULL` as the object**, losing the console's
   click-to-highlight — the main reason `object_error` takes one.
4. **CLAP discards messages it could deliver** — `clap_host_log` exists with a
   full severity enum, but the backend uses `halp::no_logger`.

Happy to fix those in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)