### PR TITLE
Fix default_on_toggle and value_map decoding of named float structs

### DIFF
--- a/include/avnd/binding/ossia/from_value.hpp
+++ b/include/avnd/binding/ossia/from_value.hpp
@@ -348,6 +348,12 @@ struct from_ossia_value_impl
     constexpr int sz = avnd::pfr::tuple_size_v<F>;
     if constexpr(avnd::vecf_compatible<F>())
     {
+      // A struct with 2/3/4 float fields AND field names is serialized as a
+      // value_map by to_ossia_value_impl (the field-names branch wins there);
+      // ossia::convert<vecNf>(map) returns zeroes, so route maps through the
+      // field-order decoder instead of the vecNf shortcut.
+      if(src.get_type() == ossia::val_type::MAP)
+        return from_vector(src, dst);
       if constexpr(sz == 2)
       {
         auto [x, y] = ossia::convert<ossia::vec2f>(src);
@@ -1388,6 +1394,11 @@ bool from_ossia_value(const ossia::value& src, T& dst)
   }
   else if constexpr(avnd::vecf_compatible<type>())
   {
+    // See from_ossia_value_impl: a named all-float struct arrives as a
+    // value_map when produced by a nested context; decode it by field order
+    // instead of ossia::convert<vecNf>(map) which returns zeroes.
+    if(src.get_type() == ossia::val_type::MAP)
+      return from_ossia_value_rec(src, dst);
     if constexpr(sz == 2)
     {
       auto [x, y] = ossia::convert<ossia::vec2f>(src);

--- a/include/halp/controls.sliders.hpp
+++ b/include/halp/controls.sliders.hpp
@@ -118,7 +118,7 @@ struct toggle_setup
 };
 
 inline constexpr auto default_toggle = toggle_setup{.init = false};
-inline constexpr auto default_on_toggle = toggle_setup{.init = false};
+inline constexpr auto default_on_toggle = toggle_setup{.init = true};
 
 /// XY position ///
 template <typename T, static_string lit, range setup>


### PR DESCRIPTION
Two independent bugs found while building a process on top of this binding.

### `default_on_toggle` defaulted to off

`default_toggle` and `default_on_toggle` were both `toggle_setup{.init = false}`, so the only thing separating them was the name. Any control declared `halp::toggle<"...", halp::default_on_toggle>` came up off.

It stayed invisible because a toggle reading `false` looks exactly like one the user turned off, and the binding initialises controls from `range().init` only in the host — a unit test constructing the object directly sees the same value either way.

### A named all-float struct lost its value crossing `ossia::value`

`to_ossia_value_impl` tests for field names *before* vec-compatibility, so a struct with 2/3/4 float members and `halp_field_names` encodes as a `value_map`. The inbound path tested the two in the opposite order, took the `vecNf` shortcut, and called `ossia::convert<vecNf>(map)` — which returns zeroes.

So the round trip silently dropped the data: a `std::vector` of such structs (the ordinary shape for detector or tracker output) arrived as a list of correctly-sized, entirely zero elements. Downstream code saw the right number of entries with every field at 0.

Maps are now routed through the field-order decoder in both the nested and the top-level overload. Unnamed all-float structs still encode as `vecNf` and are unaffected, as is a bare `vecNf` sent by an external source.

### Testing

Both directions are covered by a regression test in score (`Tests/from_ossia_value_Test.cpp`), which asserts the named struct round-trips, that an unnamed one still encodes as `vec3f`, and that a plain `vec3f` from an external sender still decodes into a named struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnNVzm2dPA5iHbSYKrpzZj