### PR TITLE
include <vector> where std::vector is used

### DIFF
--- a/examples/Advanced/AI/PromptComposer.hpp
+++ b/examples/Advanced/AI/PromptComposer.hpp
@@ -10,6 +10,7 @@
 #include <ossia/detail/small_vector.hpp>
 
 #include <algorithm>
+#include <vector>
 
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 

--- a/examples/Advanced/AI/PromptInterpolator.hpp
+++ b/examples/Advanced/AI/PromptInterpolator.hpp
@@ -10,6 +10,7 @@
 #include <ossia/detail/small_vector.hpp>
 
 #include <algorithm>
+#include <vector>
 
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 

--- a/examples/Advanced/Audio/AudioFilters.hpp
+++ b/examples/Advanced/Audio/AudioFilters.hpp
@@ -10,6 +10,8 @@
 #include <halp/mappers.hpp>
 #include <halp/meta.hpp>
 
+#include <vector>
+
 namespace Dsp
 {
 template <class StateType>

--- a/examples/Advanced/Audio/MonoMix.hpp
+++ b/examples/Advanced/Audio/MonoMix.hpp
@@ -5,6 +5,9 @@
 #include <halp/audio.hpp>
 #include <halp/meta.hpp>
 #include <halp/smooth_controls.hpp>
+
+#include <vector>
+
 namespace ao
 {
 class MonoMix

--- a/examples/Advanced/AudioParticles/AudioParticles.hpp
+++ b/examples/Advanced/AudioParticles/AudioParticles.hpp
@@ -7,6 +7,7 @@
 #include <rnd/random.hpp>
 
 #include <QFile>
+#include <vector>
 
 // Note: this example leverages a lot of built-in Qt & ossia score API features,
 // in particular to decode audio files on the fly.

--- a/examples/Advanced/Display/ColorDisplay.hpp
+++ b/examples/Advanced/Display/ColorDisplay.hpp
@@ -9,6 +9,7 @@
 #include <halp/layout.hpp>
 
 #include <cstdio>
+#include <vector>
 
 namespace dspl
 {

--- a/examples/Advanced/GeoZones/GeoZones.hpp
+++ b/examples/Advanced/GeoZones/GeoZones.hpp
@@ -8,6 +8,9 @@
 #include <ossia/detail/flat_map.hpp>
 #include <ossia/detail/flat_set.hpp>
 #include <ossia/network/value/value.hpp>
+
+#include <vector>
+
 namespace co
 {
 

--- a/examples/Advanced/Graph/Graph.hpp
+++ b/examples/Advanced/Graph/Graph.hpp
@@ -4,6 +4,8 @@
 
 #include <halp/meta.hpp>
 
+#include <vector>
+
 namespace grph
 {
 

--- a/examples/Advanced/Image/LightnessComputer.hpp
+++ b/examples/Advanced/Image/LightnessComputer.hpp
@@ -7,6 +7,7 @@
 #include <halp/texture.hpp>
 
 #include <chrono>
+#include <vector>
 
 #include <halp/controls.enums.hpp>
 

--- a/examples/Advanced/Image/LightnessSampler.hpp
+++ b/examples/Advanced/Image/LightnessSampler.hpp
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <algorithm>
+#include <vector>
 
 namespace vo
 {

--- a/examples/Advanced/MidiScaler/MidiReader.hpp
+++ b/examples/Advanced/MidiScaler/MidiReader.hpp
@@ -3,6 +3,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include <cmath>
+#include <vector>
 #include <halp/audio.hpp>
 #include <halp/controls.hpp>
 #include <halp/file_port.hpp>

--- a/examples/Advanced/MidiScaler/MidiScaler.hpp
+++ b/examples/Advanced/MidiScaler/MidiScaler.hpp
@@ -23,6 +23,7 @@
 #include <istream>
 #include <optional>
 #include <sstream>
+#include <vector>
 
 namespace mtk
 {

--- a/examples/Advanced/Parametriq/EQDiagram.hpp
+++ b/examples/Advanced/Parametriq/EQDiagram.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace utilities
 {

--- a/examples/Advanced/Patternal/Melodial.hpp
+++ b/examples/Advanced/Patternal/Melodial.hpp
@@ -5,6 +5,9 @@
 #include <halp/audio.hpp>
 #include <halp/meta.hpp>
 #include <halp/midi.hpp>
+
+#include <vector>
+
 namespace melodial
 {
 struct Note

--- a/examples/Advanced/Patternal/Patternal.hpp
+++ b/examples/Advanced/Patternal/Patternal.hpp
@@ -5,6 +5,9 @@
 #include <halp/audio.hpp>
 #include <halp/meta.hpp>
 #include <halp/midi.hpp>
+
+#include <vector>
+
 namespace patternal
 {
 

--- a/examples/Advanced/Spatialization/DBAP.hpp
+++ b/examples/Advanced/Spatialization/DBAP.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <boost/container/small_vector.hpp>
 #include <cmath>
+#include <vector>
 #include <halp/controls.hpp>
 #include <halp/dynamic_port.hpp>
 #include <halp/meta.hpp>

--- a/examples/Advanced/UI/2DView.hpp
+++ b/examples/Advanced/UI/2DView.hpp
@@ -18,6 +18,7 @@
 #include <score/application/GUIApplicationContext.hpp>
 
 #include <QPainter>
+#include <vector>
 namespace uo
 {
 struct Point2DView

--- a/examples/Advanced/UI/LEDView.hpp
+++ b/examples/Advanced/UI/LEDView.hpp
@@ -18,6 +18,7 @@
 #include <score/model/Skin.hpp>
 
 #include <QPainter>
+#include <vector>
 namespace uo
 {
 #if 0

--- a/examples/Advanced/UI/Widgets.hpp
+++ b/examples/Advanced/UI/Widgets.hpp
@@ -5,6 +5,8 @@
 #include <halp/meta.hpp>
 #include <ossia/network/value/value.hpp>
 
+#include <vector>
+
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 namespace uo

--- a/examples/Advanced/Utilities/ArrayCombiner.hpp
+++ b/examples/Advanced/Utilities/ArrayCombiner.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 #include <cmath>
+#include <vector>
 #include <halp/controls.hpp>
 #include <halp/dynamic_port.hpp>
 #include <halp/meta.hpp>

--- a/examples/Advanced/Utilities/ArrayFlattener.hpp
+++ b/examples/Advanced/Utilities/ArrayFlattener.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 #include <cmath>
+#include <vector>
 #include <halp/controls.hpp>
 #include <halp/dynamic_port.hpp>
 #include <halp/meta.hpp>

--- a/examples/Advanced/Utilities/ArrayRecombiner.hpp
+++ b/examples/Advanced/Utilities/ArrayRecombiner.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 #include <cmath>
+#include <vector>
 #include <halp/controls.hpp>
 #include <halp/dynamic_port.hpp>
 #include <halp/meta.hpp>

--- a/examples/Advanced/Utilities/ArrayTool.hpp
+++ b/examples/Advanced/Utilities/ArrayTool.hpp
@@ -2,6 +2,9 @@
 #include "MapTool.hpp"
 
 #include <halp/callback.hpp>
+
+#include <vector>
+
 namespace ao
 {
 /**

--- a/examples/Advanced/Utilities/Combine.hpp
+++ b/examples/Advanced/Utilities/Combine.hpp
@@ -4,6 +4,8 @@
 #include <halp/meta.hpp>
 #include <ossia/network/value/value.hpp>
 
+#include <vector>
+
 namespace ao
 {
 struct Combine

--- a/examples/Advanced/Utilities/Mapping.hpp
+++ b/examples/Advanced/Utilities/Mapping.hpp
@@ -9,6 +9,7 @@
 #include <halp/smoothers.hpp>
 
 #include <variant>
+#include <vector>
 
 namespace ao
 {

--- a/examples/Advanced/Utilities/Spread.hpp
+++ b/examples/Advanced/Utilities/Spread.hpp
@@ -4,6 +4,8 @@
 #include <halp/meta.hpp>
 #include <ossia/network/value/value.hpp>
 
+#include <vector>
+
 namespace ao
 {
 struct Spread

--- a/examples/Gpu/ArrayToBuffer.hpp
+++ b/examples/Gpu/ArrayToBuffer.hpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <variant>
+#include <vector>
 
 namespace uo
 {

--- a/examples/Gpu/BufferToArray.hpp
+++ b/examples/Gpu/BufferToArray.hpp
@@ -6,6 +6,8 @@
 #include <halp/controls.hpp>
 #include <halp/meta.hpp>
 
+#include <vector>
+
 namespace uo
 {
 struct BufferToArray

--- a/examples/Gpu/DrawRaw.hpp
+++ b/examples/Gpu/DrawRaw.hpp
@@ -4,6 +4,8 @@
 #include <gpp/meta.hpp>
 #include <gpp/ports.hpp>
 
+#include <vector>
+
 namespace examples
 {
 struct GpuRawExample

--- a/examples/Gpu/DrawWithHelpers.hpp
+++ b/examples/Gpu/DrawWithHelpers.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <avnd/common/member_reflection.hpp>
 #include <cmath>
+#include <vector>
 #include <gpp/commands.hpp>
 #include <gpp/meta.hpp>
 #include <gpp/ports.hpp>

--- a/examples/Helpers/FFTDisplay.hpp
+++ b/examples/Helpers/FFTDisplay.hpp
@@ -15,6 +15,7 @@
 
 #include <cstdio>
 #include <variant>
+#include <vector>
 
 namespace examples::helpers
 {

--- a/examples/Helpers/Gpu.hpp
+++ b/examples/Helpers/Gpu.hpp
@@ -16,6 +16,7 @@
 
 /*
 #include <cmath>
+#include <vector>
 #include <halp/audio.hpp>
 #include <halp/sample_accurate_controls.hpp>
 #include <halp/texture.hpp>

--- a/examples/Helpers/UiBus.hpp
+++ b/examples/Helpers/UiBus.hpp
@@ -14,6 +14,7 @@
 
 #include <cstdio>
 #include <variant>
+#include <vector>
 
 namespace examples::helpers
 {

--- a/examples/Helpers/ValueDelay.hpp
+++ b/examples/Helpers/ValueDelay.hpp
@@ -11,6 +11,8 @@
 #include <halp/log.hpp>
 #include <halp/meta.hpp>
 
+#include <vector>
+
 namespace examples::helpers
 {
 /**

--- a/examples/Tutorial/CubeGenerator.hpp
+++ b/examples/Tutorial/CubeGenerator.hpp
@@ -8,6 +8,7 @@
 #include <halp/meta.hpp>
 
 #include <cstring>
+#include <vector>
 
 namespace examples
 {

--- a/include/avnd/binding/clap/audio_effect.hpp
+++ b/include/avnd/binding/clap/audio_effect.hpp
@@ -18,6 +18,7 @@
 #include <clap/all.h>
 
 #include <algorithm>
+#include <vector>
 
 namespace avnd_clap
 {

--- a/include/avnd/binding/dump/DumpText.hpp
+++ b/include/avnd/binding/dump/DumpText.hpp
@@ -14,6 +14,8 @@
 #include <fmt/printf.h>
 #include <fmt/ranges.h>
 
+#include <vector>
+
 namespace dump_text
 {
 template <typename T>

--- a/include/avnd/binding/gstreamer/audio_sink.hpp
+++ b/include/avnd/binding/gstreamer/audio_sink.hpp
@@ -3,6 +3,8 @@
 #include <avnd/binding/gstreamer/utils.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 
+#include <vector>
+
 namespace gst
 {
 

--- a/include/avnd/binding/gstreamer/audio_source.hpp
+++ b/include/avnd/binding/gstreamer/audio_source.hpp
@@ -3,6 +3,7 @@
 #include <avnd/binding/gstreamer/utils.hpp>
 #include <avnd/wrappers/process_adapter.hpp>
 #include <cmath>
+#include <vector>
 
 namespace gst
 {

--- a/include/avnd/binding/max/from_atoms.hpp
+++ b/include/avnd/binding/max/from_atoms.hpp
@@ -14,6 +14,7 @@
 #include <ext.h>
 
 #include <string>
+#include <vector>
 
 namespace max
 {

--- a/include/avnd/binding/max/init.hpp
+++ b/include/avnd/binding/max/init.hpp
@@ -9,6 +9,7 @@
 
 #include <string_view>
 #include <variant>
+#include <vector>
 
 namespace max
 {

--- a/include/avnd/binding/max/messages.hpp
+++ b/include/avnd/binding/max/messages.hpp
@@ -6,6 +6,8 @@
 #include <avnd/binding/max/helpers.hpp>
 #include <avnd/introspection/messages.hpp>
 
+#include <vector>
+
 namespace max
 {
 template <typename T>

--- a/include/avnd/binding/ossia/callbacks.hpp
+++ b/include/avnd/binding/ossia/callbacks.hpp
@@ -3,6 +3,8 @@
 #include <ossia/dataflow/value_port.hpp>
 #include <tuplet/tuple.hpp>
 
+#include <vector>
+
 namespace oscr
 {
 

--- a/include/avnd/binding/ossia/data_node.hpp
+++ b/include/avnd/binding/ossia/data_node.hpp
@@ -2,6 +2,8 @@
 #include <avnd/binding/ossia/node.hpp>
 #include <avnd/concepts/temporality.hpp>
 
+#include <vector>
+
 namespace oscr
 {
 

--- a/include/avnd/binding/ossia/ffts.hpp
+++ b/include/avnd/binding/ossia/ffts.hpp
@@ -11,6 +11,8 @@
 #include <ossia/audio/fft.hpp>
 #include <ossia/dataflow/nodes/media.hpp>
 
+#include <vector>
+
 namespace oscr
 {
 template <typename Field>

--- a/include/avnd/binding/ossia/message_process.hpp
+++ b/include/avnd/binding/ossia/message_process.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <tuple>
+#include <vector>
 
 namespace oscr
 {

--- a/include/avnd/binding/ossia/ossia_dynamic_audio_node.hpp
+++ b/include/avnd/binding/ossia/ossia_dynamic_audio_node.hpp
@@ -1,5 +1,8 @@
 #pragma once
 #include <avnd/binding/ossia/node.hpp>
+
+#include <vector>
+
 namespace oscr
 {
 #if 0

--- a/include/avnd/binding/ossia/ossia_to_curve.hpp
+++ b/include/avnd/binding/ossia/ossia_to_curve.hpp
@@ -8,6 +8,7 @@
 #include <ossia/network/value/value_conversion.hpp>
 
 #include <optional>
+#include <vector>
 namespace oscr
 {
 struct convert_to_curve

--- a/include/avnd/binding/ossia/port_reload.hpp
+++ b/include/avnd/binding/ossia/port_reload.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include <avnd/binding/ossia/dynamic_ports.hpp>
 #include <avnd/binding/ossia/port_setup.hpp>
+
+#include <vector>
+
 namespace oscr
 {
 template <typename T>

--- a/include/avnd/binding/ossia/port_run_postprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_postprocess.hpp
@@ -13,6 +13,8 @@
 #include <ossia/dataflow/graph_node.hpp>
 #include <ossia/dataflow/port.hpp>
 
+#include <vector>
+
 namespace oscr
 {
 static inline auto& thread_local_midi_1to2_converter_instance()

--- a/include/avnd/binding/ossia/port_run_preprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_preprocess.hpp
@@ -22,6 +22,8 @@
 #include <ossia/network/base/parameter.hpp>
 #include <ossia/network/value/format_value.hpp>
 
+#include <vector>
+
 namespace oscr
 {
 template <typename Field, std::size_t Idx>

--- a/include/avnd/binding/ossia/port_setup.hpp
+++ b/include/avnd/binding/ossia/port_setup.hpp
@@ -11,6 +11,8 @@
 #include <ossia/network/dataspace/dataspace_visitors.hpp>
 #include <tuplet/tuple.hpp>
 
+#include <vector>
+
 namespace oscr
 {
 // Compile-time map of avnd concept to ossia port

--- a/include/avnd/binding/ossia/soundfiles.hpp
+++ b/include/avnd/binding/ossia/soundfiles.hpp
@@ -308,6 +308,7 @@ struct midifile_storage : midifile_input_storage<T>
 #if __has_include(<QFile>)
 #define OSCR_HAS_MMAP_FILE_STORAGE 1
 #include <QFile>
+#include <vector>
 namespace oscr
 {
 struct raw_file_data

--- a/include/avnd/binding/ossia/to_value.hpp
+++ b/include/avnd/binding/ossia/to_value.hpp
@@ -6,6 +6,8 @@
 #include <avnd/concepts/tensor.hpp>
 #include <ossia/network/value/value.hpp>
 
+#include <vector>
+
 namespace oscr
 {
 namespace tensor_detail

--- a/include/avnd/binding/pd/construct.hpp
+++ b/include/avnd/binding/pd/construct.hpp
@@ -9,6 +9,8 @@
 #include <boost/container/small_vector.hpp>
 #include <boost/variant2/variant.hpp>
 
+#include <vector>
+
 namespace pd
 {
 template <typename T>

--- a/include/avnd/binding/pd/init.hpp
+++ b/include/avnd/binding/pd/init.hpp
@@ -7,6 +7,8 @@
 #include <avnd/concepts/generic.hpp>
 #include <avnd/concepts/object.hpp>
 
+#include <vector>
+
 namespace pd
 {
 

--- a/include/avnd/binding/pd/inputs.hpp
+++ b/include/avnd/binding/pd/inputs.hpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <cmath>
 #include <mutex>
+#include <vector>
 namespace pd
 {
 

--- a/include/avnd/binding/standalone/oscquery_mapper.hpp
+++ b/include/avnd/binding/standalone/oscquery_mapper.hpp
@@ -19,6 +19,8 @@
 #include <ossia/protocols/midi/midi.hpp>
 #include <ossia/protocols/oscquery/oscquery_server_asio.hpp>
 
+#include <vector>
+
 namespace standalone
 {
 template <typename T>

--- a/include/avnd/binding/vintage/polyphonic_synth.hpp
+++ b/include/avnd/binding/vintage/polyphonic_synth.hpp
@@ -5,6 +5,8 @@
 #include <avnd/binding/vintage/helpers.hpp>
 #include <avnd/binding/vintage/vintage.hpp>
 
+#include <vector>
+
 namespace vintage
 {
 

--- a/include/avnd/common/optionals.hpp
+++ b/include/avnd/common/optionals.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <span>
 #include <type_traits>
+#include <vector>
 
 namespace avnd
 {

--- a/include/avnd/concepts/generic.hpp
+++ b/include/avnd/concepts/generic.hpp
@@ -8,6 +8,7 @@
 
 #include <string_view>
 #include <type_traits>
+#include <vector>
 
 namespace avnd
 {

--- a/include/avnd/introspection/midi.hpp
+++ b/include/avnd/introspection/midi.hpp
@@ -8,6 +8,8 @@
 #include <avnd/introspection/port.hpp>
 #include <boost/mp11.hpp>
 
+#include <vector>
+
 namespace avnd
 {
 

--- a/include/avnd/wrappers/controls_storage.hpp
+++ b/include/avnd/wrappers/controls_storage.hpp
@@ -8,6 +8,9 @@
 #include <avnd/introspection/output.hpp>
 #include <avnd/introspection/port.hpp>
 #include <boost/mp11.hpp>
+
+#include <vector>
+
 namespace avnd
 {
 // Field:

--- a/include/avnd/wrappers/soundfile_storage.hpp
+++ b/include/avnd/wrappers/soundfile_storage.hpp
@@ -9,6 +9,8 @@
 #include <avnd/introspection/port.hpp>
 #include <boost/mp11.hpp>
 
+#include <vector>
+
 namespace avnd
 {
 // Field: struct { struct { float** data; } soundfile; }

--- a/include/avnd/wrappers/tensor_shim.hpp
+++ b/include/avnd/wrappers/tensor_shim.hpp
@@ -30,6 +30,7 @@
 
 #if __has_include(<mdspan>)
 #include <mdspan>
+#include <vector>
 namespace std
 {
 template <typename T, typename Ext, typename L, typename A>

--- a/include/avnd/wrappers/widgets.hpp
+++ b/include/avnd/wrappers/widgets.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <vector>
 
 namespace avnd
 {


### PR DESCRIPTION
66 headers name `std::vector` without including `<vector>`. They compile against libstdc++, which still provides it transitively, and stop compiling as soon as the standard library does not.

clang 23.1.0 with libc++ is such a toolchain. Building ossia score against the current `ossia/sdk` continuous build, six of these fail with

```
error: no template named 'vector' in namespace 'std'; did you mean 'boost::container::vector'?
```

in `MonoMix`, `LightnessComputer`, `LightnessSampler`, `Melodial`, `Patternal` and `ArrayTool` — those six being the ones score's avnd plugin instantiates. The other 60 are the same shape, found by grep, and only escape today because nothing compiles them on that toolchain yet.

## The change

Purely additive: 66 include lines and 40 blank separators, nothing else — `git diff` has zero removed lines.

Placed per the existing convention: slotted alphabetically into the standard-header group where a file already has one, otherwise added as its own group after the project includes, the way `examples/Advanced/Audio/Soundfile.hpp` already does it.

## Verification

- **Confirmed fixed** on clang 23.1.0 + libc++ (Windows, ossia SDK): the six named above compile.
- **Confirmed neutral** on the toolchain to hand (clang 22, libstdc++): of these 66 headers, the same **19** pass `-fsyntax-only` before and after, **0 regressions**. The change is a no-op there, as expected — libstdc++ still pulls `<vector>` in transitively.
- The remaining 47 fail `-fsyntax-only` both before and after, on unrelated external dependencies (gstreamer, Max, clap, ossia, magic_enum). Not touched by this PR.

Only `<vector>` was swept. There may well be other include-what-you-use gaps of the same kind; this does not attempt to find them.