### PR TITLE
ossia: deduce a port's unit from the arity of its value

### DIFF
--- a/include/avnd/binding/ossia/port_setup.hpp
+++ b/include/avnd/binding/ossia/port_setup.hpp
@@ -358,7 +358,9 @@ struct setup_value_port
     port.domain = setup_value_port::range_to_domain<Field>();
   }
 
+  // These concepts nest: an xyzw value also satisfies xyz and xy.
   template <avnd::xy_parameter Field>
+    requires(!avnd::xyz_parameter<Field>)
   static void setup(ossia::value_port& port)
   {
     setup_port_is_event<Field>(port);
@@ -366,7 +368,34 @@ struct setup_value_port
     port.domain = setup_value_port::range_to_domain<Field>();
   }
 
+  template <avnd::xyz_parameter Field>
+    requires(!avnd::xyzw_parameter<Field>)
+  static void setup(ossia::value_port& port)
+  {
+    setup_port_is_event<Field>(port);
+    port.type = ossia::cartesian_3d_u{};
+    port.domain = setup_value_port::range_to_domain<Field>();
+  }
+
+  template <avnd::xyzw_parameter Field>
+  static void setup(ossia::value_port& port)
+  {
+    setup_port_is_event<Field>(port);
+    // No unit: orientation.axis is the only xyzw one and means something else.
+    port.type = ossia::val_type::VEC4F;
+    port.domain = setup_value_port::range_to_domain<Field>();
+  }
+
   template <avnd::rgb_parameter Field>
+    requires(!avnd::rgba_parameter<Field>)
+  static void setup(ossia::value_port& port)
+  {
+    setup_port_is_event<Field>(port);
+    port.type = ossia::rgb_u{};
+    port.domain = {};
+  }
+
+  template <avnd::rgba_parameter Field>
   static void setup(ossia::value_port& port)
   {
     setup_port_is_event<Field>(port);
@@ -400,6 +429,29 @@ struct setup_value_port
         port.is_event = true;
     }
   }
+
+  //! halp_meta(unit, "..."), which takes precedence over the shape of the value.
+  template <typename Field>
+  static void setup_declared_unit(ossia::value_port& port)
+  {
+    if constexpr(avnd::has_unit<Field>)
+    {
+      static constexpr auto unit = avnd::get_unit<Field>();
+      if(!unit.empty())
+      {
+        // Not parse_dataspace: that one only knows the eight dataspace names.
+        if(auto u = ossia::parse_pretty_unit(unit))
+          port.type = u;
+      }
+    }
+  }
+
+  template <typename Field>
+  static void setup_port(ossia::value_port& port)
+  {
+    setup_value_port{}.setup<Field>(port);
+    setup_declared_unit<Field>(port);
+  }
 };
 
 template <typename Exec_T>
@@ -414,14 +466,7 @@ struct setup_inlets
   {
     inlets.push_back(std::addressof(port));
 
-    setup_value_port{}.setup<Field>(*port);
-
-    if constexpr(avnd::has_unit<Field>)
-    {
-      static constexpr auto unit = avnd::get_unit<Field>();
-      if(!unit.empty())
-        port->type = ossia::parse_dataspace(unit);
-    }
+    setup_value_port::setup_port<Field>(*port);
   }
 
   template <std::size_t Idx, typename Field, typename OssiaPortType>
@@ -478,14 +523,7 @@ struct setup_outlets
   {
     outlets.push_back(std::addressof(port));
 
-    setup_value_port{}.setup<Field>(*port);
-
-    if constexpr(avnd::has_unit<Field>)
-    {
-      static constexpr auto unit = avnd::get_unit<Field>();
-      if(!unit.empty())
-        port->type = ossia::parse_dataspace(unit);
-    }
+    setup_value_port::setup_port<Field>(*port);
   }
 
   template <std::size_t Idx, typename Field, typename OssiaPortType>


### PR DESCRIPTION
The concepts behind the ossia binding's unit deduction nest: a value with
`x, y, z` also has `x, y`, and one with `r, g, b, a` also has `r, g, b`. There
was a single `xy_parameter` overload and a single `rgb_parameter` one, so every
three- and four-component port was declared to be in `position.cart2D`, and every
colour in `color.rgba`.

Each overload now excludes the wider ones, which is how the TouchDesigner binding
already chooses between `appendXY` / `appendXYZ` / `appendXYZW`:

| value | unit |
|---|---|
| `.x .y` | `cartesian_2d_u` — unchanged |
| `.x .y .z` | `cartesian_3d_u` |
| `.x .y .z .w` | no unit, `val_type::VEC4F` |
| `.r .g .b` | `rgb_u` |
| `.r .g .b .a` | `rgba_u` — unchanged |

`xyzw` deliberately gets no unit: the only four-component unit in ossia is
`orientation.axis`, and claiming axis-angle for a generic vec4 control would be
exactly the kind of wrong inference this fixes. The arity is what the conversion
machinery needs there.

Affected in score: TinyObj's `Position` / `Rotation` / `Scale`, Point Tracker 3D's
`Anchor`, and in the addons SolvePnP's object points. Nothing in tree declares a
three-component colour today, so the `rgb_u` branch is new ground.

### `halp_meta(unit, "...")`

That declaration went through `ossia::parse_dataspace`, which knows only the eight
dataspace names — so `"midipitch"`, `"distance.mm"`, `"color.rgb"` and everything
else a process might actually want to name resolved to an empty unit. It now goes
through `parse_pretty_unit`, which accepts all of those and answers with a concrete
unit rather than a dataspace with nothing picked inside it. A name that does not
parse leaves the port alone instead of wiping the value type deduced just above.

The only in-tree user is score's Pitch To Value (`unit, "midipitch"`), whose outlet
consequently gains a real unit (`time.midinote`) where it previously had none.

The two duplicated blocks in `setup_inlets` / `setup_outlets` are folded into one
`setup_value_port::setup_port<Field>()`, which is also what the test drives.

### Testing

Covered by a new test on the score side (`Avnd_port_unit_Test`, 16 assertions),
since that is where the binding is instantiated: arity for xy / xyz / xyzw and
rgb / rgba, a declared unit resolving, a declared unit winning over the shape of
the value, and a bare dataspace name giving its neutral unit. Reverting the
overload constraints fails 4 of its assertions; reverting the `parse_pretty_unit`
change fails 3 more.

A full score build is clean — every avnd process in the tree recompiles against
the new overloads.

### Ordering

Part of a three-repo change. This one stands alone; ossia/libossia and ossia/score
carry the rest, and the score PR needs all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197hSihNtB1bPw9WDUV3SR2
