### PR TITLE
ossia: make the live reload of dynamic ports safe

### DIFF
--- a/include/avnd/binding/ossia/node.hpp
+++ b/include/avnd/binding/ossia/node.hpp
@@ -404,10 +404,17 @@ public:
     this->control.inputs_set.set(N);
   }
 
+  // N is the index of the port in dynamic_ports_input_introspection<T>.
+  // The value is dropped if dynamic_port is out of range: the UI may send an
+  // update for a port that has just been removed, or before the port vector
+  // was resized here.
   template <typename Val, std::size_t N>
   void control_updated_from_ui(Val&& new_value, int dynamic_port)
   {
-    // FIXME how to combine dynamic_ports and control_input
+    if(dynamic_port < 0)
+      return;
+    const auto k = static_cast<std::size_t>(dynamic_port);
+
     if constexpr(requires { avnd::effect_container<T>::multi_instance; })
     {
       for(const auto& state : this->impl.full_state())
@@ -415,7 +422,9 @@ public:
         // Replace the value in the field
         auto& field = avnd::dynamic_ports_input_introspection<T>::template field<N>(
             state.inputs);
-        auto& port = field.ports[dynamic_port];
+        if(k >= field.ports.size())
+          continue;
+        auto& port = field.ports[k];
 
         // OPTIMIZEME we're loosing a few allocations here that should be gc'd
         port.value = new_value;
@@ -428,15 +437,18 @@ public:
       // Replace the value in the field
       auto& field = avnd::dynamic_ports_input_introspection<T>::template field<N>(
           this->impl.inputs());
-      auto& port = field.ports[dynamic_port];
+      if(k >= field.ports.size())
+        return;
+      auto& port = field.ports[k];
 
       std::swap(port.value, new_value);
 
       if_possible(port.update(this->impl.effect));
     }
 
-    // Mark the control as changed
-    this->control.inputs_set.set(N);
+    // Not marked in control.inputs_set: that bitset is indexed by control input
+    // (control_input_introspection), not by dynamic port, and with more dynamic
+    // ports than controls the index would fall outside the bitset.
   }
   void audio_configuration_changed(ossia::exec_state_facade st)
   {

--- a/include/avnd/binding/ossia/port_reload.hpp
+++ b/include/avnd/binding/ossia/port_reload.hpp
@@ -2,52 +2,88 @@
 #include <avnd/binding/ossia/dynamic_ports.hpp>
 #include <avnd/binding/ossia/port_setup.hpp>
 
+#include <algorithm>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace oscr
 {
+// Live reloading of the ports of a node whose dynamic port count changed.
+//
+// The exec node keeps its ossia ports as members (regular ports) or as vectors of
+// heap-allocated ports (dynamic ports). Replacing the dynamic ones has to be split
+// in two phases so that the execution thread never allocates or frees:
+//
+//  1. reload_inlets / reload_outlets, in the main thread: for every regular port,
+//     record its address; for every dynamic port, build a brand new vector of ports
+//     of the requested size. Both go in an {inlet,outlet}_reload_storage, which
+//     owns the new dynamic ports until they are handed over.
+//  2. apply_inlets / apply_outlets, in the execution thread: swap the new vectors
+//     into the node. Afterwards the storage owns the previous ports, and it must be
+//     destroyed in the main thread so that they are freed there.
+//
+// If phase 2 never runs (the node went away first), the storage still owns the
+// unused new ports and frees them.
+
+// Regular port: pointer to the port living in the node.
+// Dynamic port: a vector of ports, owned.
+template <typename T>
+struct reload_slot_type
+{
+  using type = T*;
+};
+template <typename T>
+struct reload_slot_type<std::vector<T*>>
+{
+  using type = std::vector<T*>;
+};
+template <typename T>
+using reload_slot_t = typename reload_slot_type<T>::type;
+
 template <typename T>
 struct inlet_reload_storage
 {
-  // Type of the "inputs" struct:
-  // struct inputs {
-  //   struct a: audio_in { } a;
-  //   struct b: audio_out { } b;
-  //   struct c: control_inlet { float value; } c;
-  // };
-  using inputs_type = typename avnd::inputs_type<T>::type;
-
   // typelist<a, b, c>
   using inputs_tuple = typename avnd::inputs_type<T>::tuple;
 
-  // inputs_getter<a> -> ossia::value_port
+  // inputs_getter<a> -> ossia::value_inlet* or std::vector<ossia::value_inlet*>
   template <typename Port>
-  using inputs_getter = typename get_ossia_inlet_type<T, Port>::type;
+  using inputs_getter = reload_slot_t<typename get_ossia_inlet_type<T, Port>::type>;
 
-  // tuple<ossia::audio_inlet, ossia::audio_outlet, ossia::value_inlet>
   using ossia_inputs_tuple = boost::mp11::mp_rename<
-      boost::mp11::mp_transform<
-          std::add_pointer_t, boost::mp11::mp_transform<inputs_getter, inputs_tuple>>,
-      tuplet::tuple>;
-  ossia_inputs_tuple ports;
+      boost::mp11::mp_transform<inputs_getter, inputs_tuple>, tuplet::tuple>;
+  ossia_inputs_tuple ports{};
+
+  inlet_reload_storage() = default;
+  inlet_reload_storage(const inlet_reload_storage&) = delete;
+  inlet_reload_storage& operator=(const inlet_reload_storage&) = delete;
+  inlet_reload_storage(inlet_reload_storage&&) = delete;
+  inlet_reload_storage& operator=(inlet_reload_storage&&) = delete;
+  ~inlet_reload_storage() { delete_dynamic_ports(ports); }
 };
 
 template <typename T>
 struct outlet_reload_storage
 {
-  using outputs_type = typename avnd::outputs_type<T>::type;
   using outputs_tuple = typename avnd::outputs_type<T>::tuple;
 
   template <typename Port>
-  using outputs_getter = typename get_ossia_outlet_type<T, Port>::type;
+  using outputs_getter = reload_slot_t<typename get_ossia_outlet_type<T, Port>::type>;
 
   using ossia_outputs_tuple = boost::mp11::mp_rename<
-      boost::mp11::mp_transform<
-          std::add_pointer_t, boost::mp11::mp_transform<outputs_getter, outputs_tuple>>,
-      tuplet::tuple>;
-  ossia_outputs_tuple ports;
+      boost::mp11::mp_transform<outputs_getter, outputs_tuple>, tuplet::tuple>;
+  ossia_outputs_tuple ports{};
+
+  outlet_reload_storage() = default;
+  outlet_reload_storage(const outlet_reload_storage&) = delete;
+  outlet_reload_storage& operator=(const outlet_reload_storage&) = delete;
+  outlet_reload_storage(outlet_reload_storage&&) = delete;
+  outlet_reload_storage& operator=(outlet_reload_storage&&) = delete;
+  ~outlet_reload_storage() { delete_dynamic_ports(ports); }
 };
 
+// Phase 1 (main thread)
 template <typename Exec_T>
 struct reload_inlets
 {
@@ -55,42 +91,58 @@ struct reload_inlets
   ossia::inlets& inlets;
   oscr::dynamic_ports_storage<typename Exec_T::processor_type>& dynamic_ports;
 
-  void operator()(auto ctrl, auto& port, auto*& pout) const noexcept
+  // Regular port: it stays where it is, in the node, and keeps the type,
+  // domain and unit it was given when the node was created. Only its address
+  // is taken: the exec thread may be reading it right now (the value domain
+  // owns memory), so nothing is written to it from here.
+  template <std::size_t Idx, typename Field, typename OssiaPortType>
+  void operator()(
+      avnd::field_reflection<Idx, Field>, OssiaPortType& port,
+      OssiaPortType*& pout) const noexcept
   {
-    setup_inlets{self, inlets}(ctrl, port);
+    inlets.push_back(std::addressof(port));
     pout = &port;
   }
 
+  // Dynamic port: a fresh set of ports, handed over in the exec thread
   template <std::size_t Idx, typename Field, typename OssiaPortType>
   void operator()(
       avnd::field_reflection<Idx, Field> ctrl, std::vector<OssiaPortType*>&,
-      std::vector<OssiaPortType*>*& pout) const noexcept
+      std::vector<OssiaPortType*>& out) const noexcept
   {
-    int expected = dynamic_ports.num_in_ports(avnd::field_index<Idx>{});
-    pout = new std::vector<OssiaPortType*>;
-    auto& port = *pout; //FIXME
-    while(port.size() < expected)
-      port.push_back(new OssiaPortType); // FIXME not freed
+    const int expected = std::max(0, dynamic_ports.num_in_ports(avnd::field_index<Idx>{}));
 
-    for(auto& p : port)
-      setup_inlets{self, inlets}(ctrl, *p);
+    for(auto p : out)
+      delete p;
+    out.clear();
+    out.reserve(expected);
+    for(int i = 0; i < expected; i++)
+      out.push_back(new OssiaPortType);
+
+    for(auto p : out)
+      setup_inlets<Exec_T>{self, inlets}(ctrl, *p);
   }
 };
 
+// Phase 2 (exec thread)
 template <typename Exec_T>
 struct apply_inlets
 {
   Exec_T& self;
   ossia::inlets& inlets;
 
-  void operator()(auto ctrl, auto& port, auto*& pout) const noexcept { }
+  template <std::size_t Idx, typename Field, typename OssiaPortType>
+  void operator()(
+      avnd::field_reflection<Idx, Field>, OssiaPortType&, OssiaPortType*&) const noexcept
+  {
+  }
 
   template <std::size_t Idx, typename Field, typename OssiaPortType>
   void operator()(
-      avnd::field_reflection<Idx, Field> ctrl, std::vector<OssiaPortType*>& port,
-      std::vector<OssiaPortType*>*& pout) const noexcept
+      avnd::field_reflection<Idx, Field>, std::vector<OssiaPortType*>& port,
+      std::vector<OssiaPortType*>& out) const noexcept
   {
-    std::swap(port, *pout);
+    std::swap(port, out);
   }
 };
 
@@ -101,25 +153,33 @@ struct reload_outlets
   ossia::outlets& outlets;
   oscr::dynamic_ports_storage<typename Exec_T::processor_type>& dynamic_ports;
 
-  void operator()(auto ctrl, auto& port, auto*& pout) const noexcept
+  // Regular port: see reload_inlets
+  template <std::size_t Idx, typename Field, typename OssiaPortType>
+  void operator()(
+      avnd::field_reflection<Idx, Field>, OssiaPortType& port,
+      OssiaPortType*& pout) const noexcept
   {
-    setup_outlets{self, outlets}(ctrl, port);
+    outlets.push_back(std::addressof(port));
     pout = &port;
   }
 
   template <std::size_t Idx, typename Field, typename OssiaPortType>
   void operator()(
       avnd::field_reflection<Idx, Field> ctrl, std::vector<OssiaPortType*>&,
-      std::vector<OssiaPortType*>*& pout) const noexcept
+      std::vector<OssiaPortType*>& out) const noexcept
   {
-    const std::size_t expected = dynamic_ports.num_out_ports(avnd::field_index<Idx>{});
-    pout = new std::vector<OssiaPortType*>;
-    auto& port = *pout; //FIXME
-    while(port.size() < expected)
-      port.push_back(new OssiaPortType); // FIXME not freed
+    const int expected
+        = std::max(0, dynamic_ports.num_out_ports(avnd::field_index<Idx>{}));
 
-    for(auto& p : port)
-      setup_outlets{self, outlets}(ctrl, *p);
+    for(auto p : out)
+      delete p;
+    out.clear();
+    out.reserve(expected);
+    for(int i = 0; i < expected; i++)
+      out.push_back(new OssiaPortType);
+
+    for(auto p : out)
+      setup_outlets<Exec_T>{self, outlets}(ctrl, *p);
   }
 };
 
@@ -129,14 +189,18 @@ struct apply_outlets
   Exec_T& self;
   ossia::outlets& outlets;
 
-  void operator()(auto ctrl, auto& port, auto*& pout) const noexcept { }
+  template <std::size_t Idx, typename Field, typename OssiaPortType>
+  void operator()(
+      avnd::field_reflection<Idx, Field>, OssiaPortType&, OssiaPortType*&) const noexcept
+  {
+  }
 
   template <std::size_t Idx, typename Field, typename OssiaPortType>
   void operator()(
-      avnd::field_reflection<Idx, Field> ctrl, std::vector<OssiaPortType*>& port,
-      std::vector<OssiaPortType*>*& pout) const noexcept
+      avnd::field_reflection<Idx, Field>, std::vector<OssiaPortType*>& port,
+      std::vector<OssiaPortType*>& out) const noexcept
   {
-    std::swap(port, *pout);
+    std::swap(port, out);
   }
 };
 }

--- a/include/avnd/binding/ossia/port_setup.hpp
+++ b/include/avnd/binding/ossia/port_setup.hpp
@@ -11,6 +11,10 @@
 #include <ossia/network/dataspace/dataspace_visitors.hpp>
 #include <tuplet/tuple.hpp>
 
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace oscr
@@ -176,6 +180,33 @@ struct get_ossia_outlet_type<N, T>
   using type = ossia::geometry_outlet;
 };
 
+template <typename Tuple, typename F, std::size_t... I>
+void for_each_port_slot_impl(Tuple& t, F&& f, std::index_sequence<I...>)
+{
+  (f(tuplet::get<I>(t)), ...);
+}
+template <typename Tuple, typename F>
+void for_each_port_slot(Tuple& t, F&& f)
+{
+  for_each_port_slot_impl(
+      t, f, std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<Tuple>>>{});
+}
+
+//! Frees the ports held in every vector slot of a port tuple: the dynamic
+//! ports are heap-allocated, the others are members of the tuple itself.
+template <typename Tuple>
+void delete_dynamic_ports(Tuple& t) noexcept
+{
+  for_each_port_slot(t, [](auto& slot) {
+    if constexpr(requires { slot.begin(); slot.clear(); })
+    {
+      for(auto p : slot)
+        delete p;
+      slot.clear();
+    }
+  });
+}
+
 template <typename T>
 struct inlet_storage
 {
@@ -198,6 +229,11 @@ struct inlet_storage
   using ossia_inputs_tuple = boost::mp11::mp_rename<
       boost::mp11::mp_transform<inputs_getter, inputs_tuple>, tuplet::tuple>;
   ossia_inputs_tuple ports;
+
+  inlet_storage() = default;
+  inlet_storage(const inlet_storage&) = delete;
+  inlet_storage& operator=(const inlet_storage&) = delete;
+  ~inlet_storage() { delete_dynamic_ports(ports); }
 };
 
 template <typename T>
@@ -212,6 +248,11 @@ struct outlet_storage
   using ossia_outputs_tuple = boost::mp11::mp_rename<
       boost::mp11::mp_transform<outputs_getter, outputs_tuple>, tuplet::tuple>;
   ossia_outputs_tuple ports;
+
+  outlet_storage() = default;
+  outlet_storage(const outlet_storage&) = delete;
+  outlet_storage& operator=(const outlet_storage&) = delete;
+  ~outlet_storage() { delete_dynamic_ports(ports); }
 };
 
 struct setup_value_port
@@ -476,11 +517,15 @@ struct setup_inlets
       avnd::field_reflection<Idx, Field> ctrl,
       std::vector<OssiaPortType*>& port) const noexcept
   {
-    int expected = self.dynamic_ports.num_in_ports(avnd::field_index<Idx>{});
-    while(port.size() < expected)
-      port.push_back(new OssiaPortType); // FIXME not freed
-    while(port.size() > expected)
+    const int expected
+        = std::max(0, self.dynamic_ports.num_in_ports(avnd::field_index<Idx>{}));
+    while(std::ssize(port) < expected)
+      port.push_back(new OssiaPortType); // Freed by inlet_storage / delete_dynamic_ports
+    while(std::ssize(port) > expected)
+    {
+      delete port.back();
       port.pop_back();
+    }
 
     for(auto& p : port)
       (*this)(ctrl, *p);
@@ -533,12 +578,15 @@ struct setup_outlets
       avnd::field_reflection<Idx, Field> ctrl,
       std::vector<OssiaPortType*>& port) const noexcept
   {
-    const std::size_t expected
-        = self.dynamic_ports.num_out_ports(avnd::field_index<Idx>{});
-    while(port.size() < expected)
-      port.push_back(new OssiaPortType); // FIXME not freed
-    while(port.size() > expected)
+    const int expected
+        = std::max(0, self.dynamic_ports.num_out_ports(avnd::field_index<Idx>{}));
+    while(std::ssize(port) < expected)
+      port.push_back(new OssiaPortType); // Freed by outlet_storage / delete_dynamic_ports
+    while(std::ssize(port) > expected)
+    {
+      delete port.back();
       port.pop_back();
+    }
 
     for(auto& p : port)
       (*this)(ctrl, *p);


### PR DESCRIPTION
Companion to ossia/score#1969 (dynamic ports resized while the document executes).

The ossia binding rebuilds the ports of a running node in place when a dynamic port group is resized (`port_reload.hpp`). This makes that path memory- and thread-safe:

- **port_reload**: the reload storage owns the new dynamic ports until the execution thread swaps them in, and the previous ones afterwards, so both sets are freed in the main thread (they used to leak, along with their vectors). Regular ports keep their setup: they are only recorded, not set up again from the main thread while the audio thread reads them.
- **port_setup**: `inlet_storage` / `outlet_storage` free their dynamic ports; shrinking a group frees the ports it drops instead of leaking them.
- **node**: `control_updated_from_ui` bounds-checks the dynamic port index (a UI value may target a port that was just removed, or arrive before the vector was resized) and no longer sets `control.inputs_set`, which is indexed by control input, not by dynamic port. With more dynamic groups than controls (e.g. `ValueMixer`: 4 groups, 2 controls) `std::bitset::set` threw `out_of_range` in the audio thread.

Exercised by the tests added in ossia/score#1969 (`tests/unit/AvndDynamicPorts*Test.cpp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WggknMW5E7bxmHnuXGEMpA
