### PR TITLE
ossia: reuse value conversion storage

### DIFF
--- a/cmake/avendish.tests.cmake
+++ b/cmake/avendish.tests.cmake
@@ -50,6 +50,11 @@ if(BUILD_TESTING)
   avnd_add_catch_test(test_gain tests/objects/gain.cpp)
   avnd_add_catch_test(test_patternal tests/objects/patternal.cpp)
 
+  if(TARGET ossia::ossia)
+    avnd_add_catch_test(test_ossia_values tests/test_ossia_values.cpp)
+    target_link_libraries(test_ossia_values PRIVATE ossia::ossia)
+  endif()
+
   # Polyphony: one effect instance per channel, each seeing only its own
   # samples (a binding calling init_channels with the compile-time count made
   # channel 1 a copy of channel 0).

--- a/include/avnd/binding/ossia/from_value.hpp
+++ b/include/avnd/binding/ossia/from_value.hpp
@@ -12,6 +12,7 @@
 #include <ossia/network/value/value.hpp>
 #include <ossia/network/value/value_conversion.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <type_traits>
 #include <vector>
@@ -112,30 +113,30 @@ using is_float = std::is_same<float, T>;
 // FIXME find better ways
 template <typename T>
 using is_vec2f = std::integral_constant<bool, requires(T t) {
-                                                T{0.f, 0.f};
-                                              } && sizeof(T) == 2 * sizeof(float)>;
+  T{0.f, 0.f};
+} && sizeof(T) == 2 * sizeof(float)>;
 template <typename T>
 using is_vec3f = std::integral_constant<bool, requires(T t) {
-                                                T{0.f, 0.f, 0.f};
-                                              } && sizeof(T) == 3 * sizeof(float)>;
+  T{0.f, 0.f, 0.f};
+} && sizeof(T) == 3 * sizeof(float)>;
 template <typename T>
 using is_vec4f = std::integral_constant<bool, requires(T t) {
-                                                T{0.f, 0.f, 0.f, 0.f};
-                                              } && sizeof(T) == 4 * sizeof(float)>;
+  T{0.f, 0.f, 0.f, 0.f};
+} && sizeof(T) == 4 * sizeof(float)>;
 template <typename T>
 using is_vecNf = std::integral_constant<bool, avnd::vector_v_strict<T, float>>;
 template <typename T>
 using is_vec2d = std::integral_constant<bool, requires(T t) {
-                                                T{0., 0.};
-                                              } && sizeof(T) == 2 * sizeof(double)>;
+  T{0., 0.};
+} && sizeof(T) == 2 * sizeof(double)>;
 template <typename T>
 using is_vec3d = std::integral_constant<bool, requires(T t) {
-                                                T{0., 0., 0.};
-                                              } && sizeof(T) == 3 * sizeof(double)>;
+  T{0., 0., 0.};
+} && sizeof(T) == 3 * sizeof(double)>;
 template <typename T>
 using is_vec4d = std::integral_constant<bool, requires(T t) {
-                                                T{0., 0., 0., 0.};
-                                              } && sizeof(T) == 4 * sizeof(double)>;
+  T{0., 0., 0., 0.};
+} && sizeof(T) == 4 * sizeof(double)>;
 template <typename T>
 using is_vecNd = std::integral_constant<bool, avnd::vector_v_strict<T, double>>;
 template <typename T>
@@ -145,6 +146,9 @@ using is_large_enough_int = std::integral_constant<
     bool, std::is_integral_v<T> && std::is_signed_v<T> && sizeof(T) >= 4>;
 template <typename T>
 using is_string = std::is_same<std::string, T>;
+template <typename T>
+using is_owning_string = std::bool_constant<avnd::string_ish<T>&& requires(
+    T& t, const char* data, std::size_t size) { t.assign(data, size); }>;
 template <typename T>
 using is_bool = std::is_same<bool, T>;
 template <typename T>
@@ -186,6 +190,8 @@ template <typename T>
 using is_large_enough_int_vector = predicate_vector<is_large_enough_int, T>;
 template <typename T>
 using is_string_vector = predicate_vector<is_string, T>;
+template <typename T>
+using is_owning_string_vector = predicate_vector<is_owning_string, T>;
 template <typename T>
 using is_bool_vector = predicate_vector<is_bool, T>;
 template <typename T>
@@ -342,8 +348,8 @@ struct from_ossia_value_impl
   }
 
   template <typename F>
-    requires(std::is_aggregate_v<F> && !avnd::tensor_like<F>) bool
-  operator()(const ossia::value& src, F& dst)
+    requires(std::is_aggregate_v<F> && !avnd::tensor_like<F>)
+  bool operator()(const ossia::value& src, F& dst)
   {
     constexpr int sz = avnd::pfr::tuple_size_v<F>;
     if constexpr(avnd::vecf_compatible<F>())
@@ -384,24 +390,24 @@ struct from_ossia_value_impl
   }
 
   template <typename F>
-    requires(avnd::optional_ish<F>) bool
-  operator()(const ossia::value& src, F& dst)
+    requires(avnd::optional_ish<F>)
+  bool operator()(const ossia::value& src, F& dst)
   {
     dst = F{std::in_place};
     return true;
   }
 
   template <typename F>
-    requires(std::is_integral_v<F>) bool
-  operator()(const ossia::value& src, F& f)
+    requires(std::is_integral_v<F>)
+  bool operator()(const ossia::value& src, F& f)
   {
     f = ossia::convert<int>(src);
     return true;
   }
 
   template <typename F>
-    requires(std::is_floating_point_v<F>) bool
-  operator()(const ossia::value& src, F& f)
+    requires(std::is_floating_point_v<F>)
+  bool operator()(const ossia::value& src, F& f)
   {
     f = ossia::convert<float>(src);
     return true;
@@ -419,9 +425,17 @@ struct from_ossia_value_impl
     return true;
   }
 
-  bool operator()(const ossia::value& src, std::string& f)
+  template <avnd::string_ish T>
+    requires is_owning_string<T>::value
+  bool operator()(const ossia::value& src, T& f)
   {
-    f = ossia::convert<std::string>(src);
+    if(auto str = src.target<std::string>())
+      f.assign(str->data(), str->size());
+    else
+    {
+      auto converted = ossia::convert<std::string>(src);
+      f.assign(converted.data(), converted.size());
+    }
     return true;
   }
 
@@ -496,6 +510,28 @@ struct from_ossia_value_impl
     }
   }
 
+  template <typename Selected, typename Variant, typename Convert>
+  void assign_variant(Variant& dst, Convert&& convert)
+  {
+    // Keep an active owning string's allocator and capacity, and a map's
+    // allocator and reserved buckets. ADL supports std and boost variants.
+    bool assigned = false;
+    if(!dst.valueless_by_exception())
+      visit([&](auto& current) {
+        if constexpr(std::is_same_v<std::remove_cvref_t<decltype(current)>, Selected>)
+        {
+          convert(current);
+          assigned = true;
+        }
+      }, dst);
+    if(!assigned)
+    {
+      Selected next;
+      convert(next);
+      dst = std::move(next);
+    }
+  }
+
 #define CHECK_PREDICATE(Pred)                              \
   typedef boost::mp11::mp_find_if<T<Args...>, Pred> index; \
   (!std::is_same_v<index, sz>)
@@ -511,19 +547,11 @@ struct from_ossia_value_impl
     return true;                                            \
   }
 
-#define APPLY_MAP_PREDICATE                                 \
-  {                                                         \
-    using var_type = boost::mp11::mp_at<T<Args...>, index>; \
-    var_type t;                                             \
-    if_possible(t.reserve(srcmap.size()));                  \
-    for(const auto& [k, v] : srcmap)                        \
-    {                                                       \
-      typename var_type::mapped_type res_v;                 \
-      (*this)(v, res_v);                                    \
-      t.emplace(k, std::move(res_v));                       \
-    }                                                       \
-    f = std::move(t);                                       \
-    return true;                                            \
+#define APPLY_MAP_PREDICATE                                             \
+  {                                                                     \
+    using var_type = boost::mp11::mp_at<T<Args...>, index>;             \
+    assign_variant<var_type>(f, [&](var_type& t) { (*this)(src, t); }); \
+    return true;                                                        \
   }
 
   template <template <typename...> typename T, typename... Args>
@@ -575,7 +603,7 @@ struct from_ossia_value_impl
         else if constexpr(CHECK_PREDICATE(is_variant_vector))
           APPLY_VEC_PREDICATE
         else // FIXME maybe if the type has a generic assignable variant-ihs data type?
-            // FIXME or something like a matrix type, e.g. vector<vector<float>> ?
+          // FIXME or something like a matrix type, e.g. vector<vector<float>> ?
           return false;
         break;
       }
@@ -634,6 +662,8 @@ struct from_ossia_value_impl
       case ossia::val_type::STRING: {
         // FIXME bitset?
         if constexpr(CHECK_PREDICATE(is_string_vector))
+          APPLY_VEC_PREDICATE
+        else if constexpr(CHECK_PREDICATE(is_owning_string_vector))
           APPLY_VEC_PREDICATE
 
         else if constexpr(CHECK_PREDICATE(is_variant_vector))
@@ -694,8 +724,8 @@ struct from_ossia_value_impl
   }
 
   template <template <typename...> typename T, typename... Args>
-    requires avnd::variant_ish<T<Args...>> bool
-  operator()(const ossia::value& src, T<Args...>& f)
+    requires avnd::variant_ish<T<Args...>>
+  bool operator()(const ossia::value& src, T<Args...>& f)
   {
     using sz = boost::mp11::mp_size<T<Args...>>;
     using namespace boost::mp11;
@@ -784,6 +814,12 @@ struct from_ossia_value_impl
           f = *src.target<std::string>();
           return true;
         }
+        else if constexpr(CHECK_PREDICATE(is_owning_string))
+        {
+          using string_type = mp_at<T<Args...>, index>;
+          assign_variant<string_type>(f, [&](string_type& str) { (*this)(src, str); });
+          return true;
+        }
         else
         {
           return false;
@@ -843,7 +879,6 @@ struct from_ossia_value_impl
       }
       case ossia::val_type::MAP: {
         // FIXME do the specific cases, e.g. map<string, int>, etc
-        auto& srcmap = *src.target<ossia::value_map_type>();
         if constexpr(CHECK_PREDICATE(is_map_ish))
           APPLY_MAP_PREDICATE
         else
@@ -953,7 +988,7 @@ struct from_ossia_value_impl
         {
           typename T::value_type res;
           (*this)(val, res);
-          f.push_back(res);
+          f.push_back(std::move(res));
         }
         return true;
         break;
@@ -1135,17 +1170,17 @@ struct from_ossia_value_impl
   template <
       template <typename, std::size_t, typename...> typename T, typename Val,
       std::size_t N>
-    requires avnd::array_ish<T<Val, N>, N>
-             && (!avnd::string_ish<T<Val, N>>) && (!avnd::vector_ish<T<Val, N>>)bool
-  operator()(const ossia::value& src, T<Val, N>& f)
+    requires avnd::array_ish<T<Val, N>, N> && (!avnd::string_ish<T<Val, N>>)
+             && (!avnd::vector_ish<T<Val, N>>)
+  bool operator()(const ossia::value& src, T<Val, N>& f)
   {
     return from_array<N>(src, f);
   }
 
   template <template <std::size_t, typename...> typename T, std::size_t N>
     requires avnd::array_ish<T<N>, N> && (!avnd::string_ish<T<N>>)
-             && (!avnd::vector_ish<T<N>>) && (!avnd::bitset_ish<T<N>>)bool
-  operator()(const ossia::value& src, T<N>& f)
+             && (!avnd::vector_ish<T<N>>) && (!avnd::bitset_ish<T<N>>)
+  bool operator()(const ossia::value& src, T<N>& f)
   {
     return from_array<N>(src, f);
   }
@@ -1288,13 +1323,32 @@ struct from_ossia_value_impl
       const ossia::value_map_type& v = *ptr;
 
       f.clear();
-      if_possible(f.reserve(v.size()));
+      if constexpr(requires {
+                     f.bucket_count();
+                     f.max_load_factor();
+                   })
+      {
+        if(v.size() > f.bucket_count() * f.max_load_factor())
+          f.reserve(v.size());
+      }
+      else
+      {
+        if_possible(f.reserve(v.size()));
+      }
 
       for(auto& [key, val] : v)
       {
         using target_key_type = typename T::key_type;
         using target_value_type = typename T::mapped_type;
-        if constexpr(std::is_constructible_v<target_key_type, std::string>)
+        if constexpr(
+            avnd::string_ish<target_key_type>
+            && std::is_constructible_v<target_key_type, std::string_view>)
+        {
+          target_value_type map_v{};
+          from_ossia_value_impl{}(val, map_v);
+          f.emplace(std::string_view{key}, std::move(map_v));
+        }
+        else if constexpr(std::is_constructible_v<target_key_type, std::string>)
         {
           target_value_type map_v{};
           from_ossia_value_impl{}(val, map_v);
@@ -1443,7 +1497,10 @@ OSSIA_INLINE bool from_ossia_value(const ossia::value& src, T& dst)
 template <avnd::string_ish T>
 OSSIA_INLINE bool from_ossia_value(const ossia::value& src, T& dst)
 {
-  dst = ossia::convert<std::string>(src);
+  if constexpr(is_owning_string<T>::value)
+    return from_ossia_value_impl{}(src, dst);
+  else
+    dst = ossia::convert<std::string>(src);
   return true;
 }
 
@@ -1477,7 +1534,7 @@ inline bool from_ossia_value(const ossia::value& src, std::string& dst)
 {
   if(auto p = src.target<std::string>())
   {
-    dst = std::move(*p);
+    dst = *p;
     return true;
   }
   else
@@ -1490,36 +1547,113 @@ inline bool from_ossia_value(const ossia::value& src, std::string& dst)
 template <
     template <typename, std::size_t, typename...> typename T, typename Val,
     std::size_t N>
-  requires avnd::array_ish<T<Val, N>, N> && (!avnd::string_ish<T<Val, N>>)bool
-from_ossia_value(const ossia::value& src, T<Val, N>& dst)
+  requires avnd::array_ish<T<Val, N>, N> && (!avnd::string_ish<T<Val, N>>)
+bool from_ossia_value(const ossia::value& src, T<Val, N>& dst)
 {
   return from_ossia_value_impl{}(src, dst);
 }
 
 template <template <std::size_t, typename...> typename T, std::size_t N>
-  requires avnd::array_ish<T<N>, N> && (!avnd::string_ish<T<N>>)bool
-from_ossia_value(const ossia::value& src, T<N>& dst)
+  requires avnd::array_ish<T<N>, N> && (!avnd::string_ish<T<N>>)
+bool from_ossia_value(const ossia::value& src, T<N>& dst)
 {
   return from_ossia_value_impl{}(src, dst);
 }
 
 template <typename T>
-  requires(!avnd::type_wrapper<T> && (
-      avnd::variant_ish<T> || avnd::set_ish<T> || avnd::map_ish<T> || avnd::bitset_ish<T>
-      || avnd::pair_ish<T> || avnd::tuple_ish<T> || avnd::iterable_ish<T>
-      || (avnd::vector_ish<T> && !avnd::string_ish<T>)))
+  requires(
+      !avnd::type_wrapper<T> && !avnd::string_ish<T>
+      && (avnd::variant_ish<T> || avnd::set_ish<T> || avnd::map_ish<T>
+          || avnd::bitset_ish<T> || avnd::pair_ish<T> || avnd::tuple_ish<T>
+          || avnd::iterable_ish<T> || (avnd::vector_ish<T> && !avnd::string_ish<T>)))
 bool from_ossia_value(const ossia::value& src, T& dst)
 {
   return from_ossia_value_impl{}(src, dst);
 }
+namespace detail
+{
+inline bool
+contains_value(const std::vector<ossia::value>& values, const ossia::value* target);
+inline bool
+contains_value(const ossia::value_map_type& values, const ossia::value* target);
+
+inline bool contains_value(const ossia::value& value, const ossia::value* target)
+{
+  if(&value == target)
+    return true;
+  if(auto list = value.target<std::vector<ossia::value>>())
+    return contains_value(*list, target);
+  if(auto map = value.target<ossia::value_map_type>())
+    return contains_value(*map, target);
+  return false;
+}
+
+inline bool
+contains_value(const std::vector<ossia::value>& values, const ossia::value* target)
+{
+  return std::ranges::any_of(
+      values, [target](const auto& value) { return contains_value(value, target); });
+}
+
+inline bool
+contains_value(const ossia::value_map_type& values, const ossia::value* target)
+{
+  return std::ranges::any_of(values, [target](const auto& entry) {
+    return contains_value(entry.second, target);
+  });
+}
+
+template <typename Container>
+inline bool contains_container(const ossia::value& value, const Container* target)
+{
+  if(auto container = value.target<Container>(); container == target)
+    return true;
+  if(auto list = value.target<std::vector<ossia::value>>())
+    return std::ranges::any_of(*list, [target](const auto& child) {
+      return contains_container(child, target);
+    });
+  if(auto map = value.target<ossia::value_map_type>())
+    return std::ranges::any_of(*map, [target](const auto& entry) {
+      return contains_container(entry.second, target);
+    });
+  return false;
+}
+}
+
 inline bool from_ossia_value(const ossia::value& src, std::vector<ossia::value>& dst)
 {
-  dst = ossia::convert<std::vector<ossia::value>>(src);
+  if(auto list = src.target<std::vector<ossia::value>>(); list)
+  {
+    if(list == &dst)
+      return true;
+    if(detail::contains_value(dst, &src) || detail::contains_container(src, &dst))
+    {
+      auto snapshot = *list;
+      dst = std::move(snapshot);
+    }
+    else
+      dst = *list;
+  }
+  else
+    dst = ossia::convert<std::vector<ossia::value>>(src);
   return true;
 }
 inline bool from_ossia_value(const ossia::value& src, ossia::value_map_type& dst)
 {
-  dst = ossia::convert<ossia::value_map_type>(src);
+  if(auto map = src.target<ossia::value_map_type>(); map)
+  {
+    if(map == &dst)
+      return true;
+    if(detail::contains_value(dst, &src) || detail::contains_container(src, &dst))
+    {
+      auto snapshot = *map;
+      dst = std::move(snapshot);
+    }
+    else
+      dst = *map;
+  }
+  else
+    dst = ossia::convert<ossia::value_map_type>(src);
   return true;
 }
 template <avnd::optional_ish T>
@@ -1588,10 +1722,7 @@ OSSIA_INLINE void from_ossia_value(auto& field, const ossia::value& src, auto& d
 template <avnd::enum_ish_parameter Field, typename Val>
 struct enum_from_ossia_visitor
 {
-  Val operator()(const float& v) const noexcept
-  {
-    return (*this)(int(v));
-  }
+  Val operator()(const float& v) const noexcept { return (*this)(int(v)); }
 
   Val operator()(const int& v) const noexcept
   {
@@ -1696,9 +1827,7 @@ inline void fill_tensor_data(
     {
       for(std::size_t i = 0; i < depth_size; ++i)
         data[out_idx++]
-            = i < list->size()
-                  ? static_cast<T>(ossia::convert<float>((*list)[i]))
-                  : T{};
+            = i < list->size() ? static_cast<T>(ossia::convert<float>((*list)[i])) : T{};
     }
     else
     {
@@ -1720,7 +1849,7 @@ inline void fill_tensor_data(
         data[out_idx++] = T{};
   }
 }
-}  // namespace tensor_detail
+} // namespace tensor_detail
 
 template <typename T>
   requires avnd::view_tensor_like<T>
@@ -1741,8 +1870,7 @@ inline bool from_ossia_value(const ossia::value& src, T& dst)
   std::size_t idx = 0;
   tensor_detail::fill_tensor_data(src, buf->data(), shape, 0, idx);
   avnd::set_view_buffer(
-      dst, buf->data(), std::move(shape),
-      std::shared_ptr<void>(buf, buf->data()));
+      dst, buf->data(), std::move(shape), std::shared_ptr<void>(buf, buf->data()));
   return true;
 }
 
@@ -1762,7 +1890,6 @@ inline bool from_ossia_value(const ossia::value& src, T& dst)
   tensor_detail::fill_tensor_data(src, data, shape, 0, idx);
   return true;
 }
-
 
 template <typename arg_t>
 static constexpr ossia::val_type type_for_arg()

--- a/include/avnd/binding/ossia/to_value.hpp
+++ b/include/avnd/binding/ossia/to_value.hpp
@@ -40,8 +40,7 @@ inline ossia::value build_tensor_value(
   }
   return result;
 }
-}  // namespace tensor_detail
-
+} // namespace tensor_detail
 
 struct to_ossia_value_impl
 {
@@ -55,8 +54,7 @@ struct to_ossia_value_impl
     v.resize(fields);
 
     int k = 0;
-    avnd::pfr::for_each_field(
-        f, [&](const auto& f) { to_ossia_value_impl{v[k++]}(f); });
+    avnd::pfr::for_each_field(f, [&](const auto& f) { to_ossia_value_impl{v[k++]}(f); });
 
     val = std::move(v);
   }
@@ -139,6 +137,8 @@ struct to_ossia_value_impl
 
   void operator()(const std::string& f) { val = f; }
 
+  void operator()(const avnd::string_ish auto& f) { (*this)(std::string_view{f}); }
+
   void operator()(bool f) { val = f; }
 
   template <template <typename> typename T, typename V>
@@ -181,7 +181,11 @@ struct to_ossia_value_impl
     val = std::vector<ossia::value>(f.begin(), f.end());
   }
 
-  void operator()(const avnd::vector_ish auto& f)
+  template <avnd::vector_ish T>
+    requires(
+        !avnd::string_ish<T> && !avnd::vector_v_strict<T, int>
+        && !avnd::vector_v_strict<T, float>)
+  void operator()(const T& f)
   {
     std::vector<ossia::value> v;
     v.resize(f.size());
@@ -280,9 +284,9 @@ struct to_ossia_value_impl
     std::vector<ossia::value> v;
     v.resize(std::tuple_size_v<U>);
 
-    std::apply(
-        [&, k = 0](auto&&... args) mutable { (to_ossia_value_impl{v[k++]}(args), ...); },
-        f);
+    std::apply([&, k = 0](auto&&... args) mutable {
+      (to_ossia_value_impl{v[k++]}(args), ...);
+    }, f);
     val = std::move(v);
   }
 
@@ -322,7 +326,8 @@ struct to_ossia_value_impl
   void operator()(const T& f)
   {
     using key_type = typename T::key_type;
-    if constexpr(std::is_convertible_v<key_type, std::string>)
+    if constexpr(
+        avnd::string_ish<key_type> || std::is_convertible_v<key_type, std::string>)
     {
       ossia::value_map_type v;
       v.reserve(f.size());
@@ -332,7 +337,10 @@ struct to_ossia_value_impl
         ossia::value sub;
         to_ossia_value_impl{sub}(map_v);
 
-        v.emplace_back(map_k, std::move(sub));
+        if constexpr(avnd::string_ish<key_type>)
+          v.emplace_back(std::string_view{map_k}, std::move(sub));
+        else
+          v.emplace_back(map_k, std::move(sub));
       }
       val = std::move(v);
     }
@@ -527,8 +535,8 @@ ossia::value to_ossia_value(const std::floating_point auto& v)
 {
   return (float)v;
 }
-template<avnd::variant_ish T>
-  requires (!avnd::type_wrapper<T>)
+template <avnd::variant_ish T>
+  requires(!avnd::type_wrapper<T>)
 ossia::value to_ossia_value(const T& v)
 {
   return to_ossia_value_rec(v);

--- a/tests/test_ossia_values.cpp
+++ b/tests/test_ossia_values.cpp
@@ -2,24 +2,31 @@
 #include <avnd/binding/ossia/to_value.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
+#include <boost/variant2/variant.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <array>
+#include <bitset>
+#include <cstdlib>
+#include <list>
 #include <map>
+#include <memory_resource>
+#include <new>
 #include <set>
-#include <vector>
-
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
+#include <vector>
 
-void test()
+TEST_CASE("ossia scalar and container roundtrips")
 {
   using namespace avnd;
   using namespace oscr;
   auto test = []<typename T>(T v) {
     ossia::value val = to_ossia_value(v);
     T t;
-    SCORE_ASSERT(from_ossia_value(val, t));
-    SCORE_ASSERT(t == v);
+    REQUIRE(from_ossia_value(val, t));
+    REQUIRE(t == v);
     return t;
   };
 
@@ -70,4 +77,317 @@ void test()
           {{1, 2}, {3, 4}},
           {"foo", "bar"},
           {{1, "foo"}, {3, "bar"}}});
+}
+
+namespace
+{
+thread_local bool count_new = false;
+thread_local std::size_t new_calls = 0;
+
+template <typename F>
+std::size_t allocations_during(F&& f)
+{
+  struct guard
+  {
+    guard()
+    {
+      new_calls = 0;
+      count_new = true;
+    }
+    ~guard() { count_new = false; }
+  } g;
+  f();
+  return new_calls;
+}
+
+struct counting_resource final : std::pmr::memory_resource
+{
+  std::size_t allocations{};
+
+  void* do_allocate(std::size_t bytes, std::size_t alignment) override
+  {
+    ++allocations;
+    return std::pmr::new_delete_resource()->allocate(bytes, alignment);
+  }
+
+  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
+  {
+    std::pmr::new_delete_resource()->deallocate(p, bytes, alignment);
+  }
+
+  bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override
+  {
+    return this == &other;
+  }
+};
+
+struct default_resource_guard
+{
+  std::pmr::memory_resource* previous;
+  explicit default_resource_guard(std::pmr::memory_resource& resource)
+      : previous{std::pmr::set_default_resource(&resource)}
+  {
+  }
+  ~default_resource_guard() { std::pmr::set_default_resource(previous); }
+};
+}
+
+// Only the measured conversion is counted, not Catch's assertions or setup.
+void* operator new(std::size_t size)
+{
+  if(count_new)
+    ++new_calls;
+  if(void* p = std::malloc(size ? size : 1))
+    return p;
+  throw std::bad_alloc{};
+}
+void* operator new[](std::size_t size)
+{
+  return ::operator new(size);
+}
+void operator delete(void* p) noexcept
+{
+  std::free(p);
+}
+void operator delete[](void* p) noexcept
+{
+  std::free(p);
+}
+void operator delete(void* p, std::size_t) noexcept
+{
+  std::free(p);
+}
+void operator delete[](void* p, std::size_t) noexcept
+{
+  std::free(p);
+}
+
+TEST_CASE("allocator-aware nested maps own both sides of the conversion")
+{
+  using leaf = std::variant<int, std::pmr::string>;
+  using map = std::map<std::pmr::string, std::vector<leaf>>;
+  std::string key(160, 'k');
+  std::string text(256, 'v');
+  key[32] = '\0';
+  text[64] = '\0';
+  ossia::value encoded;
+  {
+    std::pmr::monotonic_buffer_resource input_storage;
+    map input;
+    input.emplace(
+        std::pmr::string{key, &input_storage},
+        std::vector<leaf>{42, std::pmr::string{text, &input_storage}});
+    encoded = oscr::to_ossia_value(input);
+    REQUIRE(encoded.get_type() == ossia::val_type::MAP);
+  }
+  // The input allocator is gone; the encoded map must still own all bytes.
+  const auto* encoded_map = encoded.target<ossia::value_map_type>();
+  REQUIRE(encoded_map);
+  REQUIRE(encoded_map->front().first == key);
+  const auto* encoded_list
+      = encoded_map->front().second.target<std::vector<ossia::value>>();
+  REQUIRE(encoded_list);
+  REQUIRE(*(*encoded_list)[1].target<std::string>() == text);
+
+  map decoded;
+  REQUIRE(oscr::from_ossia_value(encoded, decoded));
+  encoded = ossia::impulse{};
+  REQUIRE(decoded.size() == 1);
+  REQUIRE(std::string_view{decoded.begin()->first} == key);
+  REQUIRE(std::get<int>(decoded.begin()->second[0]) == 42);
+  REQUIRE(
+      std::string_view{std::get<std::pmr::string>(decoded.begin()->second[1])} == text);
+}
+
+TEST_CASE("matched owning strings reuse capacity without a standard-string temporary")
+{
+  ossia::value source = std::string(256, 'x');
+  std::string standard;
+  counting_resource resource;
+  std::pmr::string allocated{&resource};
+  standard.reserve(512);
+  allocated.reserve(512);
+  const auto before = resource.allocations;
+  bool ok = false;
+  const auto standard_calls
+      = allocations_during([&] { ok = oscr::from_ossia_value(source, standard); });
+  REQUIRE(ok);
+  REQUIRE(standard_calls == 0);
+  const auto allocated_calls
+      = allocations_during([&] { ok = oscr::from_ossia_value(source, allocated); });
+  REQUIRE(ok);
+  REQUIRE(allocated_calls == 0);
+  REQUIRE(resource.allocations == before);
+  REQUIRE(standard == *source.target<std::string>());
+  REQUIRE(std::string_view{allocated} == standard);
+
+  // Exercise the recursive decoder as well as the public string overload.
+  std::vector<std::string> strings(1);
+  strings[0].reserve(512);
+  ossia::value list = std::vector<ossia::value>{source};
+  const auto nested_calls
+      = allocations_during([&] { ok = oscr::from_ossia_value(list, strings); });
+  REQUIRE(ok);
+  REQUIRE(nested_calls == 0);
+  REQUIRE(strings[0] == standard);
+
+  source = ossia::impulse{};
+  list = ossia::impulse{};
+  REQUIRE(standard == std::string(256, 'x'));
+  REQUIRE(std::string_view{allocated} == standard);
+  REQUIRE(strings[0] == standard);
+}
+
+TEST_CASE("native list and map decoding reuse reserved destination storage")
+{
+  ossia::value list = std::vector<ossia::value>{1, 2, 3};
+  std::vector<ossia::value> decoded_list;
+  decoded_list.reserve(16);
+  bool ok = false;
+  const auto list_calls
+      = allocations_during([&] { ok = oscr::from_ossia_value(list, decoded_list); });
+  REQUIRE(ok);
+  REQUIRE(list_calls == 0);
+  REQUIRE(decoded_list == *list.target<std::vector<ossia::value>>());
+
+  ossia::value_map_type entries;
+  entries.emplace_back(std::string(160, 'k'), 12);
+  ossia::value map = entries;
+  ossia::value_map_type decoded_map = entries;
+  decoded_map.reserve(16);
+  const auto map_calls
+      = allocations_during([&] { ok = oscr::from_ossia_value(map, decoded_map); });
+  REQUIRE(ok);
+  REQUIRE(map_calls == 0);
+  REQUIRE(decoded_map == entries);
+  list = ossia::impulse{};
+  map = ossia::impulse{};
+  REQUIRE(decoded_list == std::vector<ossia::value>{1, 2, 3});
+  REQUIRE(decoded_map == entries);
+
+  // Non-native inputs retain libossia's conversion and success contracts.
+  const ossia::value scalar = 7;
+  REQUIRE(oscr::from_ossia_value(scalar, decoded_list));
+  REQUIRE(decoded_list == ossia::convert<std::vector<ossia::value>>(scalar));
+  REQUIRE(oscr::from_ossia_value(scalar, decoded_map));
+  REQUIRE(decoded_map == ossia::convert<ossia::value_map_type>(scalar));
+}
+
+TEST_CASE("list append transfers converted owning strings instead of copying")
+{
+  counting_resource resource;
+  default_resource_guard defaults{resource};
+  ossia::value source
+      = std::vector<ossia::value>{std::string(256, 'a'), std::string(256, 'b')};
+  std::list<std::pmr::string> result;
+  REQUIRE(oscr::from_ossia_value(source, result));
+  REQUIRE(resource.allocations == 2);
+  source = ossia::impulse{};
+  REQUIRE(result.front() == std::pmr::string(256, 'a'));
+  REQUIRE(result.back() == std::pmr::string(256, 'b'));
+}
+
+namespace
+{
+template <template <typename...> typename Variant>
+void allocator_variant_roundtrip()
+{
+  using map = std::pmr::unordered_map<std::pmr::string, int>;
+  counting_resource resource;
+  Variant<int, std::pmr::string, map> result;
+  result.template emplace<std::pmr::string>(&resource);
+  using std::get;
+  auto& string = get<std::pmr::string>(result);
+  string.reserve(512);
+  const auto before = resource.allocations;
+  ossia::value source = std::string(256, 's');
+  REQUIRE(oscr::from_ossia_value(source, result));
+  REQUIRE(resource.allocations == before);
+  REQUIRE(
+      std::string_view{get<std::pmr::string>(result)} == *source.target<std::string>());
+  REQUIRE(oscr::to_ossia_value(result) == source);
+
+  result.template emplace<map>(&resource);
+  get<map>(result).reserve(64);
+  ossia::value_map_type entries;
+  entries.emplace_back("one", 1);
+  entries.emplace_back("two", 2);
+  source = entries;
+  const auto map_before = resource.allocations;
+  REQUIRE(oscr::from_ossia_value(source, result));
+  // Two nodes, no new bucket array: the existing map allocator is retained.
+  REQUIRE(resource.allocations == map_before + 2);
+  REQUIRE(get<map>(result).at(std::pmr::string{"one"}) == 1);
+  REQUIRE(get<map>(result).at(std::pmr::string{"two"}) == 2);
+  source = ossia::impulse{};
+  REQUIRE(get<map>(result).at(std::pmr::string{"two"}) == 2);
+}
+}
+
+TEST_CASE("std variants retain allocator-aware string and map storage")
+{
+  allocator_variant_roundtrip<std::variant>();
+}
+
+TEST_CASE("boost variants retain allocator-aware string and map storage")
+{
+  allocator_variant_roundtrip<boost::variant2::variant>();
+}
+
+TEST_CASE("failed conversions preserve their existing destination contracts")
+{
+  const ossia::value scalar = 123;
+  std::string string;
+  REQUIRE_FALSE(oscr::from_ossia_value(scalar, string));
+  REQUIRE(string == ossia::convert<std::string>(scalar));
+  std::pmr::string allocated;
+  REQUIRE(oscr::from_ossia_value(scalar, allocated));
+  REQUIRE(std::string_view{allocated} == string);
+  std::string_view view = "old";
+  REQUIRE_FALSE(oscr::from_ossia_value(scalar, view));
+  REQUIRE(view.empty());
+  const char* pointer = "old";
+  REQUIRE_FALSE(oscr::from_ossia_value(scalar, pointer));
+  REQUIRE(std::string_view{pointer}.empty());
+  std::map<std::pmr::string, int> map{{std::pmr::string{"old"}, 9}};
+  REQUIRE_FALSE(oscr::from_ossia_value(scalar, map));
+  REQUIRE(map.at(std::pmr::string{"old"}) == 9);
+  std::variant<int, std::pmr::string> variant = 17;
+  REQUIRE_FALSE(oscr::from_ossia_value(ossia::value{}, variant));
+  REQUIRE(std::get<int>(variant) == 17);
+}
+
+TEST_CASE("native conversion preserves snapshots across nested aliasing")
+{
+  using list = std::vector<ossia::value>;
+  SECTION("source is inside destination")
+  {
+    list destination{ossia::value{list{1, 2, 3}}, 4};
+    REQUIRE(oscr::from_ossia_value(destination[0], destination));
+    REQUIRE(destination == list{1, 2, 3});
+  }
+  SECTION("source is deeply inside destination")
+  {
+    list destination{ossia::value{list{ossia::value{list{1, 2, 3}}}}, 4};
+    auto& source = (*destination[0].target<list>())[0];
+    REQUIRE(oscr::from_ossia_value(source, destination));
+    REQUIRE(destination == list{1, 2, 3});
+  }
+  SECTION("destination is inside source")
+  {
+    ossia::value source{list{ossia::value{list{1, 2, 3}}, 4}};
+    const auto expected = *source.target<list>();
+    auto& destination = *(*source.target<list>())[0].target<list>();
+    REQUIRE(oscr::from_ossia_value(source, destination));
+    REQUIRE(destination == expected);
+  }
+  SECTION("map source is inside destination")
+  {
+    ossia::value_map_type inner;
+    inner.emplace_back("answer", 42);
+    ossia::value_map_type destination;
+    destination.emplace_back("nested", ossia::value{inner});
+    REQUIRE(oscr::from_ossia_value(destination.begin()->second, destination));
+    REQUIRE(destination == inner);
+  }
 }


### PR DESCRIPTION
## Problem

The OSSIA conversion boundary builds temporary standard strings and containers even when the destination already owns compatible storage. Allocator-aware strings are also classified as vectors in some overload sets, and allocator-aware string-key maps are encoded as pair lists instead of OSSIA maps.

## Changes

- decode owning allocator-aware strings directly into their existing storage
- preserve active variant string/map alternatives and their allocator/capacity
- reuse native OSSIA list/map destination capacity when source and destination do not overlap
- preserve snapshot semantics for nested source/destination aliasing
- move converted list elements instead of copying them
- encode allocator-aware string-key maps as OSSIA maps
- disambiguate string and optimized numeric-vector output overloads
- register the OSSIA conversion regression target when `ossia::ossia` is available

## Verification

Built and ran `tests/test_ossia_values.cpp` directly against the score/libossia build configuration:

- 9 test cases
- 97 assertions
- allocator-aware string/map ownership and embedded-NUL round trips
- destination capacity reuse and bounded allocation counts
- `std::variant` and `boost::variant2` active-alternative reuse
- nested native-container aliasing in both containment directions

Also rebuilt `score_addon_jk`, which exercises these conversions with allocator-aware jq values.