### PR TITLE
Add data utilities and keyed string-list controls

### DIFF
--- a/examples/Advanced/AI/PromptComposer.hpp
+++ b/examples/Advanced/AI/PromptComposer.hpp
@@ -1,13 +1,14 @@
 #pragma once
-#include <boost/algorithm/string.hpp>
 #include <cmath>
 #include <fmt/format.h>
 #include <halp/audio.hpp>
 #include <halp/controls.hpp>
 #include <halp/dynamic_port.hpp>
 #include <halp/meta.hpp>
+#include <halp/string_list.hpp>
 #include <ossia/detail/pod_vector.hpp>
 #include <ossia/detail/small_vector.hpp>
+#include <ossia/network/value/value.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -28,14 +29,40 @@ struct PromptComposer
 
   struct inputs
   {
-    struct : halp::lineedit<"Keywords", "">
+    struct keyword_list : halp::string_list<"Keywords">
     {
-      static std::function<void(PromptComposer&, const std::string&)>
+      // Retain the old empty keyword and its first dynamic weight by default.
+      keyword_list() { value.emplace_back(12000, ""); }
+
+      // Versioned by representation: old documents/presets stored a STRING;
+      // current ones store LISTs of [stable port identity, keyword]. Preserve
+      // all rows, including empty and trailing rows, and their old weight IDs.
+      static ossia::value migrate_value(const ossia::value& previous)
+      {
+        if(auto text = previous.target<std::string>())
+        {
+          std::vector<ossia::value> rows;
+          std::size_t start = 0;
+          do
+          {
+            auto end = text->find('\n', start);
+            rows.emplace_back(
+                std::vector<ossia::value>{
+                    12000 + int(rows.size()), text->substr(start, end - start)});
+            if(end == std::string::npos)
+              break;
+            start = end + 1;
+          } while(true);
+          return rows;
+        }
+        return previous;
+      }
+
+      static std::function<void(PromptComposer&, const halp::string_list_value&)>
       on_controller_interaction()
       {
-        return [](PromptComposer& object, std::string_view value) {
-          int n = std::count(value.begin(), value.end(), '\n');
-          object.inputs.in_i.request_port_resize(n + 1);
+        return [](PromptComposer& object, const halp::string_list_value& rows) {
+          object.inputs.in_i.set_rows(rows);
         };
       }
     } controller;
@@ -57,7 +84,7 @@ struct PromptComposer
       void update(PromptComposer& obj) { }
     };
 
-    halp::dynamic_port<weight_port> in_i;
+    halp::keyed_dynamic_port<weight_port> in_i;
   } inputs;
 
   struct
@@ -67,17 +94,17 @@ struct PromptComposer
 
   void operator()()
   {
-    outputs.out.value = "";
-    splitted.clear();
-    boost::split(splitted, inputs.controller.value, boost::is_any_of("\n"));
-    auto it = splitted.begin();
-    for(auto& val : inputs.in_i.ports)
+    outputs.out.value.clear();
+    const auto count
+        = std::min(inputs.controller.value.size(), inputs.in_i.ports.size());
+    for(std::size_t i = 0; i < count; ++i)
     {
-      if(it == splitted.end())
-        break;
-      boost::trim_if(*it, [](char c) { return c <= 32; });
-      outputs.out.value += fmt::format("({}:{}), ", *it, val.value);
-      ++it;
+      std::string_view text = inputs.controller.value[i].second;
+      while(!text.empty() && static_cast<unsigned char>(text.front()) <= 32)
+        text.remove_prefix(1);
+      while(!text.empty() && static_cast<unsigned char>(text.back()) <= 32)
+        text.remove_suffix(1);
+      outputs.out.value += fmt::format("({}:{}), ", text, inputs.in_i.ports[i].value);
     }
 
     if(outputs.out.value.ends_with(", "))
@@ -86,8 +113,6 @@ struct PromptComposer
       outputs.out.value.pop_back();
     }
   }
-
-  std::vector<std::string> splitted;
 };
 
 

--- a/examples/Advanced/Utilities/FileIO.hpp
+++ b/examples/Advanced/Utilities/FileIO.hpp
@@ -1,0 +1,1135 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <halp/callback.hpp>
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <ossia/dataflow/value_port.hpp>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#endif
+
+namespace examples
+{
+enum class FileIOMode
+{
+  Async,
+  Sync
+};
+enum class FileReadMode
+{
+  Whole,
+  Range,
+  Stream,
+  Autostream
+};
+enum class FileWriteMode
+{
+  Ignore,
+  Write,
+  WriteRange,
+  Append
+};
+enum class FileLineEnding : std::uint8_t
+{
+  None,
+  LF,
+  CRLF
+};
+
+namespace file_io
+{
+inline constexpr int max_file_bytes = 64 * 1024 * 1024;
+inline constexpr int max_line_bytes = 1024 * 1024;
+
+enum class Operation : std::uint8_t
+{
+  Read,
+  ReadRange,
+  ReadStream,
+  Autostream,
+  Open,
+  Next,
+  Rewind,
+  Close,
+  Write,
+  Append,
+  WriteRange
+};
+
+// Jobs and completions own only values, never an object pointer or an open file.
+// A line session stores a path and byte offset, reopening and seeking for each
+// requested line. This streams without preloading, and cannot close a handle on
+// the processor thread at destruction. Do not edit/replace a file mid-session.
+struct Request
+{
+  Operation operation{};
+  FileLineEnding ending{};
+  int timeout_ms{1000};
+  std::string path;
+  std::string data;
+  std::size_t limit{};
+  std::uint64_t offset{};
+  std::uint64_t generation{};
+};
+
+struct Result
+{
+  Operation operation{};
+  std::string path;
+  std::string data;
+  std::string error;
+  std::uint64_t offset{};
+  std::int64_t bytes{};
+  std::int64_t lines{};
+  bool has_line{};
+  bool eof{};
+  bool timed_out{};
+  bool publish_partial{};
+  std::uint64_t generation{};
+};
+
+inline std::int64_t count_lines(std::string_view text)
+{
+  if(text.empty())
+    return 0;
+  return std::count(text.begin(), text.end(), '\n') + (text.back() != '\n');
+}
+
+// Stream pulls are independent open/read/close requests, not persistent sessions.
+// Only the worker owns descriptors. Never transfer one to a completion callback.
+#if defined(__unix__) || defined(__APPLE__)
+inline void pull_stream(int fd, const Request& request, Result& result)
+{
+  const auto deadline
+      = std::chrono::steady_clock::now() + std::chrono::milliseconds{request.timeout_ms};
+  std::array<char, 8192> buffer;
+  while(result.data.size() < request.limit)
+  {
+    const auto now = std::chrono::steady_clock::now();
+    if(now >= deadline)
+    {
+      result.timed_out = true;
+      result.error = "Stream pull timed out; Data contains bytes received";
+      break;
+    }
+    const auto received = ::read(
+        fd, buffer.data(), std::min(buffer.size(), request.limit - result.data.size()));
+    if(received > 0)
+    {
+      result.data.append(buffer.data(), static_cast<std::size_t>(received));
+      continue;
+    }
+    if(received == 0)
+    {
+      result.eof = true;
+      break;
+    }
+    if(errno == EINTR)
+      continue;
+    if(errno != EAGAIN && errno != EWOULDBLOCK)
+    {
+      result.error
+          = "Stream read: " + std::error_code{errno, std::generic_category()}.message();
+      break;
+    }
+    const auto remaining = std::chrono::ceil<std::chrono::milliseconds>(
+                               deadline - std::chrono::steady_clock::now())
+                               .count();
+    if(remaining <= 0)
+      continue;
+    pollfd descriptor{fd, POLLIN, 0};
+    const auto polled = ::poll(&descriptor, 1, static_cast<int>(remaining));
+    if(polled < 0 && errno != EINTR)
+    {
+      result.error
+          = "Stream poll: " + std::error_code{errno, std::generic_category()}.message();
+      break;
+    }
+    if(polled > 0 && (descriptor.revents & POLLNVAL))
+    {
+      result.error = "Invalid stream descriptor";
+      break;
+    }
+  }
+  result.bytes = static_cast<std::int64_t>(result.data.size());
+  result.lines = count_lines(result.data);
+  // On timeout or I/O error consumers still receive the bytes already consumed.
+  result.publish_partial = true;
+}
+#endif
+// Called exclusively by work(), or explicitly on the caller in Sync mode.
+// Success for writes means stream close succeeded, not fsync / crash durability.
+inline Result perform(Request request)
+{
+  Result result;
+  result.operation = request.operation;
+  result.generation = request.generation;
+  try
+  {
+    if(request.operation == Operation::Close)
+      return result;
+    const bool bounded = request.operation == Operation::ReadRange
+                         || request.operation == Operation::ReadStream
+                         || request.operation == Operation::Autostream
+                         || request.operation == Operation::WriteRange;
+    if(bounded && request.limit == 0)
+      return result; // No open, seek, read or write; EOF remains unknown (false).
+    if(bounded && request.limit > max_file_bytes)
+    {
+      result.error = "Count is out of range";
+      return result;
+    }
+    if(request.operation == Operation::ReadStream
+       || request.operation == Operation::Autostream)
+    {
+#if defined(__unix__) || defined(__APPLE__)
+      if(request.timeout_ms < 1 || request.timeout_ms > 60000)
+      {
+        result.error = "Stream timeout is out of range";
+        return result;
+      }
+      struct Descriptor
+      {
+        int fd;
+        ~Descriptor()
+        {
+          if(fd >= 0)
+            ::close(fd);
+        }
+      } descriptor{
+          ::open(request.path.c_str(), O_RDONLY | O_NONBLOCK | O_NOCTTY | O_CLOEXEC)};
+      if(descriptor.fd < 0)
+      {
+        result.error = "Stream open: "
+                       + std::error_code{errno, std::generic_category()}.message();
+        return result;
+      }
+      struct stat status{};
+      if(::fstat(descriptor.fd, &status) != 0)
+      {
+        result.error = "Stream status: "
+                       + std::error_code{errno, std::generic_category()}.message();
+        return result;
+      }
+      if((!S_ISREG(status.st_mode) && !S_ISCHR(status.st_mode))
+         || ::isatty(descriptor.fd))
+      {
+        result.error
+            = "Stream pulls reopen each request; FIFOs, sockets, terminals "
+              "and other session sources are unsupported";
+        return result;
+      }
+      if(request.operation == Operation::Autostream && S_ISREG(status.st_mode))
+      {
+        if(request.offset > static_cast<std::uint64_t>(std::numeric_limits<off_t>::max())
+           || ::lseek(descriptor.fd, static_cast<off_t>(request.offset), SEEK_SET) < 0)
+        {
+          result.error = "Stream offset is out of range or seek failed";
+          return result;
+        }
+      }
+      pull_stream(descriptor.fd, request, result);
+      if(request.operation == Operation::Autostream)
+      {
+        result.offset = request.offset + result.data.size();
+        if(S_ISREG(status.st_mode) && status.st_size >= 0)
+          result.eof |= result.offset >= static_cast<std::uint64_t>(status.st_size);
+      }
+      return result;
+#else
+      if(request.operation == Operation::ReadStream)
+      {
+        result.error = "Non-seeking stream pulls require POSIX nonblocking I/O";
+        return result;
+      }
+      request.operation = Operation::ReadRange;
+#endif
+    }
+
+    const std::filesystem::path path{std::u8string_view{
+        reinterpret_cast<const char8_t*>(request.path.data()), request.path.size()}};
+    std::error_code ec;
+    const auto status = std::filesystem::status(path, ec);
+    const bool writing = request.operation == Operation::Write
+                         || request.operation == Operation::Append
+                         || request.operation == Operation::WriteRange;
+    const bool missing = status.type() == std::filesystem::file_type::not_found;
+    const bool may_create = writing && request.operation != Operation::WriteRange;
+    if((ec && !(may_create && missing))
+       || (!std::filesystem::is_regular_file(status) && !(may_create && missing)))
+    {
+      result.error = ec ? "File status: " + ec.message() : "Not a regular file";
+      return result;
+    }
+
+    if(request.offset
+       > static_cast<std::uint64_t>(std::numeric_limits<std::streamoff>::max()))
+    {
+      result.error = "File offset is out of range";
+      return result;
+    }
+    if(writing)
+    {
+      if(request.ending == FileLineEnding::LF)
+        request.data += '\n';
+      else if(request.ending == FileLineEnding::CRLF)
+        request.data += "\r\n";
+      if(request.operation == Operation::WriteRange)
+      {
+        const auto count = std::min(request.limit, request.data.size());
+        if(count > static_cast<std::uint64_t>(std::numeric_limits<std::streamoff>::max())
+                       - request.offset)
+        {
+          result.error = "File range is out of range";
+          return result;
+        }
+        std::fstream stream{path, std::ios::binary | std::ios::in | std::ios::out};
+        if(!stream)
+        {
+          result.error = "Cannot open existing file for range writing";
+          return result;
+        }
+        stream.seekp(static_cast<std::streamoff>(request.offset));
+        if(!stream)
+        {
+          result.error = "File seek failed";
+          return result;
+        }
+        stream.write(request.data.data(), static_cast<std::streamsize>(count));
+        stream.close();
+        if(!stream)
+          result.error = "Write or close failed; file may be partially written";
+        else
+        {
+          result.bytes = static_cast<std::int64_t>(count);
+          result.lines = count_lines(std::string_view{request.data}.substr(0, count));
+        }
+        return result;
+      }
+      std::ofstream stream{
+          path, std::ios::binary | std::ios::out
+                    | (request.operation == Operation::Append ? std::ios::app
+                                                              : std::ios::trunc)};
+      if(!stream)
+      {
+        result.error = "Cannot open file for writing";
+        return result;
+      }
+      stream.write(
+          request.data.data(), static_cast<std::streamsize>(request.data.size()));
+      stream.close();
+      if(!stream)
+        result.error = "Write or close failed; file may be partially written";
+      else
+      {
+        result.bytes = static_cast<std::int64_t>(request.data.size());
+        result.lines = count_lines(request.data);
+      }
+      return result;
+    }
+
+    std::ifstream stream{path, std::ios::binary};
+    if(!stream)
+    {
+      result.error = "Cannot open file for reading";
+      return result;
+    }
+    if(request.operation == Operation::ReadRange)
+    {
+      stream.seekg(0, std::ios::end);
+      const auto end = stream.tellg();
+      if(end < 0)
+      {
+        result.error = "Cannot determine file size";
+        return result;
+      }
+      const auto size = static_cast<std::uint64_t>(end);
+      if(request.offset >= size)
+      {
+        result.eof = true;
+        return result;
+      }
+      stream.seekg(static_cast<std::streamoff>(request.offset));
+      if(!stream)
+      {
+        result.error = "File seek failed";
+        return result;
+      }
+      // Never probe an extra byte: an exact boundary is known from the size.
+      const auto count = std::min<std::uint64_t>(request.limit, size - request.offset);
+      result.data.resize(static_cast<std::size_t>(count));
+      stream.read(result.data.data(), static_cast<std::streamsize>(count));
+      result.data.resize(static_cast<std::size_t>(stream.gcount()));
+      result.bytes = static_cast<std::int64_t>(result.data.size());
+      result.lines = count_lines(result.data);
+      result.eof = stream.eof() || result.data.size() >= size - request.offset;
+      result.offset = request.offset + result.data.size();
+      if(stream.bad() || (stream.fail() && !stream.eof()))
+        result.error = "File range read failed";
+      return result;
+    }
+    if(request.operation == Operation::Read)
+    {
+      std::array<char, 8192> buffer;
+      while(stream)
+      {
+        // One extra byte distinguishes an exact-limit file from truncation.
+        const auto count
+            = std::min(buffer.size(), request.limit - result.data.size() + 1);
+        stream.read(buffer.data(), static_cast<std::streamsize>(count));
+        const auto received = static_cast<std::size_t>(stream.gcount());
+        if(received > request.limit - result.data.size())
+        {
+          result.error = "File exceeds maximum bytes";
+          break;
+        }
+        result.data.append(buffer.data(), received);
+      }
+      if(result.error.empty() && (stream.bad() || !stream.eof()))
+        result.error = "File read failed";
+      if(result.error.empty())
+      {
+        result.bytes = static_cast<std::int64_t>(result.data.size());
+        result.lines = count_lines(result.data);
+        result.eof = true;
+      }
+      return result;
+    }
+
+    if(request.operation == Operation::Open || request.operation == Operation::Rewind)
+    {
+      result.path = std::move(request.path);
+      result.eof = stream.peek() == std::char_traits<char>::eof();
+      if(stream.bad())
+        result.error = "File read failed";
+      return result;
+    }
+
+    stream.seekg(static_cast<std::streamoff>(request.offset));
+    if(!stream)
+    {
+      result.error = "File seek failed";
+      return result;
+    }
+    result.offset = request.offset;
+    for(;;)
+    {
+      const auto character = stream.get();
+      if(character == std::char_traits<char>::eof())
+      {
+        result.eof = true;
+        if(stream.bad())
+          result.error = "File read failed";
+        break;
+      }
+      ++result.offset;
+      result.has_line = true;
+      if(character == '\n')
+      {
+        if(!result.data.empty() && result.data.back() == '\r')
+          result.data.pop_back();
+        result.eof = stream.peek() == std::char_traits<char>::eof();
+        if(stream.bad())
+          result.error = "File read failed";
+        break;
+      }
+      result.data += static_cast<char>(character);
+      // Permit one trailing CR beyond the payload limit, only for CRLF.
+      if(result.data.size() > request.limit
+         && !(result.data.size() == request.limit + 1 && character == '\r'))
+      {
+        result.error = "Line exceeds maximum bytes; cursor unchanged";
+        break;
+      }
+    }
+    if(result.data.size() > request.limit && result.error.empty())
+      result.error = "Line exceeds maximum bytes; cursor unchanged";
+    result.bytes = static_cast<std::int64_t>(result.offset - request.offset);
+    result.lines = result.has_line ? 1 : 0;
+    return result;
+  }
+  catch(const std::exception& error)
+  {
+    result.error = error.what();
+    return result;
+  }
+}
+
+template <typename Object>
+struct Worker
+{
+  std::function<void(Request)> request;
+  std::optional<Result> completed;
+
+  static std::function<void(Object&)> work(Request request)
+  {
+    auto result = perform(std::move(request));
+    return [result = std::move(result)](Object& self) mutable {
+      // Execution commands arrive before graph ports are cleared. Stage here;
+      // callbacks must be emitted by operator() during the next processing tick.
+      self.worker.completed.emplace(std::move(result));
+    };
+  }
+
+  void publish(Object& self)
+  {
+    if(!completed)
+      return;
+    auto result = std::move(*completed);
+    completed.reset();
+    if constexpr(requires { self.consume_stream(result); })
+      if(self.consume_stream(result))
+        return;
+    // Keep Busy during Data/Line callbacks; Success is the pacing signal.
+    if(result.error.empty() || result.publish_partial)
+      self.apply(result);
+    self.outputs.busy = false;
+    if(result.error.empty())
+      self.outputs.success();
+    else
+      self.outputs.error(std::move(result.error));
+  }
+};
+
+template <typename Object>
+bool ready(Object& self)
+{
+  if(self.outputs.busy.value)
+    self.outputs.error("Busy: request rejected");
+  else if(self.inputs.mode.value == FileIOMode::Async && !self.worker.request)
+    self.outputs.error("Async worker unavailable: request rejected");
+  else if(
+      self.inputs.mode.value != FileIOMode::Async
+      && self.inputs.mode.value != FileIOMode::Sync)
+    self.outputs.error("Invalid I/O mode");
+  else
+    return true;
+  return false;
+}
+
+template <typename Object>
+bool valid_path(Object& self, const std::string& path)
+{
+  if(path.empty() || path.size() > 32768 || path.find('\0') != std::string::npos)
+  {
+    self.outputs.error("Invalid file path");
+    return false;
+  }
+  return true;
+}
+
+template <typename Object>
+bool valid_limit(Object& self, int limit, int maximum)
+{
+  if(limit < 1 || limit > maximum)
+  {
+    self.outputs.error("Byte limit is out of range");
+    return false;
+  }
+  return true;
+}
+
+template <typename Object>
+bool valid_offset(Object& self, std::uint64_t& offset)
+{
+  // Decimal text is lossless through hosts whose numeric ports are only int32.
+  const auto& text = self.inputs.offset.value;
+  std::int64_t parsed{};
+  const auto [end, error]
+      = std::from_chars(text.data(), text.data() + text.size(), parsed);
+  if(error != std::errc{} || end != text.data() + text.size() || parsed < 0)
+  {
+    self.outputs.error("Offset must be a non-negative signed 64-bit decimal integer");
+    return false;
+  }
+  offset = static_cast<std::uint64_t>(parsed);
+  return true;
+}
+
+template <typename Object>
+bool valid_count(Object& self)
+{
+  if(self.inputs.count.value < 0 || self.inputs.count.value > max_file_bytes)
+  {
+    self.outputs.error("Count is out of range");
+    return false;
+  }
+  return true;
+}
+
+template <typename Object>
+void submit(Object& self, Request request)
+{
+  self.outputs.busy = true;
+  if(self.inputs.mode.value == FileIOMode::Sync)
+  {
+    Worker<Object>::work(std::move(request))(self);
+    self.worker.publish(self);
+  }
+  else
+  {
+    try
+    {
+      self.worker.request(std::move(request));
+    }
+    catch(const std::exception& error)
+    {
+      self.outputs.busy = false;
+      self.outputs.error(error.what());
+    }
+  }
+}
+}
+
+struct FileRead
+{
+  halp_meta(name, "Read File")
+  halp_meta(c_name, "avnd_read_file")
+  halp_meta(category, "Control/Files")
+  halp_meta(author, "ossia score")
+  halp_meta(
+      description,
+      "Read Whole, Range or Stream on demand, or Autostream chunks each tick. "
+      "Async Autostream prefetches bounded batches; startup and slow sources may "
+      "starve. Regular files advance; devices reopen on the worker. No FIFO sessions.")
+  halp_meta(uuid, "f82d1b69-c381-4eef-86c3-506d42b3d8e1")
+
+  void read()
+  {
+    if(inputs.read_mode.value == FileReadMode::Autostream)
+      return; // Autostream is paced exclusively by processing ticks.
+    if(!file_io::ready(*this) || !file_io::valid_path(*this, inputs.path.value))
+      return;
+    file_io::Request request{
+        .operation = file_io::Operation::Read, .path = inputs.path.value};
+    switch(inputs.read_mode.value)
+    {
+      case FileReadMode::Whole:
+        if(!file_io::valid_limit(*this, inputs.max_bytes.value, file_io::max_file_bytes))
+          return;
+        request.limit = static_cast<std::size_t>(inputs.max_bytes.value);
+        break;
+      case FileReadMode::Range:
+      case FileReadMode::Stream:
+        if(!file_io::valid_count(*this) || !file_io::valid_offset(*this, request.offset))
+          return;
+        request.limit = static_cast<std::size_t>(inputs.count.value);
+        if(inputs.read_mode.value == FileReadMode::Range)
+          request.operation = file_io::Operation::ReadRange;
+        else
+        {
+          if(request.offset != 0)
+          {
+            outputs.error("Stream pulls do not seek; Offset must be zero");
+            return;
+          }
+          if(inputs.timeout_ms.value < 1 || inputs.timeout_ms.value > 60000)
+          {
+            outputs.error("Stream timeout is out of range");
+            return;
+          }
+          request.operation = file_io::Operation::ReadStream;
+          request.timeout_ms = inputs.timeout_ms.value;
+        }
+        break;
+      default:
+        outputs.error("Invalid read mode");
+        return;
+    }
+    file_io::submit(*this, std::move(request));
+  }
+
+  struct
+  {
+    halp::lineedit<"Path", ""> path;
+    halp::enum_t<FileIOMode, "Execution"> mode;
+    halp::spinbox_i32<"Maximum bytes", halp::range{1, file_io::max_file_bytes, 1048576}>
+        max_bytes;
+    halp::impulse_button<"Read"> read;
+    halp::enum_t<FileReadMode, "Mode"> read_mode;
+    struct : halp::lineedit<"Offset", "0">
+    {
+      using halp::lineedit<"Offset", "0">::operator=;
+      halp_meta(
+          description,
+          "Non-negative signed 64-bit decimal byte offset for Range. Autostream starts "
+          "at zero.")
+    } offset;
+    struct : halp::spinbox_i32<"Count", halp::range{0, file_io::max_file_bytes, 65536}>
+    {
+      halp_meta(
+          description,
+          "Bytes per Range or Stream request, or per Autostream tick. Zero performs no "
+          "I/O. A terminal chunk may be shorter.")
+    } count;
+    struct : halp::spinbox_i32<"Timeout", halp::range{1, 60000, 1000}>
+    {
+      halp_meta(
+          description,
+          "Stream worker deadline in milliseconds. Timeouts report Error; Autostream "
+          "retains partial bytes until a chunk is ready.")
+    } timeout_ms;
+  } inputs;
+
+  struct
+  {
+    halp::callback<"Data", std::string> data;
+    halp::val_port<"Bytes", std::int64_t> bytes;
+    halp::val_port<"Lines", std::int64_t> lines;
+    halp::val_port<"EOF", bool> eof;
+    halp::val_port<"Busy", bool> busy;
+    halp::callback<"Success"> success;
+    halp::callback<"Error", std::string> error;
+    halp::val_port<"Timed out", bool> timed_out;
+  } outputs;
+
+  file_io::Worker<FileRead> worker;
+  struct StreamSettings
+  {
+    std::string path;
+    FileReadMode read_mode{};
+    FileIOMode execution{};
+    int count{};
+    int timeout{};
+  } stream_settings;
+  std::string stream_buffer;
+  std::size_t stream_consumed{};
+  std::uint64_t stream_offset{};
+  bool stream_eof{};
+  std::uint64_t stream_generation{};
+  bool stream_finished{};
+  bool stream_enabled{true};
+
+  void reset_stream()
+  {
+    ++stream_generation;
+    stream_buffer.clear();
+    stream_consumed = 0;
+    stream_offset = 0;
+    stream_eof = false;
+    stream_finished = false;
+    outputs.eof = false;
+    outputs.timed_out = false;
+    // Do not clear Busy: an invalidated worker must finish before another starts.
+  }
+
+  void start()
+  {
+    stream_enabled = true;
+    reset_stream();
+  }
+
+  void stop()
+  {
+    stream_enabled = false;
+    reset_stream();
+  }
+
+  void update_stream_settings()
+  {
+    if(stream_settings.path != inputs.path.value
+       || stream_settings.read_mode != inputs.read_mode.value
+       || stream_settings.execution != inputs.mode.value
+       || stream_settings.count != inputs.count.value
+       || stream_settings.timeout != inputs.timeout_ms.value)
+    {
+      stream_settings
+          = {inputs.path.value, inputs.read_mode.value, inputs.mode.value,
+             inputs.count.value, inputs.timeout_ms.value};
+      reset_stream();
+    }
+  }
+
+  bool consume_stream(file_io::Result& result)
+  {
+    if(result.operation != file_io::Operation::Autostream)
+    {
+      if(inputs.read_mode.value != FileReadMode::Autostream)
+        return false;
+      // An on-demand request accepted before entering Autostream is not a chunk.
+      outputs.busy = false;
+      return true;
+    }
+    outputs.busy = false;
+    if(result.generation != stream_generation || !stream_enabled
+       || inputs.read_mode.value != FileReadMode::Autostream)
+      return true;
+    stream_offset = result.offset;
+    if(stream_buffer.empty())
+      stream_buffer = std::move(result.data);
+    else
+      stream_buffer += result.data;
+    stream_finished = result.eof || (!result.error.empty() && !result.timed_out);
+    outputs.timed_out = result.timed_out;
+    stream_eof = result.eof;
+    if(!result.error.empty())
+      outputs.error(std::move(result.error));
+    return true;
+  }
+
+  void autostream()
+  {
+    if(!stream_enabled)
+      return;
+    if(!stream_finished && !outputs.busy.value)
+    {
+      if(!file_io::valid_count(*this) || !file_io::valid_path(*this, inputs.path.value)
+         || inputs.timeout_ms.value < 1 || inputs.timeout_ms.value > 60000)
+      {
+        if(inputs.timeout_ms.value < 1 || inputs.timeout_ms.value > 60000)
+          outputs.error("Stream timeout is out of range");
+        stream_finished = true;
+        return;
+      }
+      const auto count = static_cast<std::size_t>(inputs.count.value);
+      if(count == 0)
+        return;
+      const auto batch
+          = inputs.mode.value == FileIOMode::Sync
+                ? count
+                : std::min<std::size_t>(count * 32, file_io::max_file_bytes);
+      // Refill early while buffered chunks cover worker latency. At most one
+      // request and one bounded buffer exist; no locks or I/O on Async ticks.
+      if(stream_buffer.size() - stream_consumed <= batch / 2)
+      {
+        if(!file_io::ready(*this))
+        {
+          stream_finished = true;
+          return;
+        }
+        stream_buffer.erase(0, stream_consumed);
+        stream_consumed = 0;
+        file_io::Request request{
+            .operation = file_io::Operation::Autostream, .path = inputs.path.value};
+        request.limit = batch;
+        request.offset = stream_offset;
+        request.timeout_ms = inputs.timeout_ms.value;
+        request.generation = stream_generation;
+        file_io::submit(*this, std::move(request));
+      }
+    }
+    const auto available = stream_buffer.size() - stream_consumed;
+    const auto count = static_cast<std::size_t>(std::max(0, inputs.count.value));
+    if(count && (available >= count || (stream_finished && available)))
+    {
+      const auto size = std::min(count, available);
+      auto data = stream_buffer.substr(stream_consumed, size);
+      stream_consumed += size;
+      outputs.bytes = static_cast<std::int64_t>(size);
+      outputs.lines = file_io::count_lines(data);
+      outputs.eof = stream_eof && stream_consumed == stream_buffer.size();
+      outputs.data(std::move(data));
+      outputs.success();
+    }
+    else if(stream_finished && !available)
+      outputs.eof = stream_eof;
+  }
+  void operator()()
+  {
+    update_stream_settings();
+    if(inputs.read_mode.value == FileReadMode::Autostream)
+    {
+      worker.publish(*this);
+      autostream();
+    }
+    else
+    {
+      if(inputs.read.value)
+        read();
+      worker.publish(*this);
+    }
+  }
+
+  void apply(file_io::Result& result)
+  {
+    outputs.bytes = result.bytes;
+    outputs.lines = result.lines;
+    outputs.eof = result.eof;
+    outputs.timed_out = result.timed_out;
+    outputs.data(std::move(result.data));
+  }
+};
+
+struct FileReadLine
+{
+  halp_meta(name, "Read File Line")
+  halp_meta(c_name, "avnd_read_file_line")
+  halp_meta(category, "Control/Files")
+  halp_meta(author, "ossia score")
+  halp_meta(
+      description,
+      "Stream one bounded LF/CRLF line per Next; preserve blank lines. Async by "
+      "default.")
+  halp_meta(uuid, "0d2bd0c7-392c-45ec-bd70-6be4937f0348")
+
+  // Processor-owned cursor; no shared worker state or mutexes.
+  std::string opened_path;
+  std::uint64_t offset{};
+
+  void open()
+  {
+    if(file_io::ready(*this) && file_io::valid_path(*this, inputs.path.value))
+      file_io::submit(
+          *this, {.operation = file_io::Operation::Open, .path = inputs.path.value});
+  }
+  void next()
+  {
+    if(!file_io::ready(*this))
+      return;
+    if(!outputs.open.value)
+    {
+      outputs.error("No file is open");
+      return;
+    }
+    if(file_io::valid_limit(*this, inputs.max_bytes.value, file_io::max_line_bytes))
+      file_io::submit(
+          *this, {.operation = file_io::Operation::Next,
+                  .path = opened_path,
+                  .limit = static_cast<std::size_t>(inputs.max_bytes.value),
+                  .offset = offset});
+  }
+  void rewind()
+  {
+    if(!file_io::ready(*this))
+      return;
+    if(!outputs.open.value)
+      outputs.error("No file is open");
+    else
+      file_io::submit(
+          *this, {.operation = file_io::Operation::Rewind, .path = opened_path});
+  }
+  void close()
+  {
+    if(file_io::ready(*this))
+      file_io::submit(*this, {.operation = file_io::Operation::Close});
+  }
+
+  struct
+  {
+    halp::lineedit<"Path", ""> path;
+    halp::enum_t<FileIOMode, "Mode"> mode;
+    halp::spinbox_i32<
+        "Maximum line bytes", halp::range{1, file_io::max_line_bytes, 65536}>
+        max_bytes;
+    halp::impulse_button<"Open"> open;
+    halp::impulse_button<"Next"> next;
+    halp::impulse_button<"Rewind"> rewind;
+    halp::impulse_button<"Close"> close;
+  } inputs;
+
+  struct
+  {
+    halp::callback<"Line", std::string> line;
+    halp::val_port<"Line number", std::int64_t> lines;
+    halp::val_port<"Bytes", std::int64_t> bytes;
+    halp::val_port<"Open", bool> open;
+    halp::val_port<"EOF", bool> eof;
+    halp::val_port<"Busy", bool> busy;
+    halp::callback<"Success"> success;
+    halp::callback<"Error", std::string> error;
+  } outputs;
+
+  file_io::Worker<FileReadLine> worker;
+  void operator()()
+  {
+    if(inputs.open.value)
+      open();
+    if(inputs.next.value)
+      next();
+    if(inputs.rewind.value)
+      rewind();
+    if(inputs.close.value)
+      close();
+    worker.publish(*this);
+  }
+
+  void apply(file_io::Result& result)
+  {
+    outputs.bytes = result.bytes;
+    outputs.eof = result.eof;
+    offset = result.offset;
+    if(result.operation == file_io::Operation::Close)
+    {
+      opened_path.clear();
+      outputs.open = false;
+      outputs.lines = 0;
+    }
+    else if(
+        result.operation == file_io::Operation::Open
+        || result.operation == file_io::Operation::Rewind)
+    {
+      opened_path = std::move(result.path);
+      outputs.open = true;
+      outputs.lines = 0;
+    }
+    else if(result.has_line)
+    {
+      ++outputs.lines.value;
+      outputs.line(std::move(result.data));
+    }
+  }
+};
+
+struct FileWrite
+{
+  halp_meta(name, "Write File")
+  halp_meta(c_name, "avnd_write_file")
+  halp_meta(category, "Control/Files")
+  halp_meta(author, "ossia score")
+  halp_meta(
+      description,
+      "Each Data event performs Mode: Write replaces the entire file, WriteRange "
+      "overwrites at Offset without truncation, Append adds continuous chunks, "
+      "Ignore does nothing. Async rejects busy events explicitly; no write queue.")
+  halp_meta(uuid, "810761ce-52ea-4105-8bb3-598d5692c20f")
+
+  void receive(const std::string& data)
+  {
+    file_io::Operation operation;
+    switch(inputs.action.value)
+    {
+      case FileWriteMode::Ignore:
+        return;
+      case FileWriteMode::Write:
+        operation = file_io::Operation::Write;
+        break;
+      case FileWriteMode::WriteRange:
+        operation = file_io::Operation::WriteRange;
+        break;
+      case FileWriteMode::Append:
+        operation = file_io::Operation::Append;
+        break;
+      default:
+        outputs.error("Invalid write mode");
+        return;
+    }
+    if(!file_io::ready(*this) || !file_io::valid_path(*this, inputs.path.value)
+       || !file_io::valid_limit(*this, inputs.max_bytes.value, file_io::max_file_bytes))
+      return;
+    if(inputs.ending.value != FileLineEnding::None
+       && inputs.ending.value != FileLineEnding::LF
+       && inputs.ending.value != FileLineEnding::CRLF)
+    {
+      outputs.error("Invalid line ending");
+      return;
+    }
+    const std::size_t suffix = inputs.ending.value == FileLineEnding::CRLF ? 2
+                               : inputs.ending.value == FileLineEnding::LF ? 1
+                                                                           : 0;
+    if(data.size() + suffix > static_cast<std::size_t>(inputs.max_bytes.value))
+    {
+      outputs.error("Data exceeds maximum bytes; file unchanged");
+      return;
+    }
+    std::uint64_t offset{};
+    if(operation == file_io::Operation::WriteRange
+       && (!file_io::valid_count(*this) || !file_io::valid_offset(*this, offset)))
+      return;
+    file_io::submit(
+        *this, {.operation = operation,
+                .ending = inputs.ending.value,
+                .path = inputs.path.value,
+                .data = operation == file_io::Operation::WriteRange
+                            ? data.substr(0, static_cast<std::size_t>(inputs.count.value))
+                            : data,
+                .limit = operation == file_io::Operation::WriteRange
+                             ? static_cast<std::size_t>(inputs.count.value)
+                             : static_cast<std::size_t>(inputs.max_bytes.value),
+                .offset = offset});
+  }
+
+  struct
+  {
+    struct
+    {
+      static constexpr bool is_event() { return true; }
+      halp_meta(name, "Data")
+      halp_meta(
+          description,
+          "Binary string events. Every arrival, including equal values at the same "
+          "timestamp, triggers Mode. No retained value is replayed.")
+      ossia::value_port* value{};
+    } data;
+    halp::lineedit<"Path", ""> path;
+    struct : halp::enum_t<FileWriteMode, "Mode">
+    {
+      using halp::enum_t<FileWriteMode, "Mode">::operator=;
+      halp_meta(
+          description,
+          "Write replaces the file on each event. WriteRange preserves surrounding "
+          "bytes. Append adds chunks. Ignore performs no I/O.")
+    } action;
+    halp::enum_t<FileIOMode, "Execution"> mode;
+    halp::enum_t<FileLineEnding, "Line ending"> ending;
+    halp::spinbox_i32<"Maximum bytes", halp::range{1, file_io::max_file_bytes, 1048576}>
+        max_bytes;
+    struct : halp::lineedit<"Offset", "0">
+    {
+      using halp::lineedit<"Offset", "0">::operator=;
+      halp_meta(
+          description, "Non-negative signed 64-bit decimal byte offset for WriteRange.")
+    } offset;
+    struct : halp::spinbox_i32<"Count", halp::range{0, file_io::max_file_bytes, 65536}>
+    {
+      halp_meta(
+          description,
+          "Maximum bytes written by WriteRange, including the selected line ending. "
+          "Zero performs no I/O.")
+    } count;
+  } inputs;
+
+  struct
+  {
+    halp::val_port<"Bytes", std::int64_t> bytes;
+    halp::val_port<"Lines", std::int64_t> lines;
+    halp::val_port<"Busy", bool> busy;
+    halp::callback<"Success"> success;
+    halp::callback<"Error", std::string> error;
+  } outputs;
+
+  file_io::Worker<FileWrite> worker;
+  void operator()()
+  {
+    if(inputs.data.value && inputs.action.value != FileWriteMode::Ignore)
+    {
+      for(const auto& event : inputs.data.value->get_data())
+      {
+        if(const auto* data = event.value.target<std::string>())
+          receive(*data);
+        else
+          outputs.error("Data must be a binary string");
+      }
+    }
+    worker.publish(*this);
+  }
+
+  void apply(file_io::Result& result)
+  {
+    outputs.bytes = result.bytes;
+    outputs.lines = result.lines;
+  }
+};
+}

--- a/examples/Advanced/Utilities/StringTool.hpp
+++ b/examples/Advanced/Utilities/StringTool.hpp
@@ -1,0 +1,561 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <halp/callback.hpp>
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace ao
+{
+namespace string_detail
+{
+inline constexpr int byte_limit = 1024 * 1024;
+inline constexpr int part_limit = 65536;
+
+// Strict UTF-8 scalar validation. The existing UTF-16 conversion helper is not
+// a validator: it permits overlong encodings and surrogate code points.
+inline bool valid_utf8(std::string_view text, std::size_t* count = nullptr)
+{
+  std::size_t n = 0;
+  for(std::size_t i = 0; i < text.size(); ++n)
+  {
+    const auto lead = static_cast<unsigned char>(text[i++]);
+    if(lead < 0x80)
+      continue;
+    int extra;
+    std::uint32_t cp;
+    std::uint32_t minimum;
+    if(lead >= 0xC2 && lead <= 0xDF)
+    {
+      extra = 1;
+      cp = lead & 0x1F;
+      minimum = 0x80;
+    }
+    else if(lead >= 0xE0 && lead <= 0xEF)
+    {
+      extra = 2;
+      cp = lead & 0x0F;
+      minimum = 0x800;
+    }
+    else if(lead >= 0xF0 && lead <= 0xF4)
+    {
+      extra = 3;
+      cp = lead & 0x07;
+      minimum = 0x10000;
+    }
+    else
+      return false;
+    if(text.size() - i < static_cast<std::size_t>(extra))
+      return false;
+    for(int k = 0; k < extra; ++k)
+    {
+      const auto b = static_cast<unsigned char>(text[i++]);
+      if((b & 0xC0) != 0x80)
+        return false;
+      cp = (cp << 6) | (b & 0x3F);
+    }
+    if(cp < minimum || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+      return false;
+  }
+  if(count)
+    *count = n;
+  return true;
+}
+
+// Only called on already validated UTF-8.
+inline std::size_t width(unsigned char lead)
+{
+  return lead < 0x80 ? 1 : lead < 0xE0 ? 2 : lead < 0xF0 ? 3 : 4;
+}
+
+inline std::size_t offset(std::string_view text, std::size_t codepoints)
+{
+  std::size_t pos = 0;
+  while(codepoints-- && pos < text.size())
+    pos += width(static_cast<unsigned char>(text[pos]));
+  return pos;
+}
+
+inline bool ascii_space(char c)
+{
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+inline bool valid_limit(int limit)
+{
+  return limit >= 1 && limit <= byte_limit;
+}
+}
+
+enum class StringTrim
+{
+  None,
+  Both,
+  Left,
+  Right
+};
+enum class StringCase
+{
+  Unchanged,
+  ASCII_Lower,
+  ASCII_Upper
+};
+
+/**
+ * Message-triggered, cold controls. Chain order:
+ * ASCII trim -> codepoint slice -> literal replacement -> ASCII case ->
+ * codepoint reverse -> signed left rotation -> repeat -> left/right padding ->
+ * maximum-length truncation -> minimum-length right padding.
+ * Slice starts are clamped; negative starts count from the end; length -1
+ * means the remainder. Rotation wraps, including negative (right) rotations.
+ * Padding counts copies of exactly one Unicode scalar, not a target width.
+ * Min length 0 and Max length -1 disable their limits. Active minimum greater
+ * than active maximum is an error, even when a particular input would fit.
+ * Codepoints are NOT graphemes: combining marks / emoji sequences can separate.
+ * All text is strict UTF-8, including embedded NUL. No normalization is done.
+ * Max bytes bounds input, text options and every intermediate/output string.
+ * On failure emit only Error; on success clear Error before emitting Text.
+ */
+struct StringTool
+{
+  halp_meta(name, "String tool")
+  halp_meta(c_name, "string_tool")
+  halp_meta(category, "Control/Strings")
+  halp_meta(author, "ossia team")
+  halp_meta(
+      description,
+      "UTF-8 codepoint trim, slice, replace, case, reverse, rotate, repeat, pad "
+      "and length limits; ASCII trim/case")
+  halp_meta(uuid, "a7de81b5-6e90-47c8-8f2b-9023c0a16e54")
+
+  struct ins
+  {
+    halp::enum_t<StringTrim, "ASCII trim"> trim;
+    halp::toggle<"Slice"> slice;
+    struct : halp::spinbox_i32<"Start", halp::range{-1048576, 1048576, 0}>
+    {
+      halp_meta(
+          description,
+          "Slice start in Unicode codepoints; negative counts from the end.")
+    } start;
+    struct : halp::spinbox_i32<"Length", halp::range{-1, 1048576, -1}>
+    {
+      halp_meta(
+          description, "Slice length in Unicode codepoints; -1 keeps the remainder.")
+    } length;
+    halp::toggle<"Replace"> replace;
+    struct : halp::lineedit<"Find", "">
+    {
+      halp_meta(description, "Literal text to replace; not a regular expression.")
+    } find;
+    halp::lineedit<"Replacement", ""> replacement;
+    halp::enum_t<StringCase, "Case"> casing;
+    struct : halp::toggle<"Reverse">
+    {
+      halp_meta(description, "Reverse Unicode codepoints, not grapheme clusters.")
+    } reverse;
+    struct : halp::spinbox_i32<"Rotate left", halp::range{-1048576, 1048576, 0}>
+    {
+      halp_meta(description, "Rotate by Unicode codepoints; negative rotates right.")
+    } rotate;
+    halp::spinbox_i32<"Repeat", halp::range{0, 1048576, 1}> repeat;
+    struct : halp::spinbox_i32<"Pad left", halp::range{0, 1048576, 0}>
+    {
+      halp_meta(description, "Number of copies of Pad character to prepend.")
+    } pad_left;
+    struct : halp::spinbox_i32<"Pad right", halp::range{0, 1048576, 0}>
+    {
+      halp_meta(description, "Number of copies of Pad character to append.")
+    } pad_right;
+    halp::lineedit<"Pad character", " "> pad;
+    struct : halp::spinbox_i32<"Min length", halp::range{0, 1048576, 0}>
+    {
+      halp_meta(
+          description,
+          "Minimum final Unicode codepoint count; 0 disables. Pads on the right after "
+          "truncation.")
+    } min_length;
+    struct : halp::spinbox_i32<"Max length", halp::range{-1, 1048576, -1}>
+    {
+      halp_meta(
+          description,
+          "Maximum final Unicode codepoint count; -1 disables, 0 produces empty text. "
+          "Truncates after existing transformations.")
+    } max_length;
+    struct : halp::lineedit<"Min length pad", " ">
+    {
+      halp_meta(
+          description,
+          "Exactly one Unicode codepoint, appended as needed to reach Min length.")
+    } min_pad;
+    halp::spinbox_i32<"Max bytes", halp::range{1, 1048576, 1048576}> max_bytes;
+  } inputs;
+
+  struct messages
+  {
+    struct message
+    {
+      halp_meta(name, "Text")
+      void operator()(StringTool& self, const std::string& text) { self.process(text); }
+    } text;
+  };
+
+  struct outs
+  {
+    halp::callback<"Text", std::string> text;
+    halp::callback<"Error", std::string> error;
+  } outputs;
+
+  void process(std::string_view source)
+  {
+    using namespace string_detail;
+    const auto fail = [this](const char* message) { outputs.error(message); };
+    if(!valid_limit(inputs.max_bytes))
+      return fail("Max bytes must be between 1 and 1048576");
+    const std::size_t limit = inputs.max_bytes.value;
+    if(source.size() > limit)
+      return fail("Input exceeds byte limit");
+    if(!valid_utf8(source))
+      return fail("Input is not valid UTF-8");
+    if(inputs.repeat < 0 || inputs.pad_left < 0 || inputs.pad_right < 0
+       || (inputs.slice && inputs.length < -1))
+      return fail("Invalid negative repeat, padding or slice length");
+    if(inputs.min_length < 0 || inputs.min_length > byte_limit || inputs.max_length < -1
+       || inputs.max_length > byte_limit)
+      return fail("Invalid minimum or maximum length");
+    if(inputs.max_length >= 0 && inputs.min_length > inputs.max_length.value)
+      return fail("Min length exceeds Max length");
+    if(std::size_t(inputs.min_length.value) > limit)
+      return fail("Min length cannot fit within byte limit");
+    switch(inputs.trim.value)
+    {
+      case StringTrim::None:
+        break;
+      case StringTrim::Both:
+      case StringTrim::Left:
+      case StringTrim::Right:
+        if(inputs.trim != StringTrim::Right)
+          while(!source.empty() && ascii_space(source.front()))
+            source.remove_prefix(1);
+        if(inputs.trim != StringTrim::Left)
+          while(!source.empty() && ascii_space(source.back()))
+            source.remove_suffix(1);
+        break;
+      default:
+        return fail("Invalid trim mode");
+    }
+    if(inputs.slice)
+    {
+      std::size_t count{};
+      valid_utf8(source, &count);
+      const auto start = std::clamp<std::int64_t>(
+          inputs.start < 0 ? std::int64_t(count) + inputs.start.value
+                           : inputs.start.value,
+          0, count);
+      source.remove_prefix(offset(source, start));
+      if(inputs.length >= 0)
+        source = source.substr(0, offset(source, inputs.length.value));
+    }
+    std::string text;
+    if(inputs.replace)
+    {
+      const auto& find = inputs.find.value;
+      const auto& replacement = inputs.replacement.value;
+      if(find.empty())
+        return fail("Literal search must not be empty");
+      if(find.size() > limit || replacement.size() > limit)
+        return fail("Replacement options exceed byte limit");
+      if(!valid_utf8(find) || !valid_utf8(replacement))
+        return fail("Replacement options are not valid UTF-8");
+      // Non-overlapping left-to-right matches in the original slice. Inserted
+      // text is never searched again (including when it contains the needle).
+      std::size_t matches = 0;
+      for(std::size_t pos = 0; (pos = source.find(find, pos)) != source.npos;
+          pos += find.size())
+        ++matches;
+      std::size_t size = source.size() - matches * find.size();
+      if(!replacement.empty() && matches > (limit - size) / replacement.size())
+        return fail("Replacement exceeds byte limit");
+      size += matches * replacement.size();
+      text.reserve(size);
+      std::size_t pos = 0;
+      for(std::size_t match; (match = source.find(find, pos)) != source.npos;)
+      {
+        text.append(source.substr(pos, match - pos));
+        text.append(replacement);
+        pos = match + find.size();
+      }
+      text.append(source.substr(pos));
+    }
+    else
+      text.assign(source);
+
+    switch(inputs.casing.value)
+    {
+      case StringCase::Unchanged:
+        break;
+      case StringCase::ASCII_Lower:
+        for(char& c : text)
+          if(c >= 'A' && c <= 'Z')
+            c += 'a' - 'A';
+        break;
+      case StringCase::ASCII_Upper:
+        for(char& c : text)
+          if(c >= 'a' && c <= 'z')
+            c -= 'a' - 'A';
+        break;
+      default:
+        return fail("Invalid case mode");
+    }
+    if(inputs.reverse)
+    {
+      for(std::size_t pos = 0; pos < text.size();)
+      {
+        const auto end = pos + width(static_cast<unsigned char>(text[pos]));
+        std::reverse(text.begin() + pos, text.begin() + end);
+        pos = end;
+      }
+      std::reverse(text.begin(), text.end());
+    }
+    if(inputs.rotate != 0 && !text.empty())
+    {
+      std::size_t count{};
+      valid_utf8(text, &count);
+      std::int64_t rotation = std::int64_t(inputs.rotate.value) % std::int64_t(count);
+      if(rotation < 0)
+        rotation += count;
+      std::rotate(text.begin(), text.begin() + offset(text, rotation), text.end());
+    }
+    const std::size_t repeat = inputs.repeat.value;
+    if(!text.empty() && repeat > limit / text.size())
+      return fail("Repeat exceeds byte limit");
+    const auto original_size = text.size();
+    text.resize(original_size * repeat);
+    if(original_size)
+      for(std::size_t pos = original_size; pos < text.size(); pos += original_size)
+        std::copy_n(text.begin(), original_size, text.begin() + pos);
+
+    const std::size_t padding
+        = std::size_t(inputs.pad_left.value) + inputs.pad_right.value;
+    if(padding)
+    {
+      std::size_t count{};
+      const auto& pad = inputs.pad.value;
+      if(pad.size() > limit || !valid_utf8(pad, &count) || count != 1)
+        return fail("Padding must be exactly one UTF-8 codepoint within the byte limit");
+      if(padding > (limit - text.size()) / pad.size())
+        return fail("Padding exceeds byte limit");
+      const auto left_bytes = std::size_t(inputs.pad_left.value) * pad.size();
+      const auto body_size = text.size();
+      text.resize(body_size + padding * pad.size());
+      if(left_bytes && body_size)
+        std::move_backward(
+            text.begin(), text.begin() + body_size,
+            text.begin() + left_bytes + body_size);
+      for(std::size_t pos = 0; pos < left_bytes; pos += pad.size())
+        std::copy(pad.begin(), pad.end(), text.begin() + pos);
+      for(std::size_t pos = left_bytes + body_size; pos < text.size(); pos += pad.size())
+        std::copy(pad.begin(), pad.end(), text.begin() + pos);
+    }
+    if(inputs.max_length >= 0)
+      text.resize(offset(text, inputs.max_length.value));
+    if(inputs.min_length > 0)
+    {
+      std::size_t count{};
+      valid_utf8(text, &count);
+      if(count < std::size_t(inputs.min_length.value))
+      {
+        std::size_t pad_count{};
+        const auto& pad = inputs.min_pad.value;
+        if(pad.size() > limit || !valid_utf8(pad, &pad_count) || pad_count != 1)
+          return fail(
+              "Min length pad must be exactly one UTF-8 codepoint within the byte "
+              "limit");
+        const auto missing = std::size_t(inputs.min_length.value) - count;
+        if(missing > (limit - text.size()) / pad.size())
+          return fail("Min length padding exceeds byte limit");
+        const auto body_size = text.size();
+        text.resize(body_size + missing * pad.size());
+        for(std::size_t pos = body_size; pos < text.size(); pos += pad.size())
+          std::copy(pad.begin(), pad.end(), text.begin() + pos);
+      }
+    }
+    outputs.error(std::string{});
+    outputs.text(std::move(text));
+  }
+};
+
+/** Literal full-string delimiter; empty delimiter splits Unicode codepoints.
+ * Keep empty preserves leading, consecutive and trailing empty fields. Empty
+ * input yields one empty field with a nonempty delimiter, none in codepoint
+ * mode. No quoting/CSV parsing. Max parts rejects overflow, never truncates.
+ * Messages trigger processing; controls are cold. Error contract as StringTool.
+ */
+struct StringSplit
+{
+  halp_meta(name, "Split string")
+  halp_meta(c_name, "string_split")
+  halp_meta(category, "Control/Strings")
+  halp_meta(author, "ossia team")
+  halp_meta(
+      description,
+      "Split UTF-8 by a literal delimiter; empty delimiter splits codepoints")
+  halp_meta(uuid, "5e3a285a-37c6-4e38-97b3-03e216843409")
+
+  struct ins
+  {
+    struct : halp::lineedit<"Delimiter", ",">
+    {
+      halp_meta(description, "Literal delimiter; empty splits Unicode codepoints.")
+    } delimiter;
+    halp::toggle<"Keep empty", halp::default_on_toggle> keep_empty;
+    halp::spinbox_i32<"Max parts", halp::range{1, 65536, 65536}> max_parts;
+    halp::spinbox_i32<"Max bytes", halp::range{1, 1048576, 1048576}> max_bytes;
+  } inputs;
+  struct messages
+  {
+    struct message
+    {
+      halp_meta(name, "Text")
+      void operator()(StringSplit& self, const std::string& text) { self.process(text); }
+    } text;
+  };
+  struct outs
+  {
+    halp::callback<"Parts", std::vector<std::string>> parts;
+    halp::callback<"Error", std::string> error;
+  } outputs;
+
+  void process(std::string_view text)
+  {
+    using namespace string_detail;
+    const auto fail = [this](const char* message) { outputs.error(message); };
+    if(!valid_limit(inputs.max_bytes) || inputs.max_parts < 1
+       || inputs.max_parts > part_limit)
+      return fail("Invalid byte or part limit");
+    const auto& delimiter = inputs.delimiter.value;
+    const std::size_t limit = inputs.max_bytes.value;
+    if(text.size() > limit || delimiter.size() > limit)
+      return fail("Input or delimiter exceeds byte limit");
+    if(!valid_utf8(text) || !valid_utf8(delimiter))
+      return fail("Input or delimiter is not valid UTF-8");
+    std::vector<std::string> parts;
+    const auto append = [&](std::string_view part) {
+      if(part.empty() && !inputs.keep_empty)
+        return true;
+      if(parts.size() >= std::size_t(inputs.max_parts.value))
+        return false;
+      parts.emplace_back(part);
+      return true;
+    };
+    if(delimiter.empty())
+    {
+      while(!text.empty())
+      {
+        const auto n = width(static_cast<unsigned char>(text.front()));
+        if(!append(text.substr(0, n)))
+          return fail("Split exceeds part limit");
+        text.remove_prefix(n);
+      }
+    }
+    else
+    {
+      for(std::size_t pos; (pos = text.find(delimiter)) != text.npos;)
+      {
+        if(!append(text.substr(0, pos)))
+          return fail("Split exceeds part limit");
+        text.remove_prefix(pos + delimiter.size());
+      }
+      if(!append(text))
+        return fail("Split exceeds part limit");
+    }
+    outputs.error(std::string{});
+    outputs.parts(std::move(parts));
+  }
+};
+
+/** Join UTF-8 string lists without implicit number coercion or quoting. Empty
+ * fields are retained; separators go only between fields. Hard part limit
+ * bounds processing even for lists of empty strings. Error contract as above.
+ */
+struct StringJoin
+{
+  halp_meta(name, "Join strings")
+  halp_meta(c_name, "string_join")
+  halp_meta(category, "Control/Strings")
+  halp_meta(author, "ossia team")
+  halp_meta(description, "Join UTF-8 string lists with a literal separator")
+  halp_meta(uuid, "ebae143d-ff33-422c-afdc-150c7738db1f")
+  struct ins
+  {
+    halp::lineedit<"Separator", ","> separator;
+    halp::spinbox_i32<"Max bytes", halp::range{1, 1048576, 1048576}> max_bytes;
+  } inputs;
+  struct messages
+  {
+    struct message
+    {
+      halp_meta(name, "Parts")
+      void operator()(StringJoin& self, const std::vector<std::string>& parts)
+      {
+        self.process(parts);
+      }
+    } parts;
+  };
+  struct outs
+  {
+    halp::callback<"Text", std::string> text;
+    halp::callback<"Error", std::string> error;
+  } outputs;
+
+  void process(const std::vector<std::string>& parts)
+  {
+    using namespace string_detail;
+    const auto fail = [this](const char* message) { outputs.error(message); };
+    if(!valid_limit(inputs.max_bytes))
+      return fail("Invalid byte limit");
+    if(parts.size() > part_limit)
+      return fail("Input exceeds part limit");
+    const std::size_t limit = inputs.max_bytes.value;
+    const auto& separator = inputs.separator.value;
+    if(separator.size() > limit)
+      return fail("Separator exceeds byte limit");
+    if(!valid_utf8(separator))
+      return fail("Separator is not valid UTF-8");
+    std::size_t size = 0;
+    if(parts.size() > 1)
+    {
+      if(separator.size() > limit / (parts.size() - 1))
+        return fail("Join exceeds byte limit");
+      size = separator.size() * (parts.size() - 1);
+    }
+    for(const auto& part : parts)
+    {
+      if(part.size() > limit - size)
+        return fail("Join exceeds byte limit");
+      if(!valid_utf8(part))
+        return fail("A part is not valid UTF-8");
+      size += part.size();
+    }
+    std::string text;
+    text.reserve(size);
+    for(std::size_t i = 0; i < parts.size(); ++i)
+    {
+      if(i)
+        text.append(separator);
+      text.append(parts[i]);
+    }
+    outputs.error(std::string{});
+    outputs.text(std::move(text));
+  }
+};
+}

--- a/include/avnd/binding/ossia/geometry.hpp
+++ b/include/avnd/binding/ossia/geometry.hpp
@@ -6,6 +6,7 @@
 #include <halp/polyfill.hpp>
 #include <ossia/dataflow/geometry_port.hpp>
 
+#include <cassert>
 #include <memory>
 
 namespace oscr
@@ -733,8 +734,7 @@ update_buffer(T& buf, std::size_t buf_k, ossia::geometry& geom)
   gpu_buf.handle = buf.handle;
   gpu_buf.byte_size = buf.byte_size;
 
-  SCORE_ASSERT(buf_k >= 0);
-  SCORE_ASSERT(buf_k < geom.buffers.size());
+  assert(buf_k < geom.buffers.size());
   auto& in = geom.buffers[buf_k];
   in.data = gpu_buf;
 

--- a/include/avnd/binding/ossia/node.hpp
+++ b/include/avnd/binding/ossia/node.hpp
@@ -795,7 +795,7 @@ struct tick_info
 namespace avnd
 {
 
-template <typename T, typename Tick>
+template <typename T>
   requires(std::same_as<std::remove_cvref_t<typename T::tick>, ossia::token_request>)
 inline constexpr const ossia::token_request&
 get_tick_or_frames(avnd::effect_container<T>& implementation, const oscr::tick_info& v)

--- a/include/avnd/binding/ossia/port_run_postprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_postprocess.hpp
@@ -140,12 +140,13 @@ struct process_after_run
   {
     int N = port.size();
     assert(N == ctrl.ports.size());
-    for(int i = 0; i < N; i++)
-    {
-      // FIXME double-check all the "0", most likely they should be the tick start timestamp instead
-      write_value(
-          ctrl.ports[i], *port[i], ctrl.ports[i].value, 0, avnd::field_index<Idx>{});
-    }
+    if constexpr(!ossia_port<avnd::dynamic_port_type<Field>>)
+      for(int i = 0; i < N; i++)
+      {
+        // FIXME double-check all the "0", most likely they should be the tick start timestamp instead
+        write_value(
+            ctrl.ports[i], *port[i], ctrl.ports[i].value, 0, avnd::field_index<Idx>{});
+      }
   }
 
   template <avnd::linear_sample_accurate_parameter_port Field, std::size_t Idx>

--- a/include/avnd/binding/ossia/port_run_preprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_preprocess.hpp
@@ -116,12 +116,16 @@ struct process_before_run
     for(auto pport : ports)
     {
       auto& port = *pport;
+      if constexpr(ossia_port<avnd::dynamic_port_type<Field>>)
+        ctrl.ports[p].value = &port.data;
       if(!port.data.get_data().empty())
       {
         auto& last = port.data.get_data().back().value;
 
         // FIXME check optional ports case
-        written |= self.from_ossia_value(ctrl.ports[p], last, ctrl.ports[p].value, idx);
+        if constexpr(!ossia_port<avnd::dynamic_port_type<Field>>)
+          written
+              |= self.from_ossia_value(ctrl.ports[p], last, ctrl.ports[p].value, idx);
 
         // FIXME
         // if constexpr(avnd::control_port<Field>)
@@ -477,10 +481,16 @@ struct process_before_run
       avnd::field_index<Idx>) const noexcept
   {
     ctrl.ports.resize(ports.size());
-    for(auto& port_value : ctrl.ports)
+    for(std::size_t i = 0; i < ports.size(); ++i)
     {
-      using type = std::remove_cvref_t<decltype(port_value.value)>;
-      port_value.value = type{};
+      auto& port_value = ctrl.ports[i];
+      if constexpr(ossia_port<avnd::dynamic_port_type<Field>>)
+        port_value.value = &ports[i]->data;
+      else
+      {
+        using type = std::remove_cvref_t<decltype(port_value.value)>;
+        port_value.value = type{};
+      }
     }
   }
 

--- a/include/avnd/binding/ossia/port_setup.hpp
+++ b/include/avnd/binding/ossia/port_setup.hpp
@@ -464,7 +464,9 @@ struct setup_value_port
   template <typename Field>
   static void setup(ossia::value_port& port)
   {
-    if constexpr(requires { bool(Field::event); })
+    if constexpr(ossia_value_port<Field>)
+      port.is_event = Field::is_event();
+    else if constexpr(requires { bool(Field::event); })
       port.is_event = Field::event;
     if constexpr(requires { Field::value; })
     {
@@ -492,8 +494,9 @@ struct setup_value_port
   template <typename Field>
   static void setup_port(ossia::value_port& port)
   {
-    setup_value_port{}.setup<Field>(port);
-    setup_declared_unit<Field>(port);
+    using Port = avnd::concrete_port_type<Field>;
+    setup_value_port{}.setup<Port>(port);
+    setup_declared_unit<Port>(port);
   }
 };
 

--- a/include/avnd/concepts/layout.hpp
+++ b/include/avnd/concepts/layout.hpp
@@ -23,6 +23,9 @@ AVND_DEFINE_TAG(fully_custom_item)
  */
 AVND_DEFINE_TAG(no_background)
 
+/** Hide a tab layout's selector; its model controls the visible page. */
+AVND_DEFINE_TAG(hide_tabs)
+
 type_or_value_qualification(ui)
 type_or_value_reflection(ui)
 

--- a/include/avnd/wrappers/widgets.hpp
+++ b/include/avnd/wrappers/widgets.hpp
@@ -221,10 +221,10 @@ consteval auto get_widget()
   else if constexpr(requires { T::widget::folder; })
   {
     return widget_reflection<std::string>{widget_type::folder};
+  }
   else if constexpr(requires { T::widget::string_list; })
   {
     return widget_reflection<value_type>{widget_type::string_list};
-  }
   }
   else if constexpr(requires { T::widget::multi_slider; })
   {

--- a/include/avnd/wrappers/widgets.hpp
+++ b/include/avnd/wrappers/widgets.hpp
@@ -29,6 +29,7 @@ enum class widget_type
   iknob,
   lineedit,
   combobox,
+  string_list,
   choices,
   xy,
   xy_spinbox,
@@ -82,6 +83,8 @@ struct widget_reflection
         return "lineedit";
       case widget_type::combobox:
         return "combobox";
+      case widget_type::string_list:
+        return "string_list";
       case widget_type::choices:
         return "choices";
       case widget_type::xy:
@@ -218,6 +221,10 @@ consteval auto get_widget()
   else if constexpr(requires { T::widget::folder; })
   {
     return widget_reflection<std::string>{widget_type::folder};
+  else if constexpr(requires { T::widget::string_list; })
+  {
+    return widget_reflection<value_type>{widget_type::string_list};
+  }
   }
   else if constexpr(requires { T::widget::multi_slider; })
   {

--- a/include/halp/string_list.hpp
+++ b/include/halp/string_list.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <halp/dynamic_port.hpp>
+#include <halp/static_string.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace halp
+{
+// The identity travels with the text through edits, moves, presets and undo.
+// Hosts serialize this as a list of [integer identity, string] pairs.
+using string_list_value = std::vector<std::pair<int, std::string>>;
+
+template <static_string Name>
+struct string_list
+{
+  enum class widget
+  {
+    string_list
+  };
+  static constexpr auto name() { return std::string_view{Name.value}; }
+  string_list_value value;
+};
+
+// A keyed resize preserves each surviving port, its value and its cables.
+// Keys must be unique and >= 10000 (below that is reserved for static ports).
+// Editing a label keeps its key; moving a row moves its key; deleting a row
+// removes only that port. Hosts without keyed support can use the count hook.
+template <typename Port>
+struct keyed_dynamic_port : dynamic_port<Port>
+{
+  std::function<void(const string_list_value&)> request_port_rows;
+
+  void set_rows(const string_list_value& rows)
+  {
+    if(request_port_rows)
+      request_port_rows(rows);
+    else if(this->request_port_resize)
+      this->request_port_resize(rows.size());
+  }
+};
+}


### PR DESCRIPTION
## Summary

- Add StringTool, StringSplit and StringJoin, plus bounded binary-safe FileRead, FileReadLine and FileWrite utilities.
- Support per-tick Autostream reads and event-driven Write / WriteRange / Append / Ignore modes, with worker completions published on the processing thread.
- Add stable-ID string-list controls and keyed dynamic ports; migrate PromptComposer keywords without losing weight identity.
- Bind native dynamic ossia value ports directly, preserve event semantics, and fix native token-request tick deduction.
- Add the `hide_tabs` layout tag and document utility behavior and binary layout syntax.

## Integration and scope

Based directly on upstream `main` (this repository has no `master` branch). Companion https://github.com/ossia/score/pull/2258 registers the objects, implements the keyed-row editor and cable/undo integration, and contains the focused regression tests. Merge this Avendish change before the score companion.

Only the audited utility changes are included. The allocation-optimization commit, ArrayTool changes, and formatting-only changes from the shared development checkout are excluded. The clean build additionally exposed a standalone-header dependency on score's `SCORE_ASSERT`: this PR now includes `<cassert>` and uses a standard bounds assertion, removing the tautological unsigned lower-bound check.

## Verification

The development integration build and 13 selected regression targets passed before extraction. Native score smoke checks exercised row editing/reordering/deletion, hidden format panes, six-byte `/dev/urandom` Autostream into Hex display, and data-driven Append/Ignore writes.

Fresh isolated verification passed: score master plus its companion PR, pinned to Avendish `73b2c4c3676b8a4f061ba408e4c48bac1a97f428`, with other submodules kept at score master's commits and add-ons disabled. The utility, Avendish, UI and FX targets built successfully. All nine focused test targets passed: six utility suites, graphics combo, dynamic-port model/UI, and dynamic-port execution. The app-backed tests require the inspector runtime plugin, which was built before their successful run.
