### PR TITLE
Add dynamic_combobox and folder_combobox, with tests

### DIFF
--- a/cmake/avendish.tests.cmake
+++ b/cmake/avendish.tests.cmake
@@ -45,6 +45,7 @@ if(BUILD_TESTING)
 
   avnd_add_executable_test(test_introspection_many tests/test_introspection_many.cpp)
   avnd_add_executable_test(test_reflection tests/test_reflection.cpp)
+  avnd_add_executable_test(test_dynamic_combobox tests/test_dynamic_combobox.cpp)
 
   avnd_add_catch_test(test_gain tests/objects/gain.cpp)
   avnd_add_catch_test(test_patternal tests/objects/patternal.cpp)

--- a/include/avnd/concepts/dynamic_items.hpp
+++ b/include/avnd/concepts/dynamic_items.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/concepts/parameter.hpp>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace avnd
+{
+// enum-ish parameter carrying an update_items callback for runtime item lists.
+template <typename T>
+concept dynamic_items_parameter = enum_ish_parameter<T> && requires(T t) {
+  {
+    t.update_items
+  } -> std::convertible_to<std::function<void(std::vector<std::string>)>>;
+};
+}

--- a/include/avnd/concepts/dynamic_items.hpp
+++ b/include/avnd/concepts/dynamic_items.hpp
@@ -1,20 +1,18 @@
 #pragma once
 
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
 
+#include <avnd/common/function_reflection.hpp>
 #include <avnd/concepts/parameter.hpp>
-
-#include <functional>
-#include <string>
-#include <vector>
 
 namespace avnd
 {
 // enum-ish parameter carrying an update_items callback for runtime item lists.
+// Any function-like member works (std::function-ish object, function pointer,
+// ...); the argument type is left to the binding.
 template <typename T>
-concept dynamic_items_parameter = enum_ish_parameter<T> && requires(T t) {
-  {
-    t.update_items
-  } -> std::convertible_to<std::function<void(std::vector<std::string>)>>;
-};
+concept dynamic_items_parameter
+    = enum_ish_parameter<T>
+      && (function_ish<std::decay_t<decltype(T{}.update_items)>>
+          || function<std::decay_t<decltype(T{}.update_items)>>);
 }

--- a/include/avnd/concepts/folder_items.hpp
+++ b/include/avnd/concepts/folder_items.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <avnd/concepts/parameter.hpp>
+
+#include <string_view>
+
+namespace avnd
+{
+// A combobox whose items are the files of a sibling folder port, populated by
+// the host at edit time. The port exposes folder_port() (the sibling port's
+// name) and extensions() (accepted suffixes).
+template <typename T>
+concept folder_items_parameter = enum_ish_parameter<T> && requires {
+  { T::folder_port() } -> std::convertible_to<std::string_view>;
+  { T::extensions() } -> std::convertible_to<std::string_view>;
+};
+}

--- a/include/avnd/concepts/folder_items.hpp
+++ b/include/avnd/concepts/folder_items.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-3.0-or-later OR BSL-1.0 OR CC0-1.0 OR CC-PDCC OR 0BSD */
 
 #include <avnd/concepts/parameter.hpp>
 

--- a/include/halp/dynamic_combobox.hpp
+++ b/include/halp/dynamic_combobox.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <halp/polyfill.hpp>
+#include <halp/static_string.hpp>
+
+#include <array>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace halp
+{
+// Combobox whose items are set at runtime via update_items. Bindings without
+// support leave update_items empty and use the static range() fallback.
+template <static_string lit>
+struct dynamic_combobox
+{
+  enum widget
+  {
+    combobox
+  };
+
+  struct range
+  {
+    std::array<std::string_view, 1> values{"-"};
+    int init{0};
+  };
+
+  static clang_buggy_consteval auto name() { return std::string_view{lit.value}; }
+
+  int value{0};
+
+  std::function<void(std::vector<std::string>)> update_items;
+
+  operator int&() noexcept { return value; }
+  operator const int&() const noexcept { return value; }
+  auto& operator=(int t) noexcept
+  {
+    value = t;
+    return *this;
+  }
+};
+}

--- a/include/halp/folder_combobox.hpp
+++ b/include/halp/folder_combobox.hpp
@@ -13,9 +13,15 @@ namespace halp
 {
 // Combobox whose items are the files of a sibling folder port, listed by the
 // host at edit time (and refreshed when the folder changes) — no execution
-// needed. `folder_port` names the sibling path/folder port; `extensions` is a
-// space-separated list of accepted suffixes (empty = all files).
-template <static_string lit, static_string folder = "Folder", static_string exts = "">
+// needed. The VALUE is the selected file name (a string), so an object can use
+// it directly as a file name. `folder_port` names the sibling path/folder
+// port; `extensions` is a space-separated list of accepted suffixes (empty =
+// all files); `init` is the initially selected file name — it stays selected
+// even while the file does not exist yet, so chains of processes that write
+// then read conventionally-named files keep working with default values.
+template <
+    static_string lit, static_string folder = "Folder", static_string exts = "",
+    static_string init_value = "-">
 struct folder_combobox
 {
   enum widget
@@ -25,21 +31,21 @@ struct folder_combobox
 
   struct range
   {
-    std::array<std::string_view, 1> values{"-"};
-    int init{0};
+    std::array<std::string_view, 1> values{init_value.value};
+    std::string_view init{init_value.value};
   };
 
   static clang_buggy_consteval auto name() { return std::string_view{lit.value}; }
   static clang_buggy_consteval auto folder_port() { return std::string_view{folder.value}; }
   static clang_buggy_consteval auto extensions() { return std::string_view{exts.value}; }
 
-  int value{0};
+  std::string value{};
 
-  operator int&() noexcept { return value; }
-  operator const int&() const noexcept { return value; }
-  auto& operator=(int t) noexcept
+  operator std::string&() noexcept { return value; }
+  operator const std::string&() const noexcept { return value; }
+  auto& operator=(std::string t) noexcept
   {
-    value = t;
+    value = std::move(t);
     return *this;
   }
 };

--- a/include/halp/folder_combobox.hpp
+++ b/include/halp/folder_combobox.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <halp/polyfill.hpp>
+#include <halp/static_string.hpp>
+
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace halp
+{
+// Combobox whose items are the files of a sibling folder port, listed by the
+// host at edit time (and refreshed when the folder changes) — no execution
+// needed. `folder_port` names the sibling path/folder port; `extensions` is a
+// space-separated list of accepted suffixes (empty = all files).
+template <static_string lit, static_string folder = "Folder", static_string exts = "">
+struct folder_combobox
+{
+  enum widget
+  {
+    combobox
+  };
+
+  struct range
+  {
+    std::array<std::string_view, 1> values{"-"};
+    int init{0};
+  };
+
+  static clang_buggy_consteval auto name() { return std::string_view{lit.value}; }
+  static clang_buggy_consteval auto folder_port() { return std::string_view{folder.value}; }
+  static clang_buggy_consteval auto extensions() { return std::string_view{exts.value}; }
+
+  int value{0};
+
+  operator int&() noexcept { return value; }
+  operator const int&() const noexcept { return value; }
+  auto& operator=(int t) noexcept
+  {
+    value = t;
+    return *this;
+  }
+};
+}

--- a/tests/test_dynamic_combobox.cpp
+++ b/tests/test_dynamic_combobox.cpp
@@ -1,0 +1,78 @@
+// The two runtime-populated combobox ports are additive: a binding that has
+// never heard of them must still see plain comboboxes, and a binding that has
+// must be able to tell the two apart. Both are compile-time properties, so
+// they are checked here rather than at run time.
+
+#include <avnd/concepts/dynamic_items.hpp>
+#include <avnd/concepts/folder_items.hpp>
+#include <avnd/concepts/parameter.hpp>
+#include <avnd/introspection/range.hpp>
+#include <halp/controls.enums.hpp>
+#include <halp/dynamic_combobox.hpp>
+#include <halp/folder_combobox.hpp>
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace
+{
+using dyn = halp::dynamic_combobox<"File">;
+using folder = halp::folder_combobox<"File", "Folder", "wav aif">;
+
+enum class Choice
+{
+  a,
+  b
+};
+using plain = halp::combobox_t<"Plain", Choice>;
+
+// 1. Both look like ordinary comboboxes to every existing binding, which is
+//    what makes the addition backwards compatible.
+static_assert(avnd::enum_ish_parameter<dyn>);
+static_assert(avnd::enum_ish_parameter<folder>);
+static_assert(avnd::enum_ish_parameter<plain>);
+
+// 2. A binding that knows the concepts can pick each one out...
+static_assert(avnd::dynamic_items_parameter<dyn>);
+static_assert(avnd::folder_items_parameter<folder>);
+
+// 3. ... without confusing them with each other, or with a plain combobox.
+static_assert(!avnd::folder_items_parameter<dyn>);
+static_assert(!avnd::dynamic_items_parameter<folder>);
+static_assert(!avnd::dynamic_items_parameter<plain>);
+static_assert(!avnd::folder_items_parameter<plain>);
+
+// 4. The value each port carries is the one its host is expected to write:
+//    an index for the dynamic combobox, a file name for the folder one.
+static_assert(std::is_same_v<decltype(dyn::value), int>);
+static_assert(std::is_same_v<decltype(folder::value), std::string>);
+
+// 5. update_items takes the item list by value, so a processor may hand over a
+//    vector built on any thread.
+static_assert(std::is_invocable_v<decltype(dyn::update_items), std::vector<std::string>>);
+
+// 6. The folder port advertises which sibling to list and what to keep.
+static_assert(folder::folder_port() == std::string_view{"Folder"});
+static_assert(folder::extensions() == std::string_view{"wav aif"});
+
+// 7. Both keep a usable static fallback, so a binding that never fills
+//    update_items still renders a combobox with one item rather than none.
+static_assert(avnd::get_range<dyn>().values.size() == 1);
+static_assert(avnd::get_range<folder>().values.size() == 1);
+
+// 8. The defaults name a folder port and accept every extension.
+using folder_default = halp::folder_combobox<"F">;
+static_assert(folder_default::folder_port() == std::string_view{"Folder"});
+static_assert(folder_default::extensions() == std::string_view{""});
+}
+
+int main()
+{
+  // Assigning through the port's conversion operators is how objects use them.
+  dyn d;
+  d = 3;
+  folder f;
+  f = std::string{"kick.wav"};
+  return (d.value == 3 && f.value == "kick.wav") ? 0 : 1;
+}


### PR DESCRIPTION
Supersedes #171 (from a fork, so its tests could not be pushed there). Same
four commits, plus the tests they were missing.

### Review of #171

The design is sound and genuinely additive. Its central claim — that a binding
which has never heard of these ports still renders them as plain comboboxes —
is now asserted rather than assumed:

- both ports satisfy `avnd::enum_ish_parameter`, so existing bindings are
  unaffected;
- `dynamic_items_parameter` and `folder_items_parameter` each match only their
  own port;
- neither matches a plain `halp::combobox_t`.

Also pinned: the value each port carries (an index for `dynamic_combobox`, a
file name for `folder_combobox`), that `update_items` takes its list by value
so a processor can build it on any thread, and that both keep a one-item
static fallback so a binding that never fills `update_items` still renders
something.

The licence headers match the existing convention (GPL-3.0-or-later for
`halp/`, the permissive quad-licence for `avnd/concepts/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oUFSPD1bswcWtvrsq25t3