### PR TITLE
ossia: preserve opt-in MIDI slice batches, and fix the raw-container MIDI paths

### DIFF
--- a/book/src/writing_processors/midi.md
+++ b/book/src/writing_processors/midi.md
@@ -66,3 +66,37 @@ halp::midi_bus<"In"> midi;
 ```
 
 
+## Message lifetime and sliced ossia execution
+
+MIDI ports are scratch storage for the current invocation. Keep pending starts,
+active-note identity, future release deadlines, and cleanup debt in the processor,
+not in a port. Do not retain pointers, references, or iterators into its messages.
+Output timestamps are slice-relative and must lie in `[0, frames)`; the ossia
+binding adds the slice offset once without changing the processor's timestamp.
+A one-sample note starting on the last frame therefore releases at frame zero of
+the next writable invocation. A zero-frame invocation cannot publish that release.
+
+The ossia graph initializes native ports, runs all requested token slices, then
+publishes the node's aggregate output. Processors that need all slices preserved
+can opt in:
+
+```cpp
+halp_meta(local_midi_tick_batch, true)
+halp_meta(local_midi_tick_batch_reserve, 4096) // Optional per-MIDI-port reserve.
+```
+
+This stores only already-produced packets in executor-local storage. The
+`ossia::graph_node::begin_execution()` hook resets it before each graph execution,
+independently of seeks, repeated positions, callback counters, and buffer sizes.
+The native output is rebuilt from the batch even for empty slices. Bindings
+without the opt-in retain per-slice replacement; an explicit `false` disables
+batching. Direct users of `safe_node::run()` must call `begin_execution()` once
+before each group of slices they will publish together. This requires a libossia
+version providing that graph hook. A reserve is a capacity hint, not a bound or
+an allocation-free guarantee for arbitrary host traffic.
+
+A lifecycle callback such as `stop()` is not itself a writable publication
+window. A host must run and publish a final release-only invocation before
+disconnecting or destroying a processor that owns notes. In score's current
+hard-stop/removal path, such an invocation is not automatically supplied;
+locally queued cleanup releases alone cannot guarantee delivered note-offs.

--- a/cmake/avendish.tests.cmake
+++ b/cmake/avendish.tests.cmake
@@ -54,6 +54,8 @@ if(BUILD_TESTING)
   if(TARGET ossia::ossia)
     avnd_add_catch_test(test_ossia_values tests/test_ossia_values.cpp)
     target_link_libraries(test_ossia_values PRIVATE ossia::ossia)
+    avnd_add_catch_test(test_ossia_midi tests/test_ossia_midi.cpp)
+    target_link_libraries(test_ossia_midi PRIVATE ossia::ossia)
   endif()
 
   # Polyphony: one effect instance per channel, each seeing only its own

--- a/include/avnd/binding/ossia/current_buffer_midi.hpp
+++ b/include/avnd/binding/ossia/current_buffer_midi.hpp
@@ -1,0 +1,52 @@
+#pragma once
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <avnd/introspection/midi.hpp>
+#include <avnd/wrappers/effect_container.hpp>
+#include <avnd/wrappers/metadatas.hpp>
+#include <libremidi/ump.hpp>
+
+#include <array>
+#include <vector>
+
+namespace oscr
+{
+// This is a value property, not a presence-only flag: explicitly false opts out.
+template <typename T>
+inline constexpr bool use_local_midi_tick_batch = [] {
+  if constexpr(requires { T::local_midi_tick_batch(); })
+    return bool(T::local_midi_tick_batch());
+  else if constexpr(requires { T::local_midi_tick_batch; })
+    return bool(T::local_midi_tick_batch);
+  else
+    return avnd::annotated_or_empty<T>("local_midi_tick_batch") == "true";
+}();
+
+// Already-emitted packets for one graph execution, not pending processor events.
+template <typename T>
+struct current_buffer_midi
+{
+  static constexpr auto port_count
+      = use_local_midi_tick_batch<T> ? avnd::midi_output_introspection<T>::size : 0;
+  std::array<std::vector<libremidi::ump>, port_count> packets;
+
+  void clear() noexcept
+  {
+    for(auto& port : packets)
+      port.clear();
+  }
+
+  void reserve(std::size_t count)
+  {
+    for(auto& port : packets)
+      port.reserve(count);
+  }
+
+  template <std::size_t Index>
+  auto& messages() noexcept
+  {
+    constexpr auto index = avnd::midi_output_introspection<T>::field_index_to_index(
+        avnd::field_index<Index>{});
+    return packets[std::size_t(index)];
+  }
+};
+}

--- a/include/avnd/binding/ossia/node.hpp
+++ b/include/avnd/binding/ossia/node.hpp
@@ -8,6 +8,7 @@ class safe_node;
 #include <avnd/binding/ossia/callbacks.hpp>
 #include <avnd/binding/ossia/configure.hpp>
 #include <avnd/binding/ossia/controls.hpp>
+#include <avnd/binding/ossia/current_buffer_midi.hpp>
 #include <avnd/binding/ossia/dynamic_ports.hpp>
 #include <avnd/binding/ossia/ffts.hpp>
 #include <avnd/binding/ossia/message_process.hpp>
@@ -148,6 +149,12 @@ public:
   AVND_NO_UNIQUE_ADDRESS avnd::audio_channel_manager<T> channels;
 
   AVND_NO_UNIQUE_ADDRESS avnd::midi_storage<T> midi_buffers;
+  AVND_NO_UNIQUE_ADDRESS oscr::current_buffer_midi<T> midi_tick_batch;
+
+  void begin_execution() noexcept override
+  {
+    this->midi_tick_batch.clear();
+  }
 
   AVND_NO_UNIQUE_ADDRESS avnd::control_storage<T> control_buffers;
 
@@ -484,6 +491,15 @@ public:
 
     {
       this->midi_buffers.reserve_space(this->impl, this->buffer_size);
+      if constexpr(oscr::use_local_midi_tick_batch<T>)
+      {
+        if constexpr(requires { T::local_midi_tick_batch_reserve(); })
+          this->midi_tick_batch.reserve(T::local_midi_tick_batch_reserve());
+        else if constexpr(requires { T::local_midi_tick_batch_reserve; })
+          this->midi_tick_batch.reserve(T::local_midi_tick_batch_reserve);
+        else
+          this->midi_tick_batch.reserve(this->buffer_size);
+      }
       this->control_buffers.reserve_space(this->impl, this->buffer_size);
       this->spectrums.reserve_space(this->impl, this->buffer_size);
     }

--- a/include/avnd/binding/ossia/port_run_postprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_postprocess.hpp
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#include <avnd/binding/ossia/current_buffer_midi.hpp>
 #include <avnd/binding/ossia/geometry.hpp>
 #include <avnd/binding/ossia/port_base.hpp>
 #include <avnd/binding/ossia/to_value.hpp>
@@ -14,6 +15,7 @@
 #include <ossia/dataflow/port.hpp>
 
 #include <vector>
+#include <span>
 
 namespace oscr
 {
@@ -201,79 +203,89 @@ struct process_after_run
   {
   }
 
-  template <avnd::raw_container_midi_port Field, std::size_t Idx>
-  void operator()(
-      Field& ctrl, ossia::midi_outlet& port, avnd::field_index<Idx>) const noexcept
+  template <std::size_t Idx, typename Messages>
+  void write_midi_output(const Messages& messages, ossia::midi_outlet& port) const noexcept
   {
-    const int N = ctrl.midi_messages.size;
-    port.data.messages.clear();
-    if(N > 0)
+    auto& output = [&]() -> auto& {
+      if constexpr(use_local_midi_tick_batch<Obj_T>)
+        return self.midi_tick_batch.template messages<Idx>();
+      else
+      {
+        port.data.messages.clear();
+        return port.data.messages;
+      }
+    }();
+
+    if(!messages.empty())
     {
       auto& conv = thread_local_midi_1to2_converter_instance();
       cmidi2_midi_conversion_context_initialize(&conv.context);
-      port.data.messages.reserve(N);
-      for(int i = 0; i < N; i++)
+      if constexpr(!use_local_midi_tick_batch<Obj_T>)
+        output.reserve(messages.size());
+      for(const auto& m : messages)
       {
-        avnd::midi_message auto& m = ctrl.midi_messages[i];
-        using msg_type = std::remove_reference_t<decltype(m)>;
-        if constexpr(std::is_same_v<msg_type, libremidi::message>)
+        if constexpr(std::is_same_v<std::remove_cvref_t<decltype(m)>, libremidi::ump>)
         {
-          m.timestamp += start;
-          port.data.messages.push_back(std::move(m));
+          auto packet = m;
+          packet.timestamp = start + m.timestamp;
+          output.push_back(packet);
         }
         else
         {
+          const auto* bytes = std::data(m.bytes);
+          const auto size = std::size(m.bytes);
+          libremidi::ump packet{};
+          // The stream converter consumes bank/RPN controllers as state, which
+          // its per-invocation reset would then drop.
+          if(size >= 2 && size <= 3 && bytes[0] >= 0x80 && bytes[0] < 0xf0
+             && (size == 3 || (bytes[0] & 0xe0) == 0xc0)
+             && cmidi2_midi1_channel_voice_to_midi2(bytes, size, packet.data))
+          {
+            packet.timestamp = start + m.timestamp;
+            output.push_back(packet);
+            continue;
+          }
           conv.convert(
-              m.data(), m.size(), start + m.timestamp,
+              bytes, size, start + m.timestamp,
               [&](const uint32_t* ump, int count, int64_t ts) {
-            libremidi::ump u;
-            std::copy_n(ump, std::min(count, 4), u.data);
-            u.timestamp = ts;
-            port.data.messages.push_back(std::move(u));
+            while(count > 0)
+            {
+              const int words = cmidi2_ump_get_num_bytes(*ump) / 4;
+              if(words <= 0 || words > count)
+                return stdx::error{std::errc::invalid_argument};
+              libremidi::ump packet{};
+              std::copy_n(ump, words, packet.data);
+              packet.timestamp = ts;
+              output.push_back(packet);
+              ump += words;
+              count -= words;
+            }
             return stdx::error{};
           });
         }
       }
     }
+
+    if constexpr(use_local_midi_tick_batch<Obj_T>)
+    {
+      // Unconditional: a consumer may have moved or cleared the port between slices.
+      port.data.messages.assign(output.begin(), output.end());
+    }
   }
 
-  // TODO UMP ports
-  // TODO note ports
+  template <avnd::raw_container_midi_port Field, std::size_t Idx>
+  void operator()(
+      Field& ctrl, ossia::midi_outlet& port, avnd::field_index<Idx>) const noexcept
+  {
+    write_midi_output<Idx>(
+        std::span{ctrl.midi_messages, std::size_t(ctrl.size)}, port);
+  }
 
   template <avnd::dynamic_container_midi_port Field, std::size_t Idx>
   void operator()(
       Field& ctrl, ossia::midi_outlet& port, avnd::field_index<Idx>) const noexcept
   {
-    const int N = ctrl.midi_messages.size();
-    port.data.messages.clear();
-
-    if(N > 0)
-    {
-      auto& conv = thread_local_midi_1to2_converter_instance();
-      cmidi2_midi_conversion_context_initialize(&conv.context);
-      port.data.messages.reserve(N);
-      for(auto& m : ctrl.midi_messages)
-      {
-        using msg_type = std::remove_reference_t<decltype(m)>;
-        if constexpr(std::is_same_v<msg_type, libremidi::message>)
-        {
-          m.timestamp += start;
-          port.data.messages.push_back(libremidi::ump_from_midi1(m));
-        }
-        else
-        {
-          conv.convert(
-              m.bytes.data(), m.bytes.size(), start + m.timestamp,
-              [&](const uint32_t* ump, int count, int64_t ts) {
-            libremidi::ump u;
-            std::copy_n(ump, std::min(count, 4), u.data);
-            u.timestamp = ts;
-            port.data.messages.push_back(std::move(u));
-            return stdx::error{};
-          });
-        }
-      }
-    }
+    write_midi_output<Idx>(ctrl.midi_messages, port);
   }
 
   template <typename Field, std::size_t Idx>

--- a/include/avnd/binding/ossia/port_run_preprocess.hpp
+++ b/include/avnd/binding/ossia/port_run_preprocess.hpp
@@ -8,10 +8,12 @@
 #include <avnd/concepts/soundfile.hpp>
 #include <avnd/introspection/input.hpp>
 #include <avnd/introspection/output.hpp>
+#include <avnd/introspection/midi.hpp>
 #include <avnd/wrappers/controls.hpp>
 #include <avnd/wrappers/metadatas.hpp>
 #include <avnd/wrappers/widgets.hpp>
 #include <fmt/printf.h>
+#include <libremidi/detail/conversion.hpp>
 #include <ossia/audio/fft.hpp>
 #include <ossia/dataflow/dataflow.hpp>
 #include <ossia/dataflow/graph_node.hpp>
@@ -339,11 +341,46 @@ struct process_before_run
     ctrl.ports.resize(ports.size());
   }
 
+  template <typename Message>
+  bool copy_midi_input(Message& dst, const libremidi::ump& src) const noexcept
+  {
+    if constexpr(std::is_same_v<Message, libremidi::ump>)
+    {
+      dst = src;
+    }
+    else
+    {
+      auto converted = libremidi::midi1_from_ump(src);
+      if(converted.empty())
+        return false;
+      if constexpr(requires { dst.bytes.resize(converted.size()); })
+        dst.bytes.resize(converted.size());
+      else if(converted.size() > std::size(dst.bytes))
+        return false;
+      std::copy(converted.begin(), converted.end(), std::begin(dst.bytes));
+    }
+    dst.timestamp = src.timestamp - start;
+    return true;
+  }
+
   template <avnd::raw_container_midi_port Field, std::size_t Idx>
   void
   operator()(Field& ctrl, ossia::midi_inlet& port, avnd::field_index<Idx>) const noexcept
   {
-    // FIXME
+    constexpr auto index
+        = avnd::raw_container_midi_input_introspection<Obj_T>::field_index_to_index(
+            avnd::field_index<Idx>{});
+    auto& storage = tpl::get<std::size_t(index)>(self.midi_buffers.inputs_storage);
+    if(storage.size() < port.data.messages.size())
+      storage.resize(port.data.messages.size());
+    ctrl.midi_messages = storage.data();
+    ctrl.size = 0;
+    for(const auto& msg : port.data.messages)
+    {
+      if(msg.timestamp >= start && msg.timestamp < start + frames
+         && copy_midi_input(storage[ctrl.size], msg))
+        ++ctrl.size;
+    }
   }
 
   template <typename Field, std::size_t Idx>
@@ -442,35 +479,15 @@ struct process_before_run
     using midi_msg_type =
         typename std::remove_cvref_t<decltype(Field::midi_messages)>::value_type;
 
-    if constexpr(std::is_same_v<midi_msg_type, libremidi::message>)
+    ctrl.midi_messages.clear();
+    ctrl.midi_messages.reserve(port.data.messages.size());
+    for(const auto& msg_in : port.data.messages)
     {
-      ctrl.midi_messages.reserve(port.data.messages.size());
-      for(const libremidi::ump& msg_in : port.data.messages)
+      if(msg_in.timestamp >= start && msg_in.timestamp < start + frames)
       {
-        if(msg_in.timestamp >= start && msg_in.timestamp < start + frames)
-        {
-          if(auto mm = libremidi::midi1_from_ump(msg_in); !mm.empty())
-          {
-            ctrl.midi_messages.push_back(std::move(mm));
-            ctrl.midi_messages.back().timestamp -= start;
-          }
-        }
-      }
-    }
-    else
-    {
-      static_assert((requires { std::declval<midi_msg_type>().bytes.resize(123); }));
-      // we must make sure that the MIDI data is copied, not referenced
-      ctrl.midi_messages.reserve(port.data.messages.size());
-      for(const libremidi::ump& msg_in : port.data.messages)
-      {
-        if(msg_in.timestamp >= start && msg_in.timestamp < start + frames)
-        {
-          auto msg = libremidi::midi1_from_ump(msg_in);
-          ctrl.midi_messages.push_back(
-              {.bytes{msg.begin(), msg.end()}, .timestamp{(int)msg_in.timestamp}});
-          ctrl.midi_messages.back().timestamp -= start;
-        }
+        midi_msg_type msg{};
+        if(copy_midi_input(msg, msg_in))
+          ctrl.midi_messages.push_back(std::move(msg));
       }
     }
   }

--- a/tests/test_ossia_midi.cpp
+++ b/tests/test_ossia_midi.cpp
@@ -1,0 +1,266 @@
+#include <avnd/binding/ossia/data_node.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <halp/midi.hpp>
+#include <ossia/dataflow/graph/graph_utils.hpp>
+
+namespace
+{
+struct value_metadata_off
+{
+  static constexpr bool local_midi_tick_batch = false;
+};
+struct value_metadata_on
+{
+  static constexpr bool local_midi_tick_batch = true;
+};
+static_assert(!oscr::use_local_midi_tick_batch<value_metadata_off>);
+static_assert(oscr::use_local_midi_tick_batch<value_metadata_on>);
+
+template <typename Message>
+struct raw_midi_port
+{
+  static constexpr auto name() { return "Raw MIDI"; }
+  Message* midi_messages{};
+  int size{};
+};
+
+struct fixed_message
+{
+  unsigned char bytes[3]{};
+  int64_t timestamp{};
+};
+
+template <bool Batch>
+struct midi_effect
+{
+  static constexpr auto name() { return "MIDI binding regression"; }
+  static constexpr bool local_midi_tick_batch() { return Batch; }
+  struct
+  {
+    raw_midi_port<libremidi::message> raw;
+    halp::midi_bus<"MIDI 1", libremidi::message> midi1;
+    halp::midi_bus<"UMP", libremidi::ump> ump;
+    halp::midi_bus<"Generic"> generic;
+  } inputs;
+  struct
+  {
+    raw_midi_port<libremidi::message> raw;
+    struct
+    {
+      int value{};
+    } non_midi;
+    halp::midi_bus<"MIDI 1", libremidi::message> midi1;
+    halp::midi_bus<"UMP", libremidi::ump> ump;
+    halp::midi_bus<"Generic"> generic;
+    raw_midi_port<fixed_message> fixed;
+    raw_midi_port<libremidi::ump> raw_ump;
+  } outputs;
+  bool emit{true};
+  int calls{};
+
+  void operator()(int frames)
+  {
+    ++calls;
+    if(!emit || frames == 0)
+      return;
+    libremidi::message message;
+    message.bytes = {0x90, 60, 100};
+    message.timestamp = frames - 1;
+    outputs.raw.midi_messages[0] = message;
+    outputs.raw.size = 1;
+    outputs.midi1.midi_messages.push_back(message);
+    auto ump = libremidi::ump_from_midi1(message);
+    outputs.ump.midi_messages.push_back(ump);
+    outputs.raw_ump.midi_messages[0] = ump;
+    outputs.raw_ump.size = 1;
+    outputs.generic.midi_messages.push_back({{0x90, 60, 100}, frames - 1});
+    outputs.fixed.midi_messages[0] = {{0x90, 60, 100}, frames - 1};
+    outputs.fixed.size = 1;
+  }
+};
+
+ossia::token_request slice(int start, int frames)
+{
+  ossia::token_request token;
+  token.prev_date = ossia::time_value{start};
+  token.date = ossia::time_value{start + frames};
+  token.start_sample = start;
+  token.length_sample = frames;
+  return token;
+}
+
+template <typename Node>
+void initialize(Node& node, ossia::execution_state& state)
+{
+  node.finish_init();
+  node.audio_configuration_changed({&state});
+  node.prepare(state);
+}
+
+template <bool Batch>
+struct moving_node : oscr::safe_node<midi_effect<Batch>>
+{
+  using base = oscr::safe_node<midi_effect<Batch>>;
+  using base::base;
+  bool move_first{};
+  void
+  run(const ossia::token_request& token,
+      ossia::exec_state_facade state) noexcept override
+  {
+    base::run(token, state);
+    if(move_first && token.start_sample == 0)
+    {
+      for(auto* port : this->root_outputs())
+      {
+        if(auto* midi = port->template target<ossia::midi_port>())
+        {
+          auto discarded = std::move(midi->messages);
+          midi->messages.clear();
+        }
+      }
+    }
+  }
+};
+
+void require_output(ossia::graph_node& node, std::initializer_list<int64_t> timestamps)
+{
+  for(auto* port : node.root_outputs())
+  {
+    if(auto* midi = port->target<ossia::midi_port>())
+    {
+      REQUIRE(midi->messages.size() == timestamps.size());
+      auto expected = timestamps.begin();
+      for(const auto& packet : midi->messages)
+      {
+        REQUIRE(packet.timestamp == *expected++);
+        const auto message = libremidi::midi1_from_ump(packet);
+        REQUIRE(message.bytes == libremidi::midi_bytes{0x90, 60, 100});
+      }
+    }
+  }
+}
+}
+
+TEST_CASE("ossia MIDI aggregates real graph slices and resets repeated callbacks")
+{
+  ossia::execution_state state;
+  moving_node<true> node{64, 44100., 1};
+  initialize(node, state);
+  node.move_first = true;
+  node.request(slice(0, 8));
+  node.request(slice(8, 8));
+  node.request(slice(16, 0));
+  ossia::graph_util::exec_node(node, state);
+  require_output(node, {7, 15});
+
+  node.requested_tokens.clear();
+  node.impl.effect.emit = false;
+  node.request(slice(0, 32));
+  ossia::graph_util::exec_node(node, state);
+  require_output(node, {});
+
+  node.requested_tokens.clear();
+  node.move_first = false;
+  node.impl.effect.emit = true;
+  node.request(slice(3, 5));
+  ossia::graph_util::exec_node(node, state);
+  require_output(node, {7});
+  REQUIRE(node.impl.effect.outputs.raw.midi_messages[0].timestamp == 4);
+  REQUIRE(node.impl.effect.outputs.midi1.midi_messages[0].timestamp == 4);
+  REQUIRE(node.impl.effect.outputs.ump.midi_messages[0].timestamp == 4);
+  REQUIRE(node.impl.effect.outputs.generic.midi_messages[0].timestamp == 4);
+}
+
+TEST_CASE("ossia MIDI explicit false preserves per-slice replacement without mutation")
+{
+  ossia::execution_state state;
+  moving_node<false> node{64, 44100., 1};
+  initialize(node, state);
+  node.request(slice(0, 8));
+  node.request(slice(8, 8));
+  ossia::graph_util::exec_node(node, state);
+  require_output(node, {15});
+  REQUIRE(node.impl.effect.outputs.raw.midi_messages[0].timestamp == 7);
+  REQUIRE(node.impl.effect.outputs.midi1.midi_messages[0].timestamp == 7);
+
+  node.finish_run();
+  require_output(node, {15});
+  node.requested_tokens.clear();
+  node.request(slice(0, 8));
+  node.request(slice(8, 0));
+  ossia::graph_util::exec_node(node, state);
+  require_output(node, {});
+}
+
+TEST_CASE("ossia raw and dynamic MIDI inputs own slice-local copies")
+{
+  ossia::execution_state state;
+  oscr::safe_node<midi_effect<false>> node{2, 44100., 1};
+  initialize(node, state);
+  auto& effect = node.impl.effect;
+  ossia::midi_inlet input;
+  for(int timestamp : {2, 4, 5, 6, 7, 8})
+  {
+    libremidi::message message;
+    message.bytes = {0x90, 60, 100};
+    message.timestamp = timestamp;
+    input.data.messages.push_back(libremidi::ump_from_midi1(message));
+  }
+  using node_type = decltype(node);
+  oscr::process_before_run<node_type, midi_effect<false>> before{node, effect, 4, 4};
+  before(effect.inputs.raw, input, avnd::field_index<0>{});
+  before(effect.inputs.midi1, input, avnd::field_index<1>{});
+  before(effect.inputs.ump, input, avnd::field_index<2>{});
+  before(effect.inputs.generic, input, avnd::field_index<3>{});
+  input.data.messages.clear();
+  REQUIRE(effect.inputs.raw.size == 4);
+  REQUIRE(effect.inputs.midi1.size() == 4);
+  REQUIRE(effect.inputs.ump.size() == 4);
+  REQUIRE(effect.inputs.generic.size() == 4);
+  for(int i = 0; i < 4; ++i)
+  {
+    REQUIRE(effect.inputs.raw.midi_messages[i].timestamp == i);
+    REQUIRE(effect.inputs.midi1.midi_messages[i].timestamp == i);
+    REQUIRE(effect.inputs.ump.midi_messages[i].timestamp == i);
+    REQUIRE(effect.inputs.generic.midi_messages[i].timestamp == i);
+    REQUIRE(effect.inputs.raw.midi_messages[i].bytes[1] == 60);
+  }
+}
+
+TEST_CASE("ossia effects without MIDI do not require output storage")
+{
+  struct no_midi
+  {
+    static constexpr auto name() { return "No MIDI"; }
+    int frames{};
+    void operator()(int n) { frames += n; }
+  };
+  ossia::execution_state state;
+  oscr::safe_node<no_midi> node{64, 44100., 1};
+  initialize(node, state);
+  node.request(slice(0, 4));
+  node.request(slice(4, 12));
+  ossia::graph_util::exec_node(node, state);
+  REQUIRE(node.impl.effect.frames == 16);
+}
+
+TEST_CASE("ossia MIDI publishes bank and RPN controllers without deferred conversion")
+{
+  ossia::execution_state state;
+  oscr::safe_node<midi_effect<false>> node{64, 44100., 1};
+  initialize(node, state);
+  node.start_frame_for_this_tick = 4;
+  auto& messages = node.impl.effect.outputs.midi1.midi_messages;
+  for(int controller : {0, 32, 101, 100, 6, 38})
+  {
+    libremidi::message message;
+    message.bytes = {0xb0, static_cast<unsigned char>(controller), 127};
+    message.timestamp = 3;
+    messages = {message};
+    node.finish_run();
+    const auto& output = tuplet::get<2>(node.ossia_outlets.ports).data.messages;
+    REQUIRE(output.size() == 1);
+    REQUIRE(output.front().timestamp == 7);
+    REQUIRE(libremidi::midi1_from_ump(output.front()).bytes == message.bytes);
+  }
+}


### PR DESCRIPTION
Needed by ossia/score#2270, where a MIDI-generating processor lost every slice but the last.

**The batch.** A node gets one `exec_node` call per graph execution but its `run()` fires once per token slice, and the post-process cleared the outlet at the top of every slice. With several slices in a tick, only the last slice's MIDI survived. Under the opt-in `local_midi_tick_batch` the post-process now appends into a per-node accumulator and re-assigns the port from the whole of it, so the port ends the tick holding every slice's messages. The accumulator is emptied once per execution from `graph_node::begin_execution()` (ossia/libossia#936), which is the only boundary that exists for it.

**Two fixes that came with it.**

The `raw_container_midi_port` pre-process was a bare `// FIXME`, so raw-container MIDI inputs received nothing at all. It is now implemented against the pre-allocated `inputs_storage`, indexed by `raw_container_midi_input_introspection`, growing only when the incoming count exceeds the buffer and re-reading `.data()` after a possible reallocation.

The post-process used to mutate the plugin's own message (`m.timestamp += start`) before forwarding it. It copies now.

**Two details worth a reviewer's eye.**

The UMP walk guards on `cmidi2_ump_get_num_bytes`, which returns `0xFF` for a message type it does not recognise; the previous code silently truncated a multi-packet conversion to one packet.

MIDI 1 channel-voice messages take a fast path that bypasses the stream converter. That converter treats eight controller numbers as state (RPN, NRPN, DTE, bank select) and emits nothing until a completing message arrives, but the context is re-initialised per invocation — so any of those a processor emitted without its partner in the same call was swallowed and lost, and an incomplete DTE pair returned an error. The fast path also scales a 7-bit value to full range, where the stream converter leaves the top of the range unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QWYTEhFJonuUNTEmBfv7Q